### PR TITLE
Cooler v2: migrator improvements

### DIFF
--- a/src/periphery/interfaces/ICoolerV2Migrator.sol
+++ b/src/periphery/interfaces/ICoolerV2Migrator.sol
@@ -41,20 +41,17 @@ interface ICoolerV2Migrator {
     /// @notice Preview the consolidation of a set of loans.
     ///
     /// @param  coolers_            The Coolers to consolidate the loans from.
-    /// @param  callerPays_         True if the caller will pay the interest owed and any fees
     /// @return collateralAmount    The amount of collateral that will be migrated into Cooler V2.
     /// @return borrowAmount        The amount of debt that will be borrowed from Cooler V2.
-    /// @return paymentAmount       The amount of DAI that the caller will need to approve and provide to the migrator.
     function previewConsolidate(
-        address[] calldata coolers_,
-        bool callerPays_
-    ) external view returns (uint256 collateralAmount, uint256 borrowAmount, uint256 paymentAmount);
+        address[] calldata coolers_
+    ) external view returns (uint256 collateralAmount, uint256 borrowAmount);
 
     /// @notice Consolidate Cooler V1 loans into Cooler V2
     ///
     ///         This function supports consolidation of loans from multiple Clearinghouses and Coolers, provided that the caller is the owner.
     ///
-    ///         The funds for paying interest owed and fees will be provided by the caller if `callerPays_` is true, otherwise it will be borrowed from Cooler V2. Note that if the LTV of Cooler V2 is not higher than Cooler V1, it will trigger a liquidation and the migration will fail.
+    ///         The funds for paying interest owed and fees will be borrowed from Cooler V2.
     ///
     ///         It is expected that the caller will have already provided approval for this contract to spend the required tokens. See `previewConsolidate()` for more details.
     ///
@@ -68,7 +65,6 @@ interface ICoolerV2Migrator {
     /// @param  coolers_            The Coolers from which the loans will be migrated.
     /// @param  clearinghouses_     The respective Clearinghouses that created and issued the loans in `coolers_`. This array must be the same length as `coolers_`.
     /// @param  newOwner_           Address of the owner of the Cooler V2 position. This can be the same as the caller, or a different address.
-    /// @param  callerPays_         True if the caller will pay the interest owed and fees, in terms of DAI.
     /// @param  authorization_      Authorization parameters for the new owner. Set the `account` field to the zero address to indicate that authorization has already been provided through `IMonoCooler.setAuthorization()`.
     /// @param  signature_          Authorization signature for the new owner. Ignored if `authorization_.account` is the zero address.
     /// @param  delegationRequests_ Delegation requests for the new owner.
@@ -76,7 +72,6 @@ interface ICoolerV2Migrator {
         address[] memory coolers_,
         address[] memory clearinghouses_,
         address newOwner_,
-        bool callerPays_,
         IMonoCooler.Authorization memory authorization_,
         IMonoCooler.Signature calldata signature_,
         IDLGTEv1.DelegationRequest[] calldata delegationRequests_

--- a/src/periphery/interfaces/ICoolerV2Migrator.sol
+++ b/src/periphery/interfaces/ICoolerV2Migrator.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
-import {IMonoCooler} from "./IMonoCooler.sol";
-import {IDLGTEv1} from "../../../modules/DLGTE/IDLGTE.v1.sol";
+import {IMonoCooler} from "src/policies/interfaces/cooler/IMonoCooler.sol";
+import {IDLGTEv1} from "src/modules/DLGTE/IDLGTE.v1.sol";
 
 /// @title  Cooler V2 Migrator
 /// @notice Interface for contracts that migrate Cooler V1 loans to Cooler V2

--- a/src/periphery/interfaces/IEnabler.sol
+++ b/src/periphery/interfaces/IEnabler.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.15;
+
+/// @title IEnabler
+/// @notice Interface for contracts that can be enabled and disabled
+/// @dev    This is designed for usage by periphery contracts that cannot inherit from `PolicyEnabler`. Authorization is deliberately left open to the implementing contract.
+interface IEnabler {
+    // ============ EVENTS ============ //
+
+    /// @notice Emitted when the contract is enabled
+    event Enabled();
+
+    /// @notice Emitted when the contract is disabled
+    event Disabled();
+
+    // ============ ERRORS ============ //
+
+    /// @notice Thrown when the contract is not enabled
+    error NotEnabled();
+
+    /// @notice Thrown when the contract is not disabled
+    error NotDisabled();
+
+    // ============ FUNCTIONS ============ //
+
+    /// @notice         Returns true if the contract is enabled
+    /// @return enabled True if the contract is enabled, false otherwise
+    function isEnabled() external view returns (bool enabled);
+
+    /// @notice             Enables the contract
+    /// @dev                Implementing contracts should implement permissioning logic
+    ///
+    /// @param enableData_  Optional data to pass to a custom enable function
+    function enable(bytes calldata enableData_) external;
+
+    /// @notice             Disables the contract
+    /// @dev                Implementing contracts should implement permissioning logic
+    ///
+    /// @param disableData_ Optional data to pass to a custom disable function
+    function disable(bytes calldata disableData_) external;
+}


### PR DESCRIPTION
- Change CoolerV2Migrator to be a periphery contract (not a policy, doesn't require installation)
- Adds an IEnabler interface for periphery contracts
- Removes callerPays parameter and borrow repaid interest from Cooler V2
- Removes flash fee calculations, since they are 0