### PR TITLE
Enableable mix-in

### DIFF
--- a/src/libraries/Enableable.sol
+++ b/src/libraries/Enableable.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import {RolesConsumer} from "src/modules/ROLES/OlympusRoles.sol";
+
+abstract contract Enableable is RolesConsumer {
+    // ===== STATE VARIABLES ===== //
+
+    bool public isEnabled;
+    bytes32 public constant ROLE = "emergency_shutdown";
+
+    // ===== ERRORS ===== //
+
+    error NotDisabled();
+    error NotEnabled();
+
+    // ===== EVENTS ===== //
+
+    event Disabled();
+    event Enabled();
+
+    // ===== MODIFIERS ===== //
+
+    modifier whenEnabled() {
+        if (!isEnabled) revert NotEnabled();
+        _;
+    }
+
+    modifier whenDisabled() {
+        if (isEnabled) revert NotDisabled();
+        _;
+    }
+
+    // ===== ENABLEABLE FUNCTIONS ===== //
+
+    /// @notice Enable the contract
+    /// @dev    This function performs the following steps:
+    ///         1. Validates that the caller has `ROLE` ("emergency_shutdown")
+    ///         2. Validates that the contract is disabled
+    ///         3. Calls the implementation-specific `_enable()` function
+    ///         4. Changes the state of the contract to enabled
+    ///         5. Emits the `Enabled` event
+    ///
+    /// @param  enableData_ The data to pass to the implementation-specific `_enable()` function
+    function enable(bytes calldata enableData_) public onlyRole(ROLE) whenDisabled {
+        // Call the implementation-specific enable function
+        _enable(enableData_);
+
+        // Change the state
+        isEnabled = true;
+
+        // Emit the enabled event
+        emit Enabled();
+    }
+
+    /// @notice Implementation-specific enable function
+    /// @dev    This function is called by the `enable()` function
+    ///
+    ///         The implementing contract should override this function and perform the following:
+    ///         1. Validate any parameters (if needed) or revert
+    ///         2. Validate state (if needed) or revert
+    ///         3. Perform any necessary actions, apart from modifying the `isEnabled` state variable
+    ///
+    /// @param  enableData_ Custom data that can be used by the implementation. The format of this data is
+    ///         left to the discretion of the implementation.
+    function _enable(bytes calldata enableData_) internal virtual;
+
+    /// @notice Disable the contract
+    /// @dev    This function performs the following steps:
+    ///         1. Validates that the caller has `ROLE` ("emergency_shutdown")
+    ///         2. Validates that the contract is enabled
+    ///         3. Calls the implementation-specific `_disable()` function
+    ///         4. Changes the state of the contract to disabled
+    ///         5. Emits the `Disabled` event
+    ///
+    /// @param  disableData_ The data to pass to the implementation-specific `_disable()` function
+    function disable(bytes calldata disableData_) public onlyRole(ROLE) whenEnabled {
+        // Call the implementation-specific disable function
+        _disable(disableData_);
+
+        // Change the state
+        isEnabled = false;
+
+        // Emit the disabled event
+        emit Disabled();
+    }
+
+    /// @notice Implementation-specific disable function
+    /// @dev    This function is called by the `disable()` function.
+    ///
+    ///         The implementing contract should override this function and perform the following:
+    ///         1. Validate any parameters (if needed) or revert
+    ///         2. Validate state (if needed) or revert
+    ///         3. Perform any necessary actions, apart from modifying the `isEnabled` state variable
+    ///
+    /// @param  disableData_ Custom data that can be used by the implementation. The format of this data is
+    ///         left to the discretion of the implementation.
+    function _disable(bytes calldata disableData_) internal virtual;
+}

--- a/src/libraries/Enableable.sol
+++ b/src/libraries/Enableable.sol
@@ -3,6 +3,11 @@ pragma solidity 0.8.15;
 
 import {RolesConsumer} from "src/modules/ROLES/OlympusRoles.sol";
 
+/// @title  Enableable
+/// @notice This contract is designed to be inherited by contracts that need to be enabled or disabled. It replaces the inconsistent usage of `active` and `locallyActive` state variables across the codebase.
+/// @dev    A contract that inherits from this contract should use the `whenEnabled` and `whenDisabled` modifiers to gate access to certain functions.
+///
+///         If custom logic and/or parameters are needed for the enable/disable functions, the inheriting contract can override the `_enable()` and `_disable()` functions. For example, `enable()` could be called with initialisation data that is decoded, validated and assigned in `_enable()`.
 abstract contract Enableable is RolesConsumer {
     // ===== STATE VARIABLES ===== //
 

--- a/src/libraries/Enableable.sol
+++ b/src/libraries/Enableable.sol
@@ -61,14 +61,14 @@ abstract contract Enableable is RolesConsumer {
     /// @notice Implementation-specific enable function
     /// @dev    This function is called by the `enable()` function
     ///
-    ///         The implementing contract should override this function and perform the following:
+    ///         The implementing contract can override this function and perform the following:
     ///         1. Validate any parameters (if needed) or revert
     ///         2. Validate state (if needed) or revert
     ///         3. Perform any necessary actions, apart from modifying the `isEnabled` state variable
     ///
     /// @param  enableData_ Custom data that can be used by the implementation. The format of this data is
     ///         left to the discretion of the implementation.
-    function _enable(bytes calldata enableData_) internal virtual;
+    function _enable(bytes calldata enableData_) internal virtual {}
 
     /// @notice Disable the contract
     /// @dev    This function performs the following steps:
@@ -93,12 +93,12 @@ abstract contract Enableable is RolesConsumer {
     /// @notice Implementation-specific disable function
     /// @dev    This function is called by the `disable()` function.
     ///
-    ///         The implementing contract should override this function and perform the following:
+    ///         The implementing contract can override this function and perform the following:
     ///         1. Validate any parameters (if needed) or revert
     ///         2. Validate state (if needed) or revert
     ///         3. Perform any necessary actions, apart from modifying the `isEnabled` state variable
     ///
     /// @param  disableData_ Custom data that can be used by the implementation. The format of this data is
     ///         left to the discretion of the implementation.
-    function _disable(bytes calldata disableData_) internal virtual;
+    function _disable(bytes calldata disableData_) internal virtual {}
 }


### PR DESCRIPTION
Adds an abstract contract, `Enableable`, that can be added to contracts that require the ability to be enabled/disabled. Most policies implement this functionality every time, so this mix-in standardizes the approach and role.