### PR TITLE
Document BondFixedTermAuctioneer steps

### DIFF
--- a/src/proposals/EmissionManagerProposal.sol
+++ b/src/proposals/EmissionManagerProposal.sol
@@ -19,6 +19,11 @@ import {Clearinghouse} from "src/policies/Clearinghouse.sol";
 import {YieldRepurchaseFacility} from "src/policies/YieldRepurchaseFacility.sol";
 import {EmissionManager} from "src/policies/EmissionManager.sol";
 
+// NOTE:
+// Any new version of the EmissionManager policy needs to be authorised
+// to create bonds with callbacks on the BondFixedTermAuctioneer.
+// This is performed by a different MS (0x007BD11FCa0dAaeaDD455b51826F9a015f2f0969) calling `setCallbackAuthStatus` on the BondFixedTermAuctioneer.
+
 /// @notice Initializes the EmissionManager policy
 contract EmissionManagerProposal is GovernorBravoProposal {
     Kernel internal _kernel;

--- a/src/scripts/env.json
+++ b/src/scripts/env.json
@@ -276,7 +276,7 @@
                     "LoanConsolidator": "0x784cA0C006b8651BAB183829A99fA46BeCe50dBc",
                     "OlympusHeart": "0xf7602c0421c283a2fc113172ebdf64c30f21654d",
                     "OlympusPriceConfig": "0xf6D5d06A4e8e6904E4360108749C177692F59E90",
-                    "Operator": "0x0AE561226896dA978EaDA0Bec4a7d3CfAE04f506",
+                    "Operator": "0x6417F206a0a6628Da136C0Faa39026d0134D2b52",
                     "ReserveMigrator": "0x986b99579BEc7B990331474b66CcDB94Fa2419F5",
                     "RolesAdmin": "0xb216d714d91eeC4F7120a732c11428857C659eC8",
                     "TreasuryCustodian": "0xC9518AC915e46D707585116451Dc19c164513Ccf",

--- a/src/scripts/env.json
+++ b/src/scripts/env.json
@@ -274,7 +274,7 @@
                     "EmissionManager": "0x50f441a3387625bDA8B8081cE3fd6C04CC48C0A2",
                     "LegacyBurner": "0x367149cf2d04D3114fFD1Cc6b273222664908D0B",
                     "LoanConsolidator": "0x784cA0C006b8651BAB183829A99fA46BeCe50dBc",
-                    "OlympusHeart": "0x39F6AA3d445e6Dd8eC232c6Bd589889A88E3034d",
+                    "OlympusHeart": "0xf7602c0421c283a2fc113172ebdf64c30f21654d",
                     "OlympusPriceConfig": "0xf6D5d06A4e8e6904E4360108749C177692F59E90",
                     "Operator": "0x0AE561226896dA978EaDA0Bec4a7d3CfAE04f506",
                     "ReserveMigrator": "0x986b99579BEc7B990331474b66CcDB94Fa2419F5",

--- a/src/scripts/ops/batches/EmissionManagerCallbackAuthStatus.sol
+++ b/src/scripts/ops/batches/EmissionManagerCallbackAuthStatus.sol
@@ -8,10 +8,10 @@ import {IBondAuctioneer} from "src/interfaces/IBondAuctioneer.sol";
 /// @notice This is a sample batch script that fixes a misconfiguration of the EmissionManager policy with the BondFixedTermAuctioneer.
 /// @dev    It should be run with `DAO_MS` set to the `bondOwner` address.
 contract EmissionManagerCallbackAuthStatus is OlyBatch {
-    address kernel;
-    address constant bondOwner = 0x007BD11FCa0dAaeaDD455b51826F9a015f2f0969;
-    address bondFixedTermAuctioneer;
-    address emissionManager;
+    address public kernel;
+    address public constant bondOwner = 0x007BD11FCa0dAaeaDD455b51826F9a015f2f0969;
+    address public bondFixedTermAuctioneer;
+    address public emissionManager;
 
     function loadEnv() internal override {
         // Load contract addresses from the environment file

--- a/src/scripts/ops/batches/EmissionManagerCallbackAuthStatus.sol
+++ b/src/scripts/ops/batches/EmissionManagerCallbackAuthStatus.sol
@@ -1,18 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity 0.8.15;
 
-import {console2} from "forge-std/console2.sol";
-import {stdJson} from "forge-std/StdJson.sol";
 import {OlyBatch} from "src/scripts/ops/OlyBatch.sol";
 
 import {IBondAuctioneer} from "src/interfaces/IBondAuctioneer.sol";
 
-// Bophades
-import {Kernel, Actions} from "src/Kernel.sol";
-
 /// @notice This is a sample batch script that fixes a misconfiguration of the EmissionManager policy with the BondFixedTermAuctioneer.
 /// @dev    It should be run with `DAO_MS` set to the `bondOwner` address.
-contract EmissionManagerFix is OlyBatch {
+contract EmissionManagerCallbackAuthStatus is OlyBatch {
     address kernel;
     address constant bondOwner = 0x007BD11FCa0dAaeaDD455b51826F9a015f2f0969;
     address bondFixedTermAuctioneer;

--- a/src/scripts/ops/batches/EmissionManagerFix.sol
+++ b/src/scripts/ops/batches/EmissionManagerFix.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity 0.8.15;
+
+import {console2} from "forge-std/console2.sol";
+import {stdJson} from "forge-std/StdJson.sol";
+import {OlyBatch} from "src/scripts/ops/OlyBatch.sol";
+
+import {IBondAuctioneer} from "src/interfaces/IBondAuctioneer.sol";
+
+// Bophades
+import {Kernel, Actions} from "src/Kernel.sol";
+
+/// @notice This is a sample batch script that fixes a misconfiguration of the EmissionManager policy with the BondFixedTermAuctioneer.
+/// @dev    It should be run with `DAO_MS` set to the `bondOwner` address.
+contract EmissionManagerFix is OlyBatch {
+    address kernel;
+    address constant bondOwner = 0x007BD11FCa0dAaeaDD455b51826F9a015f2f0969;
+    address bondFixedTermAuctioneer;
+    address emissionManager;
+
+    function loadEnv() internal override {
+        // Load contract addresses from the environment file
+        kernel = envAddress("current", "olympus.Kernel");
+        bondFixedTermAuctioneer = envAddress(
+            "current",
+            "external.bond-protocol.BondFixedTermAuctioneer"
+        );
+        emissionManager = envAddress("current", "olympus.policies.EmissionManager");
+    }
+
+    // Entry point for the batch #1
+    function fix(bool send_) external isDaoBatch(send_) {
+        addToBatch(
+            bondFixedTermAuctioneer,
+            abi.encodeWithSelector(
+                IBondAuctioneer.setCallbackAuthStatus.selector,
+                emissionManager,
+                true
+            )
+        );
+    }
+}


### PR DESCRIPTION
The EmissionManager was unable to open a bond market with a callback address (itself), as the EmissionManager address had not been authorized to do so on the BondFixedTermAuctioneer. This PR provides an MS batch script to do that (for future use), and documents the requirement.