### PR TITLE
Cooler v2: policy enabler improvements

### DIFF
--- a/src/policies/utils/PolicyEnabler.sol
+++ b/src/policies/utils/PolicyEnabler.sol
@@ -47,14 +47,14 @@ abstract contract PolicyEnabler is PolicyAdmin {
 
     /// @notice Enable the contract
     /// @dev    This function performs the following steps:
-    ///         1. Validates that the caller has `ROLE` ("emergency_shutdown")
+    ///         1. Validates that the caller has the admin role
     ///         2. Validates that the contract is disabled
     ///         3. Calls the implementation-specific `_enable()` function
     ///         4. Changes the state of the contract to enabled
     ///         5. Emits the `Enabled` event
     ///
     /// @param  enableData_ The data to pass to the implementation-specific `_enable()` function
-    function enable(bytes calldata enableData_) public onlyEmergencyOrAdminRole onlyDisabled {
+    function enable(bytes calldata enableData_) public onlyAdminRole onlyDisabled {
         // Call the implementation-specific enable function
         _enable(enableData_);
 
@@ -79,7 +79,7 @@ abstract contract PolicyEnabler is PolicyAdmin {
 
     /// @notice Disable the contract
     /// @dev    This function performs the following steps:
-    ///         1. Validates that the caller has `ROLE` ("emergency_shutdown")
+    ///         1. Validates that the caller has the admin or emergency role
     ///         2. Validates that the contract is enabled
     ///         3. Calls the implementation-specific `_disable()` function
     ///         4. Changes the state of the contract to disabled

--- a/src/test/policies/utils/PolicyAdmin/MockPolicyAdmin.sol
+++ b/src/test/policies/utils/PolicyAdmin/MockPolicyAdmin.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity 0.8.15;
+
+import {Kernel, Keycode, Policy, toKeycode} from "src/Kernel.sol";
+import {PolicyAdmin} from "src/policies/utils/PolicyAdmin.sol";
+import {ROLESv1} from "src/modules/ROLES/ROLES.v1.sol";
+
+contract MockPolicyAdmin is Policy, PolicyAdmin {
+    constructor(Kernel kernel_) Policy(kernel_) {}
+
+    function configureDependencies() external override returns (Keycode[] memory dependencies) {
+        dependencies = new Keycode[](1);
+        dependencies[0] = toKeycode("ROLES");
+
+        ROLES = ROLESv1(getModuleAddress(dependencies[0]));
+
+        return dependencies;
+    }
+
+    function gatedToAdminRole() external view onlyAdminRole returns (bool) {
+        return true;
+    }
+
+    function gatedToEmergencyRole() external view onlyEmergencyRole returns (bool) {
+        return true;
+    }
+
+    function gatedToEmergencyOrAdminRole() external view onlyEmergencyOrAdminRole returns (bool) {
+        return true;
+    }
+}

--- a/src/test/policies/utils/PolicyAdmin/PolicyAdminTest.sol
+++ b/src/test/policies/utils/PolicyAdmin/PolicyAdminTest.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity 0.8.15;
+
+import {Test} from "forge-std/Test.sol";
+import {Kernel, Actions} from "src/Kernel.sol";
+
+import {OlympusRoles} from "src/modules/ROLES/OlympusRoles.sol";
+import {RolesAdmin} from "src/policies/RolesAdmin.sol";
+
+import {ADMIN_ROLE, EMERGENCY_ROLE} from "src/policies/utils/RoleDefinitions.sol";
+
+import {MockPolicyAdmin} from "./MockPolicyAdmin.sol";
+
+contract PolicyAdminTest is Test {
+    address public constant EMERGENCY = address(0xAAAA);
+    address public constant ADMIN = address(0xBBBB);
+
+    Kernel public kernel;
+    OlympusRoles public roles;
+    RolesAdmin public rolesAdmin;
+    MockPolicyAdmin public policyAdmin;
+
+    function setUp() public {
+        kernel = new Kernel();
+        roles = new OlympusRoles(kernel);
+        rolesAdmin = new RolesAdmin(kernel);
+
+        policyAdmin = new MockPolicyAdmin(kernel);
+
+        // Install
+        kernel.executeAction(Actions.InstallModule, address(roles));
+        kernel.executeAction(Actions.ActivatePolicy, address(rolesAdmin));
+        kernel.executeAction(Actions.ActivatePolicy, address(policyAdmin));
+
+        // Grant roles
+        rolesAdmin.grantRole(ADMIN_ROLE, ADMIN);
+        rolesAdmin.grantRole(EMERGENCY_ROLE, EMERGENCY);
+    }
+}

--- a/src/test/policies/utils/PolicyAdmin/onlyAdminRole.t.sol
+++ b/src/test/policies/utils/PolicyAdmin/onlyAdminRole.t.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity 0.8.15;
+
+import {PolicyAdminTest} from "./PolicyAdminTest.sol";
+import {ROLESv1} from "src/modules/ROLES/ROLES.v1.sol";
+import {ADMIN_ROLE} from "src/policies/utils/RoleDefinitions.sol";
+
+contract PolicyAdminOnlyAdminRoleTest is PolicyAdminTest {
+    // given the caller does not have the admin role
+    //  [X] it reverts
+    // given the caller has the admin role
+    //  [X] it does not revert
+
+    function test_callerNotAdminRole_reverts() public {
+        // Expect revert
+        vm.expectRevert(abi.encodeWithSelector(ROLESv1.ROLES_RequireRole.selector, ADMIN_ROLE));
+
+        // Call function
+        policyAdmin.gatedToAdminRole();
+    }
+
+    function test_callerHasAdminRole() public {
+        // Call function
+        vm.prank(ADMIN);
+        policyAdmin.gatedToAdminRole();
+    }
+}

--- a/src/test/policies/utils/PolicyAdmin/onlyEmergencyOrAdminRole.t.sol
+++ b/src/test/policies/utils/PolicyAdmin/onlyEmergencyOrAdminRole.t.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity 0.8.15;
+
+import {PolicyAdmin} from "src/policies/utils/PolicyAdmin.sol";
+import {PolicyAdminTest} from "./PolicyAdminTest.sol";
+
+contract PolicyAdminOnlyEmergencyOrAdminRoleTest is PolicyAdminTest {
+    // given the caller does not have the admin or emergency role
+    //  [X] it reverts
+    // given the caller has the admin role
+    //  [X] it does not revert
+    // given the caller has the emergency role
+    //  [X] it does not revert
+
+    function test_callerNotEmergencyOrAdminRole_reverts() public {
+        // Expect revert
+        vm.expectRevert(PolicyAdmin.NotAuthorised.selector);
+
+        // Call function
+        policyAdmin.gatedToEmergencyOrAdminRole();
+    }
+
+    function test_callerHasAdminRole() public {
+        // Call function
+        vm.prank(ADMIN);
+        policyAdmin.gatedToEmergencyOrAdminRole();
+    }
+
+    function test_callerHasEmergencyRole() public {
+        // Call function
+        vm.prank(EMERGENCY);
+        policyAdmin.gatedToEmergencyOrAdminRole();
+    }
+}

--- a/src/test/policies/utils/PolicyAdmin/onlyEmergencyRole.t.sol
+++ b/src/test/policies/utils/PolicyAdmin/onlyEmergencyRole.t.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity 0.8.15;
+
+import {PolicyAdminTest} from "./PolicyAdminTest.sol";
+import {ROLESv1} from "src/modules/ROLES/ROLES.v1.sol";
+import {EMERGENCY_ROLE} from "src/policies/utils/RoleDefinitions.sol";
+
+contract PolicyAdminOnlyEmergencyRoleTest is PolicyAdminTest {
+    // given the caller does not have the emergency role
+    //  [X] it reverts
+    // given the caller has the emergency role
+    //  [X] it does not revert
+
+    function test_callerNotEmergencyRole_reverts() public {
+        // Expect revert
+        vm.expectRevert(abi.encodeWithSelector(ROLESv1.ROLES_RequireRole.selector, EMERGENCY_ROLE));
+
+        // Call function
+        policyAdmin.gatedToEmergencyRole();
+    }
+
+    function test_callerHasEmergencyRole() public {
+        // Call function
+        vm.prank(EMERGENCY);
+        policyAdmin.gatedToEmergencyRole();
+    }
+}

--- a/src/test/policies/utils/PolicyEnabler/PolicyEnablerTest.sol
+++ b/src/test/policies/utils/PolicyEnabler/PolicyEnablerTest.sol
@@ -64,7 +64,7 @@ contract PolicyEnablerTest is Test {
     }
 
     modifier givenEnabled() {
-        vm.prank(EMERGENCY);
+        vm.prank(ADMIN);
         policyEnabler.enable(enableData);
         _;
     }

--- a/src/test/policies/utils/PolicyEnabler/onlyDisabled.t.sol
+++ b/src/test/policies/utils/PolicyEnabler/onlyDisabled.t.sol
@@ -17,7 +17,7 @@ contract PolicyEnablerOnlyDisabledTest is PolicyEnablerTest {
         policyEnabler.requiresDisabled();
     }
 
-    function test_policyDisabled() public view {
+    function test_policyDisabled() public {
         // Call function
         assertEq(policyEnabler.requiresDisabled(), true, "Policy should be disabled");
     }


### PR DESCRIPTION
Cross-port of some PolicyEnabler improvements from #29 :

- Adds missing tests
- Gate `enable()` to the admin role only (not emergency), while `disable()` remains gated to admin OR emergency roles
