### PR TITLE
Cooler v2: ownable composites

### DIFF
--- a/src/periphery/CoolerComposites.sol
+++ b/src/periphery/CoolerComposites.sol
@@ -6,21 +6,30 @@ import {IERC20} from "../interfaces/IERC20.sol";
 import {IMonoCooler} from "../policies/interfaces/cooler/IMonoCooler.sol";
 import {ICoolerComposites} from "./interfaces/ICoolerComposites.sol";
 import {IDLGTEv1} from "src/modules/DLGTE/IDLGTE.v1.sol";
+import {IEnabler} from "./interfaces/IEnabler.sol";
 
 // Libraries
 import {ERC20} from "solmate/tokens/ERC20.sol";
 import {SafeTransferLib} from "solmate/utils/SafeTransferLib.sol";
+import {Owned} from "solmate/auth/Owned.sol";
 
 /// @title  Cooler Composites
 /// @notice The CoolerComposites contract enables users to combine multiple operations into a single call
-contract CoolerComposites is ICoolerComposites {
+contract CoolerComposites is ICoolerComposites, Owned, IEnabler {
     using SafeTransferLib for ERC20;
 
+    // ========= STATE ========= //
+
+    /// @notice Whether the contract is enabled
+    bool public isEnabled;
+
     IMonoCooler public immutable COOLER;
+
     ERC20 internal immutable _COLLATERAL_TOKEN;
+
     ERC20 internal immutable _DEBT_TOKEN;
 
-    constructor(IMonoCooler cooler_) {
+    constructor(IMonoCooler cooler_, address owner_) Owned(owner_) {
         COOLER = cooler_;
 
         _COLLATERAL_TOKEN = ERC20(address(cooler_.collateralToken()));
@@ -28,6 +37,8 @@ contract CoolerComposites is ICoolerComposites {
 
         _DEBT_TOKEN = ERC20(address(cooler_.debtToken()));
         _DEBT_TOKEN.approve(address(cooler_), type(uint256).max);
+
+        // Disabled by default
     }
 
     // ===== Composite Functions ===== //
@@ -39,7 +50,7 @@ contract CoolerComposites is ICoolerComposites {
         uint128 collateralAmount,
         uint128 borrowAmount,
         IDLGTEv1.DelegationRequest[] calldata delegationRequests
-    ) external {
+    ) external onlyEnabled {
         if (authorization.account != address(0)) {
             COOLER.setAuthorizationWithSig(authorization, signature);
         }
@@ -56,7 +67,7 @@ contract CoolerComposites is ICoolerComposites {
         uint128 repayAmount,
         uint128 collateralAmount,
         IDLGTEv1.DelegationRequest[] calldata delegationRequests
-    ) external {
+    ) external onlyEnabled {
         if (authorization.account != address(0)) {
             COOLER.setAuthorizationWithSig(authorization, signature);
         }
@@ -84,5 +95,33 @@ contract CoolerComposites is ICoolerComposites {
     /// @inheritdoc ICoolerComposites
     function debtToken() external view returns (IERC20) {
         return IERC20(address(_DEBT_TOKEN));
+    }
+
+    // ============ ENABLER FUNCTIONS ============ //
+
+    modifier onlyEnabled() {
+        if (!isEnabled) revert NotEnabled();
+        _;
+    }
+
+    /// @inheritdoc IEnabler
+    function enable(bytes calldata) external onlyOwner {
+        // Validate that the contract is disabled
+        if (isEnabled) revert NotDisabled();
+
+        // Enable the contract
+        isEnabled = true;
+
+        // Emit the enabled event
+        emit Enabled();
+    }
+
+    /// @inheritdoc IEnabler
+    function disable(bytes calldata) external onlyEnabled onlyOwner {
+        // Disable the contract
+        isEnabled = false;
+
+        // Emit the disabled event
+        emit Disabled();
     }
 }

--- a/src/periphery/CoolerComposites.sol
+++ b/src/periphery/CoolerComposites.sol
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
-import {IDLGTEv1} from "modules/DLGTE/IDLGTE.v1.sol";
-import {IMonoCooler} from "../interfaces/cooler/IMonoCooler.sol";
-import {ICoolerComposites} from "../interfaces/cooler/ICoolerComposites.sol";
-import {IERC20} from "../../interfaces/IERC20.sol";
+// Interfaces
+import {IERC20} from "../interfaces/IERC20.sol";
+import {IMonoCooler} from "../policies/interfaces/cooler/IMonoCooler.sol";
+import {ICoolerComposites} from "./interfaces/ICoolerComposites.sol";
+import {IDLGTEv1} from "src/modules/DLGTE/IDLGTE.v1.sol";
+
+// Libraries
 import {ERC20} from "solmate/tokens/ERC20.sol";
 import {SafeTransferLib} from "solmate/utils/SafeTransferLib.sol";
 

--- a/src/periphery/interfaces/ICoolerComposites.sol
+++ b/src/periphery/interfaces/ICoolerComposites.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
-import {IDLGTEv1} from "../../../modules/DLGTE/IDLGTE.v1.sol";
-import {IMonoCooler} from "./IMonoCooler.sol";
-import {IERC20} from "../../../interfaces/IERC20.sol";
+import {IDLGTEv1} from "../../modules/DLGTE/IDLGTE.v1.sol";
+import {IMonoCooler} from "../../policies/interfaces/cooler/IMonoCooler.sol";
+import {IERC20} from "../../interfaces/IERC20.sol";
 
 interface ICoolerComposites {
     event TokenRefunded(address indexed token, address indexed caller, uint256 amount);

--- a/src/test/periphery/CoolerComposites.t.sol
+++ b/src/test/periphery/CoolerComposites.t.sol
@@ -2,11 +2,15 @@
 // solhint-disable one-contract-per-file
 pragma solidity 0.8.15;
 
-import {CoolerComposites} from "src/policies/cooler/CoolerComposites.sol";
+// Interfaces
 import {IDLGTEv1} from "src/modules/DLGTE/IDLGTE.v1.sol";
 import {IMonoCooler} from "src/policies/interfaces/cooler/IMonoCooler.sol";
-import {MonoCoolerBaseTest} from "./MonoCoolerBase.t.sol";
+
+// Libraries
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+
+import {CoolerComposites} from "src/periphery/CoolerComposites.sol";
+import {MonoCoolerBaseTest} from "../policies/cooler/MonoCoolerBase.t.sol";
 
 abstract contract CoolerCompositesTest is MonoCoolerBaseTest {
     CoolerComposites internal composites;


### PR DESCRIPTION
Treat CoolerComposites like CoolerV2Migrator:
- Owned contract
- Located in periphery
- Implements the `IEnabler` interface and can be enabled/disabled