### PR TITLE
feat: Add switch to YRF so it turns off when EmissionManager is active

### DIFF
--- a/src/policies/EmissionManager.sol
+++ b/src/policies/EmissionManager.sol
@@ -86,7 +86,8 @@ contract EmissionManager is IEmissionManager, Policy, RolesConsumer {
         address reserve_,
         address sReserve_,
         address auctioneer_,
-        address teller_
+        address teller_,
+        uint256 minimumPremium_
     ) Policy(kernel_) {
         // Set immutable variables
         if (ohm_ == address(0)) revert("OHM address cannot be 0");
@@ -105,6 +106,8 @@ contract EmissionManager is IEmissionManager, Policy, RolesConsumer {
         _ohmDecimals = ohm.decimals();
         _gohmDecimals = ERC20(gohm_).decimals();
         _reserveDecimals = reserve.decimals();
+
+        minimumPremium = minimumPremium_;
 
         // Max approve sReserve contract for reserve for deposits
         reserve.approve(address(sReserve), type(uint256).max);
@@ -453,7 +456,7 @@ contract EmissionManager is IEmissionManager, Policy, RolesConsumer {
     }
 
     /// @notice return the current premium as a percentage where 1e18 is 100%
-    function getPremium() public view returns (uint256) {
+    function getPremium() public view override returns (uint256) {
         uint256 price = PRICE.getLastPrice();
         uint256 pbr = (price * 10 ** _reserveDecimals) / backing;
         return pbr > ONE_HUNDRED_PERCENT ? pbr - ONE_HUNDRED_PERCENT : 0;

--- a/src/policies/YieldRepurchaseFacility.sol
+++ b/src/policies/YieldRepurchaseFacility.sol
@@ -168,14 +168,14 @@ contract YieldRepurchaseFacility is IYieldRepo, Policy, RolesConsumer {
         if (epoch == epochLength) {
             // reset at end of week
             epoch = 0;
-            
+
             // Get funds for the week, if needed
-            uint256 currentBalance =reserve.balanceOf(address(this)) +
+            uint256 currentBalance = reserve.balanceOf(address(this)) +
                 sReserve.previewRedeem(sReserve.balanceOf(address(this)));
             if (nextYield > currentBalance) {
                 _withdraw(nextYield - currentBalance);
             }
-            
+
             nextYield = getNextYield();
             emit NextYieldSet(nextYield);
             lastConversionRate = sReserve.previewRedeem(1e18);
@@ -185,7 +185,7 @@ contract YieldRepurchaseFacility is IYieldRepo, Policy, RolesConsumer {
         _getBackingForPurchased(); // convert yesterdays ohm purchases into sReserve
 
         // Return if the contract should not be buying right now
-        // We do this after the yield and balance changes are handled to avoid 
+        // We do this after the yield and balance changes are handled to avoid
         // issues with gaps in evaluating it
         if (shouldNotBuy()) return;
 

--- a/src/policies/interfaces/IEmissionManager.sol
+++ b/src/policies/interfaces/IEmissionManager.sol
@@ -61,5 +61,6 @@ interface IEmissionManager {
     // ========== VIEW ========== //
 
     function getPremium() external view returns (uint256);
+
     function minimumPremium() external view returns (uint256);
 }

--- a/src/policies/interfaces/IEmissionManager.sol
+++ b/src/policies/interfaces/IEmissionManager.sol
@@ -57,4 +57,9 @@ interface IEmissionManager {
     /// @dev this function is restricted to the heart role and is called on each heart beat
     /// @dev if the contract is not active, the function does nothing
     function execute() external;
+
+    // ========== VIEW ========== //
+
+    function getPremium() external view returns (uint256);
+    function minimumPremium() external view returns (uint256);
 }

--- a/src/proposals/OIP_168.sol
+++ b/src/proposals/OIP_168.sol
@@ -72,9 +72,8 @@ contract OIP_168 is GovernorBravoProposal {
                 "\n",
                 "1. Set `BondCallback.operator()` to the new Operator policy\n",
                 "2. Set sUSDS as the wrapped token for USDS on BondCallback\n",
-                "3. Initialize the new YieldRepurchaseFacility policy\n",
-                "4. Initialize the new Operator policy\n",
-                "5. Activate the new Clearinghouse policy\n"
+                "3. Initialize the new Operator policy\n",
+                "4. Activate the new Clearinghouse policy\n"
             );
     }
 
@@ -194,26 +193,14 @@ contract OIP_168 is GovernorBravoProposal {
             "Set sUSDS as the wrapped token for USDS on BondCallback"
         );
 
-        // 3c. Initialize the new YieldRepurchaseFacility policy
-        _pushAction(
-            yieldRepurchaseFacility,
-            abi.encodeWithSelector(
-                YieldRepurchaseFacility.initialize.selector,
-                0, // initialReserveBalance: will be set in the next epoch
-                0, // initialConversionRate: will be set in the next epoch
-                INITIAL_YIELD // initialYield
-            ),
-            "Initialize the new YieldRepurchaseFacility policy"
-        );
-
-        // 3d. Initialize the new Operator policy
+        // 3c. Initialize the new Operator policy
         _pushAction(
             operator_1_5,
             abi.encodeWithSelector(Operator.initialize.selector),
             "Initialize the new Operator policy"
         );
 
-        // 3e. Activate the new Clearinghouse policy
+        // 3d. Activate the new Clearinghouse policy
         _pushAction(
             clearinghouse,
             abi.encodeWithSelector(Clearinghouse.activate.selector),

--- a/src/scripts/deploy/DeployV2.sol
+++ b/src/scripts/deploy/DeployV2.sol
@@ -1159,7 +1159,8 @@ contract OlympusDeploy is Script {
             address(sReserve),
             address(bondFixedTermTeller),
             address(bondAuctioneer),
-            address(clearinghouse)
+            address(clearinghouse),
+            address(emissionManager)
         );
 
         console2.log("YieldRepurchaseFacility deployed at:", address(yieldRepo));
@@ -1195,8 +1196,9 @@ contract OlympusDeploy is Script {
 
     // ========== EMISSION MANAGER ========== //
 
-    function _deployEmissionManager(bytes calldata) public returns (address) {
-        // No additional arguments for EmissionManager
+    function _deployEmissionManager(bytes calldata args) public returns (address) {
+        // Minimum premium is set on deploy
+        uint256 minimumPremium = abi.decode(args, (uint256));
 
         // Log dependencies
         console2.log("EmissionManager parameters:");
@@ -1217,7 +1219,8 @@ contract OlympusDeploy is Script {
             address(reserve),
             address(sReserve),
             address(bondAuctioneer),
-            address(bondFixedTermTeller)
+            address(bondFixedTermTeller),
+            minimumPremium
         );
 
         console2.log("EmissionManager deployed at:", address(emissionManager));

--- a/src/test/mocks/MockEmissionManager.sol
+++ b/src/test/mocks/MockEmissionManager.sol
@@ -16,6 +16,7 @@ contract MockEmissionManager is IEmissionManager {
     function getPremium() external view returns (uint256) {
         return _premium;
     }
+
     function minimumPremium() external view returns (uint256) {
         return _minimumPremium;
     }

--- a/src/test/mocks/MockEmissionManager.sol
+++ b/src/test/mocks/MockEmissionManager.sol
@@ -4,9 +4,27 @@ pragma solidity ^0.8.0;
 import {IEmissionManager} from "../../policies/interfaces/IEmissionManager.sol";
 
 contract MockEmissionManager is IEmissionManager {
+    uint256 internal _premium;
+    uint256 internal _minimumPremium;
+
     constructor() {}
 
     function execute() external override {
         // do nothing
+    }
+
+    function getPremium() external view returns (uint256) {
+        return _premium;
+    }
+    function minimumPremium() external view returns (uint256) {
+        return _minimumPremium;
+    }
+
+    function setPremium(uint256 premium_) external {
+        _premium = premium_;
+    }
+
+    function setMinimumPremium(uint256 minimumPremium_) external {
+        _minimumPremium = minimumPremium_;
     }
 }

--- a/src/test/policies/EmissionManager.t.sol
+++ b/src/test/policies/EmissionManager.t.sol
@@ -277,7 +277,8 @@ contract EmissionManagerTest is Test {
                 address(reserve),
                 address(sReserve),
                 address(auctioneer),
-                address(teller)
+                address(teller),
+                minimumPremium
             );
         }
 

--- a/src/test/policies/YieldRepurchaseFacility.t.sol
+++ b/src/test/policies/YieldRepurchaseFacility.t.sol
@@ -15,6 +15,7 @@ import {MockERC4626, ERC4626} from "solmate/test/utils/mocks/MockERC4626.sol";
 import {MockPrice} from "src/test/mocks/MockPrice.sol";
 import {MockOhm} from "src/test/mocks/MockOhm.sol";
 import {MockClearinghouse} from "src/test/mocks/MockClearinghouse.sol";
+import {MockEmissionManager} from "src/test/mocks/MockEmissionManager.sol";
 
 import {IBondSDA} from "interfaces/IBondSDA.sol";
 import {IBondAggregator} from "interfaces/IBondAggregator.sol";
@@ -59,6 +60,7 @@ contract YieldRepurchaseFacilityTest is Test {
     OlympusRoles internal ROLES;
 
     MockClearinghouse internal clearinghouse;
+    MockEmissionManager internal emissionManager;
     YieldRepurchaseFacility internal yieldRepo;
     RolesAdmin internal rolesAdmin;
     BondCallback internal callback; // only used by operator, not by yieldRepo
@@ -151,6 +153,12 @@ contract YieldRepurchaseFacilityTest is Test {
                 ]
             );
 
+            // Deploy mock emission manager
+            emissionManager = new MockEmissionManager();
+
+            // Set minimum premium to 100%
+            emissionManager.setMinimumPremium(1e18);
+
             /// Deploy protocol loop
             yieldRepo = new YieldRepurchaseFacility(
                 kernel,
@@ -158,7 +166,8 @@ contract YieldRepurchaseFacilityTest is Test {
                 address(sReserve),
                 address(teller),
                 address(auctioneer),
-                address(clearinghouse)
+                address(clearinghouse),
+                address(emissionManager)
             );
 
             /// Deploy ROLES administrator

--- a/src/test/sim/RangeSim.sol
+++ b/src/test/sim/RangeSim.sol
@@ -407,16 +407,17 @@ abstract contract RangeSim is Test {
 
             staking = new MockStakingZD(8 hours, 0, block.timestamp);
             distributor = new ZeroDistributor(address(staking));
+            emissionManager = new MockEmissionManager();
             yieldRepo = new YieldRepurchaseFacility(
                 kernel,
                 address(ohm),
                 address(wrappedReserve),
                 address(teller),
                 address(auctioneer),
-                address(0) // no clearinghouse
+                address(0), // no clearinghouse
+                address(emissionManager)
             );
             reserveMigrator = new MockReserveMigrator();
-            emissionManager = new MockEmissionManager();
 
             // Deploy PriceConfig
             priceConfig = new OlympusPriceConfig(kernel);


### PR DESCRIPTION
Adds a function to the YRF, `shouldNotBuy`, which checks if the EmissionManager will be active or not. If this function returns true, the YRF bond market is not created.

Because we are conditionally not using the funds in the contract to buy back OHM, reserves could accumulate over time in the contract. This would create a very large buy whenever it turns back on. Therefore, we also modify the weekly yield withdrawal logic to only fund the contract the delta between the current balance and the next yield (if at all).