### PR TITLE
Cooler v2 rescindDelegations

### DIFF
--- a/src/external/cooler/DelegateEscrow.sol
+++ b/src/external/cooler/DelegateEscrow.sol
@@ -14,6 +14,7 @@ import {DelegateEscrowFactory} from "src/external/cooler/DelegateEscrowFactory.s
  * can rescind the delegation to pull the gOHM back.
  * This contract uses Clones (https://github.com/wighawag/clones-with-immutable-args)
  * to save gas on deployment.
+ * Note: Any donated gOHM (transferred directly rather than using `delegate()`) cannot be recovered.
  */
 contract DelegateEscrow is Clone {
     using SafeTransferLib for ERC20;
@@ -80,6 +81,11 @@ contract DelegateEscrow is Clone {
         gohm.safeTransfer(msg.sender, gohmAmount);
 
         factory().logDelegate(msg.sender, onBehalfOf, -int256(gohmAmount));
+    }
+
+    /// @notice The total amount delegated via this escrow across all callers, including donations.
+    function totalDelegated() external view returns (uint256) {
+        return gohm.balanceOf(address(this));
     }
 
     /// @notice Ensure that the caller is the factory which created this contract only.

--- a/src/modules/DLGTE/DLGTE.v1.sol
+++ b/src/modules/DLGTE/DLGTE.v1.sol
@@ -40,7 +40,7 @@ abstract contract DLGTEv1 is Module, IDLGTEv1 {
     function depositUndelegatedGohm(address onBehalfOf, uint256 amount) external virtual override;
 
     /// @inheritdoc IDLGTEv1
-    function withdrawUndelegatedGohm(address onBehalfOf, uint256 amount) external virtual override;
+    function withdrawUndelegatedGohm(address onBehalfOf, uint256 amount, bool autoRescindDelegations) external virtual override;
 
     /// @inheritdoc IDLGTEv1
     function applyDelegations(

--- a/src/modules/DLGTE/DLGTE.v1.sol
+++ b/src/modules/DLGTE/DLGTE.v1.sol
@@ -80,6 +80,9 @@ abstract contract DLGTEv1 is Module, IDLGTEv1 {
         );
 
     /// @inheritdoc IDLGTEv1
+    function totalDelegatedTo(address delegate) external view virtual returns (uint256);
+
+    /// @inheritdoc IDLGTEv1
     function maxDelegateAddresses(
         address account
     ) external view virtual override returns (uint32 result);

--- a/src/modules/DLGTE/DLGTE.v1.sol
+++ b/src/modules/DLGTE/DLGTE.v1.sol
@@ -40,7 +40,11 @@ abstract contract DLGTEv1 is Module, IDLGTEv1 {
     function depositUndelegatedGohm(address onBehalfOf, uint256 amount) external virtual override;
 
     /// @inheritdoc IDLGTEv1
-    function withdrawUndelegatedGohm(address onBehalfOf, uint256 amount, bool autoRescindDelegations) external virtual override;
+    function withdrawUndelegatedGohm(
+        address onBehalfOf,
+        uint256 amount,
+        bool autoRescindDelegations
+    ) external virtual override;
 
     /// @inheritdoc IDLGTEv1
     function applyDelegations(

--- a/src/modules/DLGTE/DLGTE.v1.sol
+++ b/src/modules/DLGTE/DLGTE.v1.sol
@@ -53,6 +53,12 @@ abstract contract DLGTEv1 is Module, IDLGTEv1 {
         returns (uint256 totalDelegated, uint256 totalUndelegated, uint256 undelegatedBalance);
 
     /// @inheritdoc IDLGTEv1
+    function rescindDelegations(
+        address onBehalfOf,
+        uint256 requestedUndelegatedBalance
+    ) external virtual override returns (uint256 actualUndelegatedBalance);
+
+    /// @inheritdoc IDLGTEv1
     function policyAccountBalances(
         address policy,
         address account

--- a/src/modules/DLGTE/IDLGTE.v1.sol
+++ b/src/modules/DLGTE/IDLGTE.v1.sol
@@ -77,6 +77,25 @@ interface IDLGTEv1 {
         returns (uint256 totalDelegated, uint256 totalUndelegated, uint256 undelegatedBalance);
 
     /**
+     * @notice Rescind delegations until the amount undelegated for the `onBehalfOf` account
+     * is greater or equal to `requestedUndelegatedBalance`.
+     * @dev
+     *    - Delegations are rescinded by iterating through the delegate addresses for the
+     *      `onBehalfOf` address.
+     *    - No guarantees on the order of who is rescinded -- it may change as delegations are
+     *      removed (pop and swap)
+     *    - A calling policy may be able to rescind more than it added via `depositUndelegatedGohm()` 
+     *      however the policy cannot then withdraw an amount higher than what it deposited.
+     *    - If the full `requestedUndelegatedBalance` cannot be fulfilled the `actualUndelegatedBalance`
+     *      return parameter may be less than `requestedUndelegatedBalance`. The caller must decide
+     *      on how to handle that.
+     */
+    function rescindDelegations(
+        address onBehalfOf,
+        uint256 requestedUndelegatedBalance
+    ) external returns (uint256 actualUndelegatedBalance);
+
+    /**
      * @notice Report the total delegated and undelegated gOHM balance for an account
      * in a given policy
      */

--- a/src/modules/DLGTE/IDLGTE.v1.sol
+++ b/src/modules/DLGTE/IDLGTE.v1.sol
@@ -13,6 +13,7 @@ interface IDLGTEv1 {
     error DLGTE_InvalidAmount();
 
     error DLGTE_ExceededUndelegatedBalance(uint256 balance, uint256 requested);
+    error DLGTE_ExceededDelegatedBalance(address delegate, uint256 balance, uint256 requested);
     error DLGTE_ExceededPolicyAccountBalance(uint256 balance, uint256 requested);
 
     // ========= EVENTS ========= //
@@ -34,10 +35,10 @@ interface IDLGTEv1 {
     struct AccountDelegation {
         /// @dev The delegate address - the receiver account of the gOHM voting power.
         address delegate;
+        /// @dev The amount of gOHM delegated to `delegate`
+        uint256 amount;
         /// @dev The DelegateEscrow contract address for this `delegate`
         address escrow;
-        /// @dev The amount delegated to this delegate address
-        uint256 totalAmount;
     }
 
     // ========= FUNCTIONS ========= //
@@ -110,6 +111,12 @@ interface IDLGTEv1 {
             uint256 numDelegateAddresses,
             uint256 maxAllowedDelegateAddresses
         );
+
+    /**
+     * @notice The total amount delegated to a particular delegate across all policies,
+     * and externally made delegations (including any permanent donations)
+     */
+    function totalDelegatedTo(address delegate) external view returns (uint256);
 
     /**
      * @notice The maximum number of delegates an account can have accross all policies

--- a/src/modules/DLGTE/IDLGTE.v1.sol
+++ b/src/modules/DLGTE/IDLGTE.v1.sol
@@ -50,18 +50,23 @@ interface IDLGTEv1 {
     function setMaxDelegateAddresses(address account, uint32 maxDelegateAddresses) external;
 
     /**
-     * @notice gOHM is pulled from the calling policy - this will not be used for governance delegation
-     * @dev Balances are tracked per policy such that policyA cannot interfere with policyB's gOHM
+     * @notice gOHM is pulled from the calling policy and added to the undelegated balance.
+     * @dev
+     *   - This gOHM cannot be used for governance voting until it is delegated.
+     *   - Deposted gOHM balances are tracked per policy. policyA cannot withdraw gOHM that policyB deposited
      */
     function depositUndelegatedGohm(address onBehalfOf, uint256 amount) external;
 
     /**
      * @notice Undelegated gOHM is transferred to the calling policy.
-     * This will revert if there is not enough undelegated gOHM for `onBehalfOf`
-     * or if policy is attempting to withdraw more gOHM than it is entitled to.
-     * @dev Balances are tracked per policy such that policyA cannot interfere with policyB's gOHM
+     * @dev
+     *   - If `autoRescindDelegations` is true, delegations will be automatically rescinded if required, 
+     *     see `rescindDelegations()` for details
+     *   - Will revert if there is still not enough undelegated gOHM for `onBehalfOf` OR 
+     *     if policy is attempting to withdraw more gOHM than it deposited
+     *     Deposted gOHM balances are tracked per policy. policyA cannot withdraw gOHM that policyB deposited
      */
-    function withdrawUndelegatedGohm(address onBehalfOf, uint256 amount) external;
+    function withdrawUndelegatedGohm(address onBehalfOf, uint256 amount, bool autoRescindDelegations) external;
 
     /**
      * @notice Apply a set of delegation requests on behalf of a given account.

--- a/src/modules/DLGTE/IDLGTE.v1.sol
+++ b/src/modules/DLGTE/IDLGTE.v1.sol
@@ -60,13 +60,17 @@ interface IDLGTEv1 {
     /**
      * @notice Undelegated gOHM is transferred to the calling policy.
      * @dev
-     *   - If `autoRescindDelegations` is true, delegations will be automatically rescinded if required, 
+     *   - If `autoRescindDelegations` is true, delegations will be automatically rescinded if required,
      *     see `rescindDelegations()` for details
-     *   - Will revert if there is still not enough undelegated gOHM for `onBehalfOf` OR 
+     *   - Will revert if there is still not enough undelegated gOHM for `onBehalfOf` OR
      *     if policy is attempting to withdraw more gOHM than it deposited
      *     Deposted gOHM balances are tracked per policy. policyA cannot withdraw gOHM that policyB deposited
      */
-    function withdrawUndelegatedGohm(address onBehalfOf, uint256 amount, bool autoRescindDelegations) external;
+    function withdrawUndelegatedGohm(
+        address onBehalfOf,
+        uint256 amount,
+        bool autoRescindDelegations
+    ) external;
 
     /**
      * @notice Apply a set of delegation requests on behalf of a given account.
@@ -89,7 +93,7 @@ interface IDLGTEv1 {
      *      `onBehalfOf` address.
      *    - No guarantees on the order of who is rescinded -- it may change as delegations are
      *      removed (pop and swap)
-     *    - A calling policy may be able to rescind more than it added via `depositUndelegatedGohm()` 
+     *    - A calling policy may be able to rescind more than it added via `depositUndelegatedGohm()`
      *      however the policy cannot then withdraw an amount higher than what it deposited.
      *    - If the full `requestedUndelegatedBalance` cannot be fulfilled the `actualUndelegatedBalance`
      *      return parameter may be less than `requestedUndelegatedBalance`. The caller must decide

--- a/src/policies/cooler/CoolerLtvOracle.sol
+++ b/src/policies/cooler/CoolerLtvOracle.sol
@@ -239,9 +239,6 @@ contract CoolerLtvOracle is ICoolerLtvOracle, Policy, PolicyAdmin {
             unchecked {
                 uint96 delta = originationLtvData.slope * (_now - originationLtvData.startTime);
                 return delta + originationLtvData.startingValue;
-
-                // int96 delta = tpiData.tpiSlope * int32(_now - tpiData.startTime);
-                // return uint96(delta + int96(tpiData.startingTpi));
             }
         }
     }

--- a/src/policies/cooler/MonoCooler.sol
+++ b/src/policies/cooler/MonoCooler.sol
@@ -354,7 +354,7 @@ contract MonoCooler is IMonoCooler, Policy, PolicyAdmin {
             _accountCollateral -= collateralWithdrawn;
         }
 
-        DLGTE.withdrawUndelegatedGohm(onBehalfOf, collateralWithdrawn);
+        DLGTE.withdrawUndelegatedGohm(onBehalfOf, collateralWithdrawn, false);
 
         // Update the collateral balance, and then verify that it doesn't make the debt unsafe.
         aState.collateral = _accountCollateral;
@@ -573,7 +573,7 @@ contract MonoCooler is IMonoCooler, Policy, PolicyAdmin {
                 _undelegateForLiquidation(account, delegationRequests[i], status.collateral);
 
                 // Withdraw the undelegated gOHM
-                DLGTE.withdrawUndelegatedGohm(account, status.collateral);
+                DLGTE.withdrawUndelegatedGohm(account, status.collateral, false);
 
                 totalCollateralClaimed += status.collateral;
                 totalDebtWiped += status.currentDebt;

--- a/src/policies/cooler/MonoCooler.sol
+++ b/src/policies/cooler/MonoCooler.sol
@@ -536,7 +536,9 @@ contract MonoCooler is IMonoCooler, Policy, PolicyAdmin {
     //============================================================================================//
 
     /// @inheritdoc IMonoCooler
-    function batchLiquidate(address[] calldata accounts)
+    function batchLiquidate(
+        address[] calldata accounts
+    )
         external
         override
         returns (

--- a/src/policies/interfaces/cooler/IMonoCooler.sol
+++ b/src/policies/interfaces/cooler/IMonoCooler.sol
@@ -367,11 +367,13 @@ interface IMonoCooler {
     /**
      * @notice Liquidate one or more accounts which have exceeded the `liquidationLtv`
      * The gOHM collateral is seized (unstaked to OHM and burned), and the accounts debt is wiped.
-     * @dev 
+     * @dev
      *    - If one of the provided accounts in the batch hasn't exceeded the max LTV then it is skipped.
      *    - Delegations are auto-rescinded if required. Ordering of this is not guaranteed.
      */
-    function batchLiquidate(address[] calldata accounts)
+    function batchLiquidate(
+        address[] calldata accounts
+    )
         external
         returns (
             uint128 totalCollateralClaimed,

--- a/src/policies/interfaces/cooler/IMonoCooler.sol
+++ b/src/policies/interfaces/cooler/IMonoCooler.sol
@@ -367,12 +367,11 @@ interface IMonoCooler {
     /**
      * @notice Liquidate one or more accounts which have exceeded the `liquidationLtv`
      * The gOHM collateral is seized (unstaked to OHM and burned), and the accounts debt is wiped.
-     * @dev If one of the provided accounts in the batch hasn't exceeded the max LTV then it is skipped.
+     * @dev 
+     *    - If one of the provided accounts in the batch hasn't exceeded the max LTV then it is skipped.
+     *    - Delegations are auto-rescinded if required. Ordering of this is not guaranteed.
      */
-    function batchLiquidate(
-        address[] calldata accounts,
-        IDLGTEv1.DelegationRequest[][] calldata delegationRequests
-    )
+    function batchLiquidate(address[] calldata accounts)
         external
         returns (
             uint128 totalCollateralClaimed,

--- a/src/test/external/cooler/DelegateEscrowFactory.t.sol
+++ b/src/test/external/cooler/DelegateEscrowFactory.t.sol
@@ -133,11 +133,15 @@ contract DelegateEscrowImplTest is DelegateEscrowFactoryTestBase {
     function test_delegate() public {
         assertEq(delegate(CALLER1, 10e18, ALICE), 10e18);
         assertEq(aliceEscrow.delegations(CALLER1, ALICE), 10e18);
+        assertEq(aliceEscrow.totalDelegated(), 10e18);
         assertEq(delegate(CALLER1, 33e18, ALICE), 43e18);
         assertEq(aliceEscrow.delegations(CALLER1, ALICE), 43e18);
+        assertEq(aliceEscrow.totalDelegated(), 43e18);
         assertEq(delegate(CALLER1, 10e18, BOB), 10e18);
         assertEq(aliceEscrow.delegations(CALLER1, ALICE), 43e18);
         assertEq(aliceEscrow.delegations(CALLER1, BOB), 10e18);
+        assertEq(aliceEscrow.totalDelegated(), 53e18);
+        assertEq(gohm.balanceOf(address(aliceEscrow)), 53e18);
 
         assertEq(delegate(CALLER2, 10e18, ALICE), 10e18);
         assertEq(delegate(CALLER2, 33e18, ALICE), 43e18);
@@ -147,6 +151,14 @@ contract DelegateEscrowImplTest is DelegateEscrowFactoryTestBase {
 
         assertEq(aliceEscrow.delegations(CALLER1, ALICE), 43e18);
         assertEq(aliceEscrow.delegations(CALLER1, BOB), 10e18);
+
+        assertEq(aliceEscrow.totalDelegated(), 106e18);
+
+        // Donations count towards this too
+        gohm.mint(address(aliceEscrow), 33e18);
+
+        assertEq(aliceEscrow.totalDelegated(), 139e18);
+        assertEq(gohm.balanceOf(address(aliceEscrow)), 139e18);
     }
 
     function test_rescindDelegation() public {
@@ -154,6 +166,8 @@ contract DelegateEscrowImplTest is DelegateEscrowFactoryTestBase {
         delegate(CALLER1, 10e18, BOB);
         delegate(CALLER2, 43e18, ALICE);
         delegate(CALLER2, 10e18, BOB);
+        gohm.mint(address(aliceEscrow), 50e18);
+        assertEq(aliceEscrow.totalDelegated(), 156e18);
 
         vm.startPrank(CALLER1);
         vm.expectRevert(abi.encodeWithSelector(DelegateEscrow.ExceededDelegationBalance.selector));
@@ -161,17 +175,23 @@ contract DelegateEscrowImplTest is DelegateEscrowFactoryTestBase {
 
         assertEq(rescind(CALLER1, ALICE, 5e18), 38e18);
         assertEq(aliceEscrow.delegations(CALLER1, ALICE), 38e18);
+        assertEq(aliceEscrow.totalDelegated(), 151e18);
         assertEq(rescind(CALLER1, ALICE, 5e18), 33e18);
         assertEq(aliceEscrow.delegations(CALLER1, ALICE), 33e18);
+        assertEq(aliceEscrow.totalDelegated(), 146e18);
         assertEq(rescind(CALLER1, BOB, 5e18), 5e18);
         assertEq(aliceEscrow.delegations(CALLER1, BOB), 5e18);
+        assertEq(aliceEscrow.totalDelegated(), 141e18);
 
         assertEq(rescind(CALLER2, ALICE, 5e18), 38e18);
         assertEq(aliceEscrow.delegations(CALLER2, ALICE), 38e18);
+        assertEq(aliceEscrow.totalDelegated(), 136e18);
         assertEq(rescind(CALLER2, ALICE, 5e18), 33e18);
         assertEq(aliceEscrow.delegations(CALLER2, ALICE), 33e18);
+        assertEq(aliceEscrow.totalDelegated(), 131e18);
         assertEq(rescind(CALLER2, BOB, 5e18), 5e18);
         assertEq(aliceEscrow.delegations(CALLER2, BOB), 5e18);
+        assertEq(aliceEscrow.totalDelegated(), 126e18);
 
         assertEq(aliceEscrow.delegations(CALLER1, ALICE), 33e18);
         assertEq(aliceEscrow.delegations(CALLER1, BOB), 5e18);

--- a/src/test/modules/DLGTE.t.sol
+++ b/src/test/modules/DLGTE.t.sol
@@ -209,7 +209,12 @@ contract DLGTETestBase is Test {
         seedDelegate(policy, ALICE, BOB, 100e18);
     }
 
-    function seedDelegate(address caller, address onBehalfOf, address delegate, uint256 amount) internal {
+    function seedDelegate(
+        address caller,
+        address onBehalfOf,
+        address delegate,
+        uint256 amount
+    ) internal {
         vm.startPrank(caller);
         deal(address(gohm), caller, 100e18);
         gohm.approve(address(dlgte), 100e18);
@@ -630,13 +635,15 @@ contract DLGTETestDelegationsFromOneDelegate is DLGTETestBase {
         vm.expectRevert(abi.encodeWithSelector(IDLGTEv1.DLGTE_InvalidAmount.selector));
         dlgte.applyDelegations(ALICE, unDelegationRequest(BOB, 0));
 
-        vm.expectRevert(abi.encodeWithSelector(
-            IDLGTEv1.DLGTE_ExceededDelegatedBalance.selector,
-            BOB,
-            100e18,
-            100e18+1
-        ));
-        dlgte.applyDelegations(ALICE, unDelegationRequest(BOB, 100e18+1));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IDLGTEv1.DLGTE_ExceededDelegatedBalance.selector,
+                BOB,
+                100e18,
+                100e18 + 1
+            )
+        );
+        dlgte.applyDelegations(ALICE, unDelegationRequest(BOB, 100e18 + 1));
     }
 
     function test_applyDelegations_success_partialWithdraw() public {
@@ -674,7 +681,9 @@ contract DLGTETestDelegationsFromOneDelegate is DLGTETestBase {
     function test_applyDelegations_success_minUndelegate() public {
         seedDelegate();
 
-        IDLGTEv1.DelegationRequest[] memory delegationRequests = new IDLGTEv1.DelegationRequest[](1);
+        IDLGTEv1.DelegationRequest[] memory delegationRequests = new IDLGTEv1.DelegationRequest[](
+            1
+        );
         delegationRequests[0] = IDLGTEv1.DelegationRequest({
             delegate: BOB,
             amount: type(int256).min
@@ -685,13 +694,7 @@ contract DLGTETestDelegationsFromOneDelegate is DLGTETestBase {
         emit Delegate(expectedEscrow, address(dlgte), ALICE, -100e18);
         vm.expectEmit(address(dlgte));
         emit DelegationApplied(ALICE, BOB, -100e18);
-        verifyApplyDelegations(
-            ALICE,
-            delegationRequests,
-            0,
-            100e18,
-            100e18
-        );
+        verifyApplyDelegations(ALICE, delegationRequests, 0, 100e18, 100e18);
         assertEq(gohm.balanceOf(address(dlgte)), 100e18);
         assertEq(gohm.balanceOf(address(policy)), 0);
         assertEq(gohm.balanceOf(expectedEscrow), 0);
@@ -837,7 +840,7 @@ contract DLGTETestRescindDelegations is DLGTETestBase {
         seedDelegate(policy, ALICE, BOB, 100e18);
         setupUndelegated(policy, ALICE, 33e18);
 
-        address expectedEscrow = 0xCB6f5076b5bbae81D7643BfBf57897E8E3FB1db9;        
+        address expectedEscrow = 0xCB6f5076b5bbae81D7643BfBf57897E8E3FB1db9;
         vm.startPrank(policy);
         assertEq(dlgte.rescindDelegations(ALICE, 10e18), 33e18);
         verifyDelegationsOne(ALICE, BOB, 100e18, expectedEscrow);
@@ -854,12 +857,12 @@ contract DLGTETestRescindDelegations is DLGTETestBase {
         seedDelegate(policy, ALICE, BOB, 100e18);
 
         uint256 expectedRescindAmount = 33e18;
-        address expectedEscrow = 0xCB6f5076b5bbae81D7643BfBf57897E8E3FB1db9;        
+        address expectedEscrow = 0xCB6f5076b5bbae81D7643BfBf57897E8E3FB1db9;
         vm.startPrank(policy);
         vm.expectEmit(address(dlgte));
         emit DelegationApplied(ALICE, BOB, -int256(expectedRescindAmount));
         assertEq(dlgte.rescindDelegations(ALICE, expectedRescindAmount), expectedRescindAmount);
-        verifyDelegationsOne(ALICE, BOB, 100e18-expectedRescindAmount, expectedEscrow);
+        verifyDelegationsOne(ALICE, BOB, 100e18 - expectedRescindAmount, expectedEscrow);
     }
 
     function test_rescindDelegations_oneDelegateLessThanEnough() public {
@@ -894,32 +897,60 @@ contract DLGTETestRescindDelegations is DLGTETestBase {
         verifyAccountSummary(address(policy2), ALICE, 200e18, 200e18, 1, 10, 100e18);
 
         uint256 expectedRescindAmount = 133e18;
-        address expectedEscrow = 0xCB6f5076b5bbae81D7643BfBf57897E8E3FB1db9;        
+        address expectedEscrow = 0xCB6f5076b5bbae81D7643BfBf57897E8E3FB1db9;
         vm.startPrank(policy);
         vm.expectEmit(address(dlgte));
         emit DelegationApplied(ALICE, BOB, -int256(expectedRescindAmount));
         assertEq(dlgte.rescindDelegations(ALICE, expectedRescindAmount), expectedRescindAmount);
-        verifyDelegationsOne(ALICE, BOB, 200e18-expectedRescindAmount, expectedEscrow);
-        verifyAccountSummary(address(policy), ALICE, 200e18, 200e18-expectedRescindAmount, 1, 10, 100e18);
+        verifyDelegationsOne(ALICE, BOB, 200e18 - expectedRescindAmount, expectedEscrow);
+        verifyAccountSummary(
+            address(policy),
+            ALICE,
+            200e18,
+            200e18 - expectedRescindAmount,
+            1,
+            10,
+            100e18
+        );
 
         vm.expectRevert(
-            abi.encodeWithSelector(IDLGTEv1.DLGTE_ExceededPolicyAccountBalance.selector, 100e18, 133e18)
+            abi.encodeWithSelector(
+                IDLGTEv1.DLGTE_ExceededPolicyAccountBalance.selector,
+                100e18,
+                133e18
+            )
         );
         dlgte.withdrawUndelegatedGohm(ALICE, expectedRescindAmount, false);
 
         dlgte.withdrawUndelegatedGohm(ALICE, 100e18, false);
-        verifyAccountSummary(address(policy), ALICE, 100e18, 200e18-expectedRescindAmount, 1, 10, 0);
-        verifyAccountSummary(address(policy2), ALICE, 100e18, 200e18-expectedRescindAmount, 1, 10, 100e18);
+        verifyAccountSummary(
+            address(policy),
+            ALICE,
+            100e18,
+            200e18 - expectedRescindAmount,
+            1,
+            10,
+            0
+        );
+        verifyAccountSummary(
+            address(policy2),
+            ALICE,
+            100e18,
+            200e18 - expectedRescindAmount,
+            1,
+            10,
+            100e18
+        );
     }
 
     function test_rescindDelegations_multiDelegatesMoreThanEnough() public {
         seedDelegate(policy, ALICE, ALICE, 100e18);
         seedDelegate(policy, ALICE, BOB, 100e18);
         seedDelegate(policy, ALICE, CHARLIE, 100e18);
+        seedDelegate(policy, ALICE, DANIEL, 100e18);
         seedDelegate(policy2, ALICE, ALICE, 100e18);
 
         uint256 expectedRescindAmount = 320e18;
-        address expectedEscrow = 0x5Fa39CD9DD20a3A77BA0CaD164bD5CF0d7bb3303;        
         vm.startPrank(policy);
         vm.expectEmit(address(dlgte));
         emit DelegationApplied(ALICE, ALICE, -200e18);
@@ -928,7 +959,61 @@ contract DLGTETestRescindDelegations is DLGTETestBase {
         vm.expectEmit(address(dlgte));
         emit DelegationApplied(ALICE, CHARLIE, -20e18);
         assertEq(dlgte.rescindDelegations(ALICE, expectedRescindAmount), expectedRescindAmount);
-        verifyDelegationsOne(ALICE, CHARLIE, 80e18, expectedEscrow);
+
+        // The order gets switched from the 'swap + pop' strategy
+        address expectedCharlieEscrow = 0x5Fa39CD9DD20a3A77BA0CaD164bD5CF0d7bb3303;
+        address expectedDanielEscrow = 0x4B2AEa91Ed33FFb3783e545cc5F975174dC53EF0;
+        verifyDelegationsTwo(
+            ALICE,
+            DANIEL,
+            100e18,
+            expectedDanielEscrow,
+            CHARLIE,
+            80e18,
+            expectedCharlieEscrow
+        );
+
+        verifyAccountSummary(policy, ALICE, 500e18, 500e18 - 320e18, 2, 10, 400e18);
+        verifyAccountSummary(policy2, ALICE, 500e18, 500e18 - 320e18, 2, 10, 100e18);
+    }
+
+    function test_rescindDelegations_orderChange_multiDelegatesMoreThanEnough() public {
+        seedDelegate(policy, ALICE, ALICE, 100e18);
+        seedDelegate(policy, ALICE, BOB, 100e18);
+        seedDelegate(policy, ALICE, CHARLIE, 100e18);
+        seedDelegate(policy, ALICE, DANIEL, 100e18);
+        seedDelegate(policy2, ALICE, ALICE, 100e18);
+
+        // Completely undelegate BOB, then re-add again. Order will change
+        vm.startPrank(policy2);
+        dlgte.applyDelegations(ALICE, unDelegationRequest(BOB, 100e18));
+        dlgte.applyDelegations(ALICE, delegationRequest(BOB, 100e18));
+
+        uint256 expectedRescindAmount = 320e18;
+        vm.startPrank(policy);
+        vm.expectEmit(address(dlgte));
+        emit DelegationApplied(ALICE, ALICE, -200e18);
+        vm.expectEmit(address(dlgte));
+        emit DelegationApplied(ALICE, DANIEL, -100e18);
+        vm.expectEmit(address(dlgte));
+        emit DelegationApplied(ALICE, CHARLIE, -20e18);
+        assertEq(dlgte.rescindDelegations(ALICE, expectedRescindAmount), expectedRescindAmount);
+
+        // The order gets switched from the 'swap + pop' strategy
+        address expectedBobEscrow = 0xA11d35fE4b9Ca9979F2FF84283a9Ce190F60Cd00;
+        address expectedCharlieEscrow = 0x5Fa39CD9DD20a3A77BA0CaD164bD5CF0d7bb3303;
+        verifyDelegationsTwo(
+            ALICE,
+            BOB,
+            100e18,
+            expectedBobEscrow,
+            CHARLIE,
+            80e18,
+            expectedCharlieEscrow
+        );
+
+        verifyAccountSummary(policy, ALICE, 500e18, 500e18 - 320e18, 2, 10, 400e18);
+        verifyAccountSummary(policy2, ALICE, 500e18, 500e18 - 320e18, 2, 10, 100e18);
     }
 
     function test_rescindDelegations_multiDelegatesLessThanEnough() public {
@@ -976,7 +1061,7 @@ contract DLGTETestRescindDelegations is DLGTETestBase {
         uint256 actualUndelegatedBalance;
         uint256 gasBefore = gasleft();
         actualUndelegatedBalance = dlgte.rescindDelegations(ALICE, totalCollateral);
-        assertLt(gasBefore-gasleft(), 3_600_000);
+        assertLt(gasBefore - gasleft(), 3_600_000);
         assertEq(actualUndelegatedBalance, totalCollateral);
     }
 }
@@ -1138,7 +1223,11 @@ contract DLGTETestViews is DLGTETestBase {
         }
 
         {
-            IDLGTEv1.AccountDelegation[] memory delegations = dlgte.accountDelegationsList(ALICE, 15, 50);
+            IDLGTEv1.AccountDelegation[] memory delegations = dlgte.accountDelegationsList(
+                ALICE,
+                15,
+                50
+            );
             IDLGTEv1.AccountDelegation memory adelegation = delegations[0];
             assertEq(delegations.length, 15);
             adelegation = delegations[0];
@@ -1150,10 +1239,7 @@ contract DLGTETestViews is DLGTETestBase {
             adelegation = delegations[delegations.length - 1];
             assertNotEq(adelegation.delegate, address(0));
             assertEq(adelegation.amount, 1e18 + 29);
-            assertEq(
-                dlgte.totalDelegatedTo(adelegation.delegate),
-                1e18 + 29 + 99e18
-            );
+            assertEq(dlgte.totalDelegatedTo(adelegation.delegate), 1e18 + 29 + 99e18);
             assertNotEq(adelegation.escrow, address(0));
         }
     }

--- a/src/test/policies/cooler/MonoCoolerBase.t.sol
+++ b/src/test/policies/cooler/MonoCoolerBase.t.sol
@@ -443,7 +443,6 @@ abstract contract MonoCoolerBaseTest is Test {
 
     function checkBatchLiquidate(
         address[] memory accounts,
-        IDLGTEv1.DelegationRequest[][] memory requests,
         uint128 expectedCollateralClaimed,
         uint128 expectedDebtWiped,
         uint128 expectedIncentives
@@ -452,7 +451,7 @@ abstract contract MonoCoolerBaseTest is Test {
             uint128 totalCollateralClaimed,
             uint128 totalDaiDebtWiped,
             uint128 totalIncentives
-        ) = cooler.batchLiquidate(accounts, requests);
+        ) = cooler.batchLiquidate(accounts);
         assertEq(
             totalCollateralClaimed,
             expectedCollateralClaimed,

--- a/src/test/policies/cooler/MonoCoolerBase.t.sol
+++ b/src/test/policies/cooler/MonoCoolerBase.t.sol
@@ -256,11 +256,7 @@ abstract contract MonoCoolerBaseTest is Test {
         );
         assertEq(delegations.length, 1, "AccountDelegation::length::1");
         assertEq(delegations[0].delegate, expectedDelegate, "AccountDelegation::delegate");
-        assertEq(
-            delegations[0].totalAmount,
-            expectedDelegationAmount,
-            "AccountDelegation::totalAmount"
-        );
+        assertEq(delegations[0].amount, expectedDelegationAmount, "AccountDelegation::amount");
         assertEq(
             gohm.balanceOf(delegations[0].escrow),
             expectedDelegationAmount,
@@ -282,22 +278,14 @@ abstract contract MonoCoolerBaseTest is Test {
         );
         assertEq(delegations.length, 2, "AccountDelegation::length::2");
         assertEq(delegations[0].delegate, expectedDelegate1, "AccountDelegation::delegate1");
-        assertEq(
-            delegations[0].totalAmount,
-            expectedDelegationAmount1,
-            "AccountDelegation::totalAmount1"
-        );
+        assertEq(delegations[0].amount, expectedDelegationAmount1, "AccountDelegation::amount1");
         assertEq(
             gohm.balanceOf(delegations[0].escrow),
             expectedDelegationAmount1,
             "AccountDelegation::escrow1::gOHM::balanceOf"
         );
         assertEq(delegations[1].delegate, expectedDelegate2, "AccountDelegation::delegate2");
-        assertEq(
-            delegations[1].totalAmount,
-            expectedDelegationAmount2,
-            "AccountDelegation::totalAmount2"
-        );
+        assertEq(delegations[1].amount, expectedDelegationAmount2, "AccountDelegation::amount2");
         assertEq(
             gohm.balanceOf(delegations[1].escrow),
             expectedDelegationAmount2,

--- a/src/test/policies/cooler/MonoCoolerLiquidations.t.sol
+++ b/src/test/policies/cooler/MonoCoolerLiquidations.t.sol
@@ -675,12 +675,7 @@ contract MonoCoolerLiquidationsTest is MonoCoolerComputeLiquidityBaseTest {
             })
         );
 
-        checkBatchLiquidate(
-            oneAddress(ALICE),
-            0,
-            0,
-            0
-        );
+        checkBatchLiquidate(oneAddress(ALICE), 0, 0, 0);
 
         // No change
         assertEq(cooler.totalCollateral(), collateralAmount);
@@ -730,12 +725,7 @@ contract MonoCoolerLiquidationsTest is MonoCoolerComputeLiquidityBaseTest {
             })
         );
 
-        checkBatchLiquidate(
-            oneAddress(ALICE),
-            0,
-            0,
-            0
-        );
+        checkBatchLiquidate(oneAddress(ALICE), 0, 0, 0);
     }
 
     function test_batchLiquidate_oneAccount_canLiquidateAboveMax() external {
@@ -777,12 +767,7 @@ contract MonoCoolerLiquidationsTest is MonoCoolerComputeLiquidityBaseTest {
         vm.startPrank(OTHERS);
         vm.expectEmit(address(cooler));
         emit Liquidated(OTHERS, ALICE, collateralAmount, expectedDebt, expectedIncentives);
-        checkBatchLiquidate(
-            oneAddress(ALICE),
-            collateralAmount,
-            expectedDebt,
-            expectedIncentives
-        );
+        checkBatchLiquidate(oneAddress(ALICE), collateralAmount, expectedDebt, expectedIncentives);
 
         // Check position is empty now (debt + collateral)
         {
@@ -833,12 +818,7 @@ contract MonoCoolerLiquidationsTest is MonoCoolerComputeLiquidityBaseTest {
         vm.startPrank(OTHERS);
         vm.expectEmit(address(cooler));
         emit Liquidated(OTHERS, ALICE, collateralAmount, expectedDebt, collateralAmount);
-        checkBatchLiquidate(
-            oneAddress(ALICE),
-            collateralAmount,
-            expectedDebt,
-            collateralAmount
-        );
+        checkBatchLiquidate(oneAddress(ALICE), collateralAmount, expectedDebt, collateralAmount);
     }
 
     function test_batchLiquidate_noOhmToBurn() external {
@@ -865,7 +845,6 @@ contract MonoCoolerLiquidationsTest is MonoCoolerComputeLiquidityBaseTest {
         emit Liquidated(OTHERS, ALICE, collateralAmount, expectedDebt, 9.998323814584335317e18);
         checkBatchLiquidate(
             oneAddress(ALICE),
-            oneDelegationRequest(noDelegationRequest()),
             collateralAmount,
             expectedDebt,
             9.998323814584335317e18

--- a/src/test/policies/cooler/MonoCoolerLiquidations.t.sol
+++ b/src/test/policies/cooler/MonoCoolerLiquidations.t.sol
@@ -5,7 +5,6 @@ import {MonoCoolerBaseTest} from "./MonoCoolerBase.t.sol";
 import {IMonoCooler} from "policies/interfaces/cooler/IMonoCooler.sol";
 import {IDLGTEv1} from "modules/DLGTE/IDLGTE.v1.sol";
 import {ICoolerLtvOracle} from "policies/interfaces/cooler/ICoolerLtvOracle.sol";
-import {DelegateEscrow} from "src/external/cooler/DelegateEscrow.sol";
 import {MonoCooler} from "policies/cooler/MonoCooler.sol";
 import {Actions} from "policies/RolesAdmin.sol";
 import {MockStakingReal} from "test/mocks/MockStakingReal.sol";
@@ -614,12 +613,7 @@ contract MonoCoolerLiquidationsTest is MonoCoolerComputeLiquidityBaseTest {
         cooler.setLiquidationsPaused(true);
 
         vm.expectRevert(abi.encodeWithSelector(IMonoCooler.Paused.selector));
-        cooler.batchLiquidate(oneAddress(ALICE), oneDelegationRequest(noDelegationRequest()));
-    }
-
-    function test_batchLiquidate_fail_badDelegationRequests() external {
-        vm.expectRevert(abi.encodeWithSelector(IMonoCooler.InvalidDelegationRequests.selector));
-        cooler.batchLiquidate(oneAddress(ALICE), noDelegationRequests());
+        cooler.batchLiquidate(oneAddress(ALICE));
     }
 
     function test_batchLiquidate_noAccounts() external {
@@ -643,7 +637,7 @@ contract MonoCoolerLiquidationsTest is MonoCoolerComputeLiquidityBaseTest {
             })
         );
 
-        checkBatchLiquidate(noAddresses(), noDelegationRequests(), 0, 0, 0);
+        checkBatchLiquidate(noAddresses(), 0, 0, 0);
 
         // No change
         assertEq(cooler.totalCollateral(), collateralAmount);
@@ -683,7 +677,6 @@ contract MonoCoolerLiquidationsTest is MonoCoolerComputeLiquidityBaseTest {
 
         checkBatchLiquidate(
             oneAddress(ALICE),
-            oneDelegationRequest(noDelegationRequest()),
             0,
             0,
             0
@@ -739,7 +732,6 @@ contract MonoCoolerLiquidationsTest is MonoCoolerComputeLiquidityBaseTest {
 
         checkBatchLiquidate(
             oneAddress(ALICE),
-            oneDelegationRequest(noDelegationRequest()),
             0,
             0,
             0
@@ -787,7 +779,6 @@ contract MonoCoolerLiquidationsTest is MonoCoolerComputeLiquidityBaseTest {
         emit Liquidated(OTHERS, ALICE, collateralAmount, expectedDebt, expectedIncentives);
         checkBatchLiquidate(
             oneAddress(ALICE),
-            oneDelegationRequest(noDelegationRequest()),
             collateralAmount,
             expectedDebt,
             expectedIncentives
@@ -844,7 +835,6 @@ contract MonoCoolerLiquidationsTest is MonoCoolerComputeLiquidityBaseTest {
         emit Liquidated(OTHERS, ALICE, collateralAmount, expectedDebt, collateralAmount);
         checkBatchLiquidate(
             oneAddress(ALICE),
-            oneDelegationRequest(noDelegationRequest()),
             collateralAmount,
             expectedDebt,
             collateralAmount
@@ -937,7 +927,6 @@ contract MonoCoolerLiquidationsTest is MonoCoolerComputeLiquidityBaseTest {
         emit Liquidated(OTHERS, BOB, collateralAmount, expectedDebt, expectedIncentives);
         checkBatchLiquidate(
             twoAddresses(ALICE, BOB),
-            twoDelegationRequests(noDelegationRequest(), noDelegationRequest()),
             collateralAmount,
             expectedDebt,
             expectedIncentives
@@ -1064,7 +1053,6 @@ contract MonoCoolerLiquidationsTest is MonoCoolerComputeLiquidityBaseTest {
         emit Liquidated(OTHERS, BOB, collateralAmount, expectedDebt, expectedIncentives);
         checkBatchLiquidate(
             twoAddresses(ALICE, BOB),
-            twoDelegationRequests(noDelegationRequest(), noDelegationRequest()),
             collateralAmount * 2,
             expectedDebt * 2,
             expectedIncentives * 2
@@ -1163,76 +1151,9 @@ contract MonoCoolerLiquidationsTest is MonoCoolerComputeLiquidityBaseTest {
         emit Liquidated(OTHERS, BOB, collateralAmount, expectedDebt, expectedIncentives);
         checkBatchLiquidate(
             twoAddresses(ALICE, BOB),
-            twoDelegationRequests(noDelegationRequest(), noDelegationRequest()),
             collateralAmount * 2,
             expectedDebt * 2,
             expectedIncentives * 2
-        );
-    }
-
-    function test_batchLiquidate_wrongSizeDelegationRequests() external {
-        vm.expectRevert(abi.encodeWithSelector(IMonoCooler.InvalidDelegationRequests.selector));
-        cooler.batchLiquidate(
-            twoAddresses(ALICE, BOB),
-            oneDelegationRequest(noDelegationRequest())
-        );
-    }
-
-    function test_batchLiquidate_fail_withPositiveDelegation() external {
-        // Alice delegates some to BOB
-        uint128 collateralAmount = 10e18;
-        addCollateral(ALICE, collateralAmount);
-        uint128 borrowAmount = uint128(cooler.debtDeltaForMaxOriginationLtv(ALICE, 0));
-        borrow(ALICE, ALICE, borrowAmount, ALICE);
-
-        skip(2 * 365 days);
-
-        // No 'delegation' requests allowed - only undelegations
-        vm.expectRevert(abi.encodeWithSelector(IMonoCooler.InvalidDelegationRequests.selector));
-        cooler.batchLiquidate(
-            oneAddress(ALICE),
-            oneDelegationRequest(delegationRequest(BOB, 3.3e18))
-        );
-    }
-
-    function test_batchLiquidate_fail_undelegateTooMuch() external {
-        // Alice delegates some to BOB
-        uint128 collateralAmount = 10e18;
-        uint128 delegationAmount = 3e18;
-        addCollateral(ALICE, ALICE, collateralAmount, delegationRequest(BOB, delegationAmount));
-        uint128 borrowAmount = uint128(cooler.debtDeltaForMaxOriginationLtv(ALICE, 0));
-        borrow(ALICE, ALICE, borrowAmount, ALICE);
-
-        skip(2 * 365 days);
-
-        // No 'delegation' requests allowed - only undelegations
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IDLGTEv1.DLGTE_ExceededDelegatedBalance.selector,
-                BOB,
-                3e18,
-                3.3e18
-            )
-        );
-        cooler.batchLiquidate(
-            oneAddress(ALICE),
-            oneDelegationRequest(unDelegationRequest(BOB, 3.3e18))
-        );
-    }
-
-    function test_batchLiquidate_notEnoughUndelegated() external {
-        uint128 collateralAmount = 10e18;
-        addCollateral(ALICE, ALICE, collateralAmount, delegationRequest(BOB, 8e18));
-        uint128 borrowAmount = uint128(cooler.debtDeltaForMaxOriginationLtv(ALICE, 0));
-        borrow(ALICE, ALICE, borrowAmount, ALICE);
-        skip(2 * 365 days);
-
-        vm.expectRevert(
-            abi.encodeWithSelector(IDLGTEv1.DLGTE_ExceededUndelegatedBalance.selector, 7e18, 10e18)
-        );
-        cooler.batchLiquidate(
-            oneAddress(ALICE),
-            oneDelegationRequest(unDelegationRequest(BOB, 5e18))
         );
     }
 
@@ -1271,7 +1192,6 @@ contract MonoCoolerLiquidationsTest is MonoCoolerComputeLiquidityBaseTest {
         vm.startPrank(OTHERS);
         checkBatchLiquidate(
             twoAddresses(ALICE, BOB),
-            twoDelegationRequests(delegationRequests, unDelegationRequest(BOB, 10e18)),
             collateralAmount * 2,
             expectedDebt * 2,
             expectedIncentives * 2
@@ -1349,27 +1269,8 @@ contract MonoCoolerLiquidationsTest is MonoCoolerComputeLiquidityBaseTest {
         MonoCooler cooler2 = _cooler2Setup(collateralAmount, delegationAmount);
 
         vm.startPrank(OTHERS);
-
-        // If only undelegating 2e18, then only 6+2=8e18 undelegated which isn't enough
-        vm.expectRevert(
-            abi.encodeWithSelector(IDLGTEv1.DLGTE_ExceededUndelegatedBalance.selector, 8e18, 10e18)
-        );
-        cooler.batchLiquidate(
-            oneAddress(ALICE),
-            oneDelegationRequest(unDelegationRequest(BOB, 2e18))
-        );
-
-        // If undelegating 4e18+1, then only 6+4=10e18+1 undelegated which is too much
-        vm.expectRevert(abi.encodeWithSelector(IMonoCooler.InvalidDelegationRequests.selector));
-        cooler.batchLiquidate(
-            oneAddress(ALICE),
-            oneDelegationRequest(unDelegationRequest(BOB, 4e18 + 1))
-        );
-
-        // Just right
         checkBatchLiquidate(
             oneAddress(ALICE),
-            oneDelegationRequest(unDelegationRequest(BOB, 4e18)),
             collateralAmount,
             29_914.049768431554843335e18,
             0.000496703803644129e18

--- a/src/test/policies/cooler/MonoCoolerLiquidations.t.sol
+++ b/src/test/policies/cooler/MonoCoolerLiquidations.t.sol
@@ -472,7 +472,14 @@ contract MonoCoolerApplyUnhealthyDelegations is MonoCoolerComputeLiquidityBaseTe
         borrow(ALICE, ALICE, borrowAmount, ALICE);
 
         skip(2 * 365 days);
-        vm.expectRevert(abi.encodeWithSelector(DelegateEscrow.ExceededDelegationBalance.selector));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IDLGTEv1.DLGTE_ExceededDelegatedBalance.selector,
+                BOB,
+                8e18,
+                8e18 + 1
+            )
+        );
         cooler.applyUnhealthyDelegations(ALICE, unDelegationRequest(BOB, 8e18 + 1));
     }
 
@@ -1199,7 +1206,14 @@ contract MonoCoolerLiquidationsTest is MonoCoolerComputeLiquidityBaseTest {
         skip(2 * 365 days);
 
         // No 'delegation' requests allowed - only undelegations
-        vm.expectRevert(abi.encodeWithSelector(DelegateEscrow.ExceededDelegationBalance.selector));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IDLGTEv1.DLGTE_ExceededDelegatedBalance.selector,
+                BOB,
+                3e18,
+                3.3e18
+            )
+        );
         cooler.batchLiquidate(
             oneAddress(ALICE),
             oneDelegationRequest(unDelegationRequest(BOB, 3.3e18))

--- a/src/test/policies/pOLY.t.sol
+++ b/src/test/policies/pOLY.t.sol
@@ -162,7 +162,12 @@ contract pOLYTest is Test {
         }
     }
 
-    function _checkTerms(address user, uint256 expectedPercent, uint256 expectedGClaimed, uint256 expectedNewMax) private view {
+    function _checkTerms(
+        address user,
+        uint256 expectedPercent,
+        uint256 expectedGClaimed,
+        uint256 expectedNewMax
+    ) private view {
         (uint256 newPercent, uint256 newGClaimed, uint256 newMax) = poly.terms(user);
         assertEq(newPercent, expectedPercent);
         assertEq(newGClaimed, expectedGClaimed);

--- a/src/test/policies/pOLY.t.sol
+++ b/src/test/policies/pOLY.t.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.15;
 
 import {Test} from "forge-std/Test.sol";
-import {console2} from "forge-std/console2.sol";
 import {UserFactory} from "src/test/lib/UserFactory.sol";
 
 import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
@@ -12,7 +11,7 @@ import {OlympusMinter} from "modules/MINTR/OlympusMinter.sol";
 import {OlympusTreasury} from "modules/TRSRY/OlympusTreasury.sol";
 import {OlympusRoles, ROLESv1} from "modules/ROLES/OlympusRoles.sol";
 import {RolesAdmin} from "policies/RolesAdmin.sol";
-import {IPOLY, pOLY} from "policies/pOLY.sol";
+import {pOLY} from "policies/pOLY.sol";
 import "src/Kernel.sol";
 
 import {IgOHM} from "interfaces/IgOHM.sol";
@@ -161,6 +160,13 @@ contract pOLYTest is Test {
             // Set OHM circulating supply
             ohm.mint(address(0), 100_000_000e9);
         }
+    }
+
+    function _checkTerms(address user, uint256 expectedPercent, uint256 expectedGClaimed, uint256 expectedNewMax) private view {
+        (uint256 newPercent, uint256 newGClaimed, uint256 newMax) = poly.terms(user);
+        assertEq(newPercent, expectedPercent);
+        assertEq(newGClaimed, expectedGClaimed);
+        assertEq(newMax, expectedNewMax);
     }
 
     //============================================================================================//
@@ -326,18 +332,12 @@ contract pOLYTest is Test {
         vm.prank(alice);
         poly.pushWalletChange(bob);
 
-        (uint256 percent, uint256 gClaimed, uint256 max) = poly.terms(bob);
-        assertEq(percent, 10_000);
-        assertEq(gClaimed, 0);
-        assertEq(max, 100_000e9);
+        _checkTerms(bob, 10_000, 0, 100_000e9);
 
         vm.prank(bob);
         poly.pullWalletChange(alice);
 
-        (percent, gClaimed, max) = poly.terms(bob);
-        assertEq(percent, 20_000);
-        assertEq(gClaimed, 0);
-        assertEq(max, 200_000e9);
+        _checkTerms(bob, 20_000, 0, 200_000e9);
     }
 
     function test_pullWalletSetsWalletChangeToZeroAddress(address newWallet_) public {
@@ -362,25 +362,13 @@ contract pOLYTest is Test {
         vm.prank(alice);
         poly.pushWalletChange(newWallet_);
 
-        (uint256 percent, uint256 gClaimed, uint256 max) = poly.terms(alice);
-        assertEq(percent, 10_000);
-        assertEq(gClaimed, 0);
-        assertEq(max, 100_000e9);
-
-        (uint256 newWalletPercent, uint256 newWalletGClaimed, uint256 newWalletMax) = poly.terms(
-            newWallet_
-        );
-        assertEq(newWalletPercent, 0);
-        assertEq(newWalletGClaimed, 0);
-        assertEq(newWalletMax, 0);
+        _checkTerms(alice, 10_000, 0, 100_000e9);
+        _checkTerms(newWallet_, 0, 0, 0);
 
         vm.prank(newWallet_);
         poly.pullWalletChange(alice);
 
-        (newWalletPercent, newWalletGClaimed, newWalletMax) = poly.terms(newWallet_);
-        assertEq(newWalletPercent, 10_000);
-        assertEq(newWalletGClaimed, 0);
-        assertEq(newWalletMax, 100_000e9);
+        _checkTerms(newWallet_, 10_000, 0, 100_000e9);
     }
 
     function test_pullWalletDeletesTermsForOldWallet(address newWallet_) public {
@@ -389,18 +377,12 @@ contract pOLYTest is Test {
         vm.prank(alice);
         poly.pushWalletChange(newWallet_);
 
-        (uint256 percent, uint256 gClaimed, uint256 max) = poly.terms(alice);
-        assertEq(percent, 10_000);
-        assertEq(gClaimed, 0);
-        assertEq(max, 100_000e9);
+        _checkTerms(alice, 10_000, 0, 100_000e9);
 
         vm.prank(newWallet_);
         poly.pullWalletChange(alice);
 
-        (percent, gClaimed, max) = poly.terms(alice);
-        assertEq(percent, 0);
-        assertEq(gClaimed, 0);
-        assertEq(max, 0);
+        _checkTerms(alice, 0, 0, 0);
     }
 
     function test_pullWalletOldWalletCanNoLongerClaim(address newWallet_) public {
@@ -460,15 +442,8 @@ contract pOLYTest is Test {
         previous.setTerms(migratedUser1_, 10_000, 0, 100_000e9);
         previous.setTerms(migratedUser2_, 5_000, 1e18, 50_000e9);
 
-        (uint256 newPercent1, uint256 newGClaimed1, uint256 newMax1) = poly.terms(migratedUser1_);
-        assertEq(newPercent1, 0);
-        assertEq(newGClaimed1, 0);
-        assertEq(newMax1, 0);
-
-        (uint256 newPercent2, uint256 newGClaimed2, uint256 newMax2) = poly.terms(migratedUser2_);
-        assertEq(newPercent2, 0);
-        assertEq(newGClaimed2, 0);
-        assertEq(newMax2, 0);
+        _checkTerms(migratedUser1_, 0, 0, 0);
+        _checkTerms(migratedUser2_, 0, 0, 0);
 
         address[] memory users = new address[](2);
         users[0] = migratedUser1_;
@@ -476,15 +451,8 @@ contract pOLYTest is Test {
 
         poly.migrate(users);
 
-        (newPercent1, newGClaimed1, newMax1) = poly.terms(migratedUser1_);
-        assertEq(newPercent1, 10_000);
-        assertEq(newGClaimed1, 0);
-        assertEq(newMax1, 100_000e9);
-
-        (newPercent2, newGClaimed2, newMax2) = poly.terms(migratedUser2_);
-        assertEq(newPercent2, 5_000);
-        assertEq(newGClaimed2, 1e18);
-        assertEq(newMax2, 50_000e9);
+        _checkTerms(migratedUser1_, 10_000, 0, 100_000e9);
+        _checkTerms(migratedUser2_, 5_000, 1e18, 50_000e9);
     }
 
     /// [X]  migrateGenesis
@@ -518,15 +486,8 @@ contract pOLYTest is Test {
         previousGenesis.setTerms(migratedUser1_, 10_000, 100e9, 1e18, 100_000e9);
         previousGenesis.setTerms(migratedUser2_, 5_000, 5e9, 5e17, 50_000e9);
 
-        (uint256 newPercent1, uint256 newGClaimed1, uint256 newMax1) = poly.terms(migratedUser1_);
-        assertEq(newPercent1, 0);
-        assertEq(newGClaimed1, 0);
-        assertEq(newMax1, 0);
-
-        (uint256 newPercent2, uint256 newGClaimed2, uint256 newMax2) = poly.terms(migratedUser2_);
-        assertEq(newPercent2, 0);
-        assertEq(newGClaimed2, 0);
-        assertEq(newMax2, 0);
+        _checkTerms(migratedUser1_, 0, 0, 0);
+        _checkTerms(migratedUser2_, 0, 0, 0);
 
         address[] memory users = new address[](2);
         users[0] = migratedUser1_;
@@ -534,15 +495,8 @@ contract pOLYTest is Test {
 
         poly.migrateGenesis(users);
 
-        (newPercent1, newGClaimed1, newMax1) = poly.terms(migratedUser1_);
-        assertEq(newPercent1, 10_000);
-        assertEq(newGClaimed1, 2e18);
-        assertEq(newMax1, 100_000e9);
-
-        (newPercent2, newGClaimed2, newMax2) = poly.terms(migratedUser2_);
-        assertEq(newPercent2, 5_000);
-        assertEq(newGClaimed2, 55e16);
-        assertEq(newMax2, 50_000e9);
+        _checkTerms(migratedUser1_, 10_000, 2e18, 100_000e9);
+        _checkTerms(migratedUser2_, 5_000, 55e16, 50_000e9);
     }
 
     /// [X]  setTerms
@@ -584,17 +538,11 @@ contract pOLYTest is Test {
     function test_setTermsSetsTermsForAccount(address user_) public {
         vm.assume(user_ != alice && user_ != bob);
 
-        (uint256 percent, uint256 gClaimed, uint256 max) = poly.terms(user_);
-        assertEq(percent, 0);
-        assertEq(gClaimed, 0);
-        assertEq(max, 0);
+        _checkTerms(user_, 0, 0, 0);
 
         poly.setTerms(user_, 10_000, 0, 100_000e9);
 
-        (percent, gClaimed, max) = poly.terms(user_);
-        assertEq(percent, 10_000);
-        assertEq(gClaimed, 0);
-        assertEq(max, 100_000e9);
+        _checkTerms(user_, 10_000, 0, 100_000e9);
     }
 
     function test_setTermsIncreasesTotalAllocatedValue(address user_) public {


### PR DESCRIPTION
In response to: https://github.com/electisec/olympus-coolerv2-report/issues/2

1. Update `OlympusGovDelegation` to track delegated **amounts** for each delegate address
2. Add `DLGTE::rescindDelegations(onBehalfOf, targetUndelegatedBalance)` to automatically rescind delegations based on these tracked delegation amounts
   1. No guarantees on ordering, since removing delegates will 'swap and pop' items in the array for efficiency
3. Update `DLGTE::withdrawUndelegatedGohm()` to take an optional boolean to `autoRescindDelegations` for the exact amount required.
4. Update `MonoCooler::batchLiquidate()` to use this option. Custom liquidation requests are no longer supported here.