### PR TITLE
CCIP Bridge: Trusted Remote Fix

### DIFF
--- a/src/periphery/bridge/CCIPCrossChainBridge.sol
+++ b/src/periphery/bridge/CCIPCrossChainBridge.sol
@@ -344,9 +344,12 @@ contract CCIPCrossChainBridge is CCIPReceiver, PeripheryEnabler, Owned, ICCIPCro
 
         // Validate that the sender is a trusted remote
         // This will be the sending bridge contract, as it is set in the OnRamp.forwardFromRouter() function
+        // Be pessimistic and ensure the sender is set (otherwise the trusted remote check will not revert)
         address sourceBridge = abi.decode(message_.sender, (address));
-        if (sourceBridge != _trustedRemoteEVM[message_.sourceChainSelector])
-            revert Bridge_SourceNotTrusted();
+        if (
+            sourceBridge == address(0) ||
+            sourceBridge != _trustedRemoteEVM[message_.sourceChainSelector]
+        ) revert Bridge_SourceNotTrusted();
 
         // There should only be a single token and amount specified in the message
         if (message_.destTokenAmounts.length != 1) revert Bridge_InvalidPayloadTokensLength();

--- a/src/periphery/bridge/CCIPCrossChainBridge.sol
+++ b/src/periphery/bridge/CCIPCrossChainBridge.sol
@@ -447,7 +447,9 @@ contract CCIPCrossChainBridge is CCIPReceiver, PeripheryEnabler, Owned, ICCIPCro
 
     /// @inheritdoc ICCIPCrossChainBridge
     /// @dev        This function will revert if the trusted remote is not set
-    function getTrustedRemoteEVM(uint64 dstChainSelector_) external view returns (TrustedRemoteEVM memory) {
+    function getTrustedRemoteEVM(
+        uint64 dstChainSelector_
+    ) external view returns (TrustedRemoteEVM memory) {
         return _trustedRemoteEVM[dstChainSelector_];
     }
 
@@ -469,7 +471,9 @@ contract CCIPCrossChainBridge is CCIPReceiver, PeripheryEnabler, Owned, ICCIPCro
 
     /// @inheritdoc ICCIPCrossChainBridge
     /// @dev        This function will revert if the trusted remote is not set
-    function getTrustedRemoteSVM(uint64 dstChainSelector_) external view returns (TrustedRemoteSVM memory) {
+    function getTrustedRemoteSVM(
+        uint64 dstChainSelector_
+    ) external view returns (TrustedRemoteSVM memory) {
         return _trustedRemoteSVM[dstChainSelector_];
     }
 

--- a/src/periphery/bridge/CCIPCrossChainBridge.sol
+++ b/src/periphery/bridge/CCIPCrossChainBridge.sol
@@ -21,18 +21,6 @@ import {CCIPReceiver} from "@chainlink-ccip-1.6.0/ccip/applications/CCIPReceiver
 ///
 ///         The contract is designed to be an intermediary when receiving OHM, so that failed messages can be retried.
 contract CCIPCrossChainBridge is CCIPReceiver, PeripheryEnabler, Owned, ICCIPCrossChainBridge {
-    // ========= DATA STRUCTURES ========= //
-
-    struct TrustedRemoteSVM {
-        bytes32 remoteAddress;
-        bool isSet;
-    }
-
-    struct TrustedRemoteEVM {
-        address remoteAddress;
-        bool isSet;
-    }
-
     // ========= STATE VARIABLES ========= //
 
     IERC20 public immutable OHM;
@@ -459,11 +447,8 @@ contract CCIPCrossChainBridge is CCIPReceiver, PeripheryEnabler, Owned, ICCIPCro
 
     /// @inheritdoc ICCIPCrossChainBridge
     /// @dev        This function will revert if the trusted remote is not set
-    function getTrustedRemoteEVM(uint64 dstChainSelector_) external view returns (address) {
-        TrustedRemoteEVM memory trustedRemote = _trustedRemoteEVM[dstChainSelector_];
-        if (!trustedRemote.isSet) revert Bridge_TrustedRemoteNotSet();
-
-        return trustedRemote.remoteAddress;
+    function getTrustedRemoteEVM(uint64 dstChainSelector_) external view returns (TrustedRemoteEVM memory) {
+        return _trustedRemoteEVM[dstChainSelector_];
     }
 
     /// @inheritdoc ICCIPCrossChainBridge
@@ -484,11 +469,8 @@ contract CCIPCrossChainBridge is CCIPReceiver, PeripheryEnabler, Owned, ICCIPCro
 
     /// @inheritdoc ICCIPCrossChainBridge
     /// @dev        This function will revert if the trusted remote is not set
-    function getTrustedRemoteSVM(uint64 dstChainSelector_) external view returns (bytes32) {
-        TrustedRemoteSVM memory trustedRemote = _trustedRemoteSVM[dstChainSelector_];
-        if (!trustedRemote.isSet) revert Bridge_TrustedRemoteNotSet();
-
-        return trustedRemote.remoteAddress;
+    function getTrustedRemoteSVM(uint64 dstChainSelector_) external view returns (TrustedRemoteSVM memory) {
+        return _trustedRemoteSVM[dstChainSelector_];
     }
 
     // ========= CONFIGURATION ========= //

--- a/src/periphery/interfaces/ICCIPCrossChainBridge.sol
+++ b/src/periphery/interfaces/ICCIPCrossChainBridge.sol
@@ -28,6 +28,8 @@ interface ICCIPCrossChainBridge {
 
     error Bridge_InvalidPayloadToken();
 
+    error Bridge_TrustedRemoteNotSet();
+
     // ========= EVENTS ========= //
 
     event Bridged(
@@ -49,7 +51,11 @@ interface ICCIPCrossChainBridge {
 
     event TrustedRemoteEVMSet(uint64 indexed dstChainSelector, address indexed to);
 
+    event TrustedRemoteEVMUnset(uint64 indexed dstChainSelector);
+
     event TrustedRemoteSVMSet(uint64 indexed dstChainSelector, bytes32 indexed to);
+
+    event TrustedRemoteSVMUnset(uint64 indexed dstChainSelector);
 
     event MessageFailed(bytes32 messageId);
 
@@ -143,6 +149,12 @@ interface ICCIPCrossChainBridge {
     /// @param to_                  The destination address
     function setTrustedRemoteEVM(uint64 dstChainSelector_, address to_) external;
 
+    /// @notice Unsets the trusted remote for the specified destination EVM chain
+    /// @dev    This is needed to stop sending/receiving messages to/from the specified destination EVM chain
+    ///
+    /// @param dstChainSelector_    The destination chain selector
+    function unsetTrustedRemoteEVM(uint64 dstChainSelector_) external;
+
     /// @notice Gets the trusted remote for the specified destination EVM chain
     ///
     /// @param dstChainSelector_    The destination chain selector
@@ -155,6 +167,12 @@ interface ICCIPCrossChainBridge {
     /// @param dstChainSelector_    The destination chain selector
     /// @param to_                  The destination address
     function setTrustedRemoteSVM(uint64 dstChainSelector_, bytes32 to_) external;
+
+    /// @notice Unsets the trusted remote for the specified destination SVM chain
+    /// @dev    This is needed to stop sending/receiving messages to/from the specified destination SVM chain
+    ///
+    /// @param dstChainSelector_    The destination chain selector
+    function unsetTrustedRemoteSVM(uint64 dstChainSelector_) external;
 
     /// @notice Gets the trusted remote for the specified destination SVM chain
     ///

--- a/src/periphery/interfaces/ICCIPCrossChainBridge.sol
+++ b/src/periphery/interfaces/ICCIPCrossChainBridge.sol
@@ -61,6 +61,18 @@ interface ICCIPCrossChainBridge {
 
     event RetryMessageSuccess(bytes32 messageId);
 
+    // ========= DATA STRUCTURES ========= //
+
+    struct TrustedRemoteEVM {
+        address remoteAddress;
+        bool isSet;
+    }
+
+    struct TrustedRemoteSVM {
+        bytes32 remoteAddress;
+        bool isSet;
+    }
+
     // ========= SEND OHM ========= //
 
     /// @notice Gets the fee for sending OHM to the specified destination SVM chain
@@ -159,7 +171,9 @@ interface ICCIPCrossChainBridge {
     ///
     /// @param dstChainSelector_    The destination chain selector
     /// @return to_                The destination address
-    function getTrustedRemoteEVM(uint64 dstChainSelector_) external view returns (address);
+    function getTrustedRemoteEVM(
+        uint64 dstChainSelector_
+    ) external view returns (TrustedRemoteEVM memory);
 
     /// @notice Sets the trusted remote for the specified destination SVM chain
     /// @dev    This is needed to send/receive messages to/from the specified destination SVM chain
@@ -179,7 +193,9 @@ interface ICCIPCrossChainBridge {
     /// @param dstChainSelector_    The destination chain selector
     ///
     /// @return to_                The destination address
-    function getTrustedRemoteSVM(uint64 dstChainSelector_) external view returns (bytes32);
+    function getTrustedRemoteSVM(
+        uint64 dstChainSelector_
+    ) external view returns (TrustedRemoteSVM memory);
 
     // ========= CONFIGURATION ========= //
 

--- a/src/test/periphery/CCIPCrossChainBridge.t.sol
+++ b/src/test/periphery/CCIPCrossChainBridge.t.sol
@@ -170,6 +170,22 @@ contract CCIPCrossChainBridgeTest is Test {
         vm.expectRevert(ICCIPCrossChainBridge.Bridge_TrustedRemoteNotSet.selector);
     }
 
+    function _assertEVMRemoteNotSet() public {
+        ICCIPCrossChainBridge.TrustedRemoteEVM memory evmRemote = bridge.getTrustedRemoteEVM(
+            DESTINATION_CHAIN_SELECTOR
+        );
+        assertEq(evmRemote.remoteAddress, address(0), "trustedRemoteEVM");
+        assertEq(evmRemote.isSet, false, "evmIsSet");
+    }
+
+    function _assertSVMRemoteNotSet() public {
+        ICCIPCrossChainBridge.TrustedRemoteSVM memory svmRemote = bridge.getTrustedRemoteSVM(
+            DESTINATION_CHAIN_SELECTOR
+        );
+        assertEq(svmRemote.remoteAddress, bytes32(0), "svmAddress");
+        assertEq(svmRemote.isSet, false, "svmIsSet");
+    }
+
     // ============ TESTS ============ //
 
     // constructor
@@ -1334,15 +1350,13 @@ contract CCIPCrossChainBridgeTest is Test {
         _setTrustedRemoteEVM(DESTINATION_CHAIN_SELECTOR, address(0));
 
         // Assert state
-        assertEq(
-            bridge.getTrustedRemoteEVM(DESTINATION_CHAIN_SELECTOR),
-            address(0),
-            "trustedRemoteEVM"
+        ICCIPCrossChainBridge.TrustedRemoteEVM memory evmRemote = bridge.getTrustedRemoteEVM(
+            DESTINATION_CHAIN_SELECTOR
         );
+        assertEq(evmRemote.remoteAddress, address(0), "trustedRemoteEVM");
+        assertEq(evmRemote.isSet, true, "evmIsSet");
 
-        // Expect revert
-        _expectRevertTrustedRemoteNotSet();
-        bridge.getTrustedRemoteSVM(DESTINATION_CHAIN_SELECTOR);
+        _assertSVMRemoteNotSet();
     }
 
     function test_setTrustedRemoteEVM(address trustedRemote_) public {
@@ -1354,15 +1368,13 @@ contract CCIPCrossChainBridgeTest is Test {
         _setTrustedRemoteEVM(DESTINATION_CHAIN_SELECTOR, trustedRemote_);
 
         // Assert state
-        assertEq(
-            bridge.getTrustedRemoteEVM(DESTINATION_CHAIN_SELECTOR),
-            trustedRemote_,
-            "trustedRemoteEVM"
+        ICCIPCrossChainBridge.TrustedRemoteEVM memory evmRemote = bridge.getTrustedRemoteEVM(
+            DESTINATION_CHAIN_SELECTOR
         );
+        assertEq(evmRemote.remoteAddress, trustedRemote_, "trustedRemoteEVM");
+        assertEq(evmRemote.isSet, true, "evmIsSet");
 
-        // Expect revert
-        _expectRevertTrustedRemoteNotSet();
-        bridge.getTrustedRemoteSVM(DESTINATION_CHAIN_SELECTOR);
+        _assertSVMRemoteNotSet();
     }
 
     // unsetTrustedRemoteEVM
@@ -1410,8 +1422,9 @@ contract CCIPCrossChainBridgeTest is Test {
         bridge.unsetTrustedRemoteEVM(DESTINATION_CHAIN_SELECTOR);
 
         // Assert state
-        _expectRevertTrustedRemoteNotSet();
-        bridge.getTrustedRemoteEVM(DESTINATION_CHAIN_SELECTOR);
+        _assertEVMRemoteNotSet();
+
+        _assertSVMRemoteNotSet();
     }
 
     function test_unsetTrustedRemoteEVM() public givenDestinationEVMChainHasTrustedRemote {
@@ -1424,37 +1437,32 @@ contract CCIPCrossChainBridgeTest is Test {
         bridge.unsetTrustedRemoteEVM(DESTINATION_CHAIN_SELECTOR);
 
         // Assert state
-        _expectRevertTrustedRemoteNotSet();
-        bridge.getTrustedRemoteEVM(DESTINATION_CHAIN_SELECTOR);
+        _assertEVMRemoteNotSet();
+
+        _assertSVMRemoteNotSet();
     }
 
     // getTrustedRemoteEVM
     // when the destination chain selector is not set
-    //  [X] it reverts
+    //  [X] it returns the zero address and false
     // when the destination chain selector has been unset
-    //  [X] it reverts
+    //  [X] it returns the zero address and false
     // when the trusted remote is set to the zero address
     //  [X] it returns the zero address for the destination chain
     // [X] it returns the trusted remote for the destination chain
 
-    function test_getTrustedRemoteEVM_destinationChainNotSet_reverts() public {
-        // Expect revert
-        _expectRevertTrustedRemoteNotSet();
-
+    function test_getTrustedRemoteEVM_destinationChainNotSet() public {
         // Call function
-        bridge.getTrustedRemoteEVM(DESTINATION_CHAIN_SELECTOR);
+        _assertEVMRemoteNotSet();
     }
 
-    function test_getTrustedRemoteEVM_destinationChainUnset_reverts()
+    function test_getTrustedRemoteEVM_destinationChainUnset()
         public
         givenSourceEVMChainHasTrustedRemote
         givenSourceEVMChainHasTrustedRemoteUnset
     {
-        // Expect revert
-        _expectRevertTrustedRemoteNotSet();
-
         // Call function
-        bridge.getTrustedRemoteEVM(DESTINATION_CHAIN_SELECTOR);
+        _assertEVMRemoteNotSet();
     }
 
     function test_getTrustedRemoteEVM_zeroAddress() public {
@@ -1462,20 +1470,20 @@ contract CCIPCrossChainBridgeTest is Test {
         _setTrustedRemoteEVM(DESTINATION_CHAIN_SELECTOR, address(0));
 
         // Call function
-        assertEq(
-            bridge.getTrustedRemoteEVM(DESTINATION_CHAIN_SELECTOR),
-            address(0),
-            "trustedRemoteEVM"
+        ICCIPCrossChainBridge.TrustedRemoteEVM memory evmRemote = bridge.getTrustedRemoteEVM(
+            DESTINATION_CHAIN_SELECTOR
         );
+        assertEq(evmRemote.remoteAddress, address(0), "trustedRemoteEVM");
+        assertEq(evmRemote.isSet, true, "evmIsSet");
     }
 
     function test_getTrustedRemoteEVM() public givenDestinationEVMChainHasTrustedRemote {
         // Call function
-        assertEq(
-            bridge.getTrustedRemoteEVM(DESTINATION_CHAIN_SELECTOR),
-            EVM_TRUSTED_REMOTE,
-            "trustedRemoteEVM"
+        ICCIPCrossChainBridge.TrustedRemoteEVM memory evmRemote = bridge.getTrustedRemoteEVM(
+            DESTINATION_CHAIN_SELECTOR
         );
+        assertEq(evmRemote.remoteAddress, EVM_TRUSTED_REMOTE, "trustedRemoteEVM");
+        assertEq(evmRemote.isSet, true, "evmIsSet");
     }
 
     // setTrustedRemoteSVM
@@ -1505,15 +1513,13 @@ contract CCIPCrossChainBridgeTest is Test {
         _setTrustedRemoteSVM(DESTINATION_CHAIN_SELECTOR, bytes32(0));
 
         // Assert state
-        assertEq(
-            bridge.getTrustedRemoteSVM(DESTINATION_CHAIN_SELECTOR),
-            bytes32(0),
-            "trustedRemoteSVM"
-        );
+        _assertEVMRemoteNotSet();
 
-        // Expect revert
-        _expectRevertTrustedRemoteNotSet();
-        bridge.getTrustedRemoteEVM(DESTINATION_CHAIN_SELECTOR);
+        ICCIPCrossChainBridge.TrustedRemoteSVM memory svmRemote = bridge.getTrustedRemoteSVM(
+            DESTINATION_CHAIN_SELECTOR
+        );
+        assertEq(svmRemote.remoteAddress, bytes32(0), "svmAddress");
+        assertEq(svmRemote.isSet, true, "svmIsSet");
     }
 
     function test_setTrustedRemoteSVM(bytes32 trustedRemote_) public {
@@ -1525,15 +1531,13 @@ contract CCIPCrossChainBridgeTest is Test {
         _setTrustedRemoteSVM(DESTINATION_CHAIN_SELECTOR, trustedRemote_);
 
         // Assert state
-        assertEq(
-            bridge.getTrustedRemoteSVM(DESTINATION_CHAIN_SELECTOR),
-            trustedRemote_,
-            "trustedRemoteSVM"
-        );
+        _assertEVMRemoteNotSet();
 
-        // Expect revert
-        _expectRevertTrustedRemoteNotSet();
-        bridge.getTrustedRemoteEVM(DESTINATION_CHAIN_SELECTOR);
+        ICCIPCrossChainBridge.TrustedRemoteSVM memory svmRemote = bridge.getTrustedRemoteSVM(
+            DESTINATION_CHAIN_SELECTOR
+        );
+        assertEq(svmRemote.remoteAddress, trustedRemote_, "svmAddress");
+        assertEq(svmRemote.isSet, true, "svmIsSet");
     }
 
     // unsetTrustedRemoteSVM
@@ -1581,8 +1585,9 @@ contract CCIPCrossChainBridgeTest is Test {
         bridge.unsetTrustedRemoteSVM(DESTINATION_CHAIN_SELECTOR);
 
         // Assert state
-        _expectRevertTrustedRemoteNotSet();
-        bridge.getTrustedRemoteSVM(DESTINATION_CHAIN_SELECTOR);
+        _assertEVMRemoteNotSet();
+
+        _assertSVMRemoteNotSet();
     }
 
     function test_unsetTrustedRemoteSVM() public givenDestinationSVMChainHasTrustedRemote {
@@ -1595,8 +1600,9 @@ contract CCIPCrossChainBridgeTest is Test {
         bridge.unsetTrustedRemoteSVM(DESTINATION_CHAIN_SELECTOR);
 
         // Assert state
-        _expectRevertTrustedRemoteNotSet();
-        bridge.getTrustedRemoteSVM(DESTINATION_CHAIN_SELECTOR);
+        _assertEVMRemoteNotSet();
+
+        _assertSVMRemoteNotSet();
     }
 
     // getTrustedRemoteSVM
@@ -1608,24 +1614,22 @@ contract CCIPCrossChainBridgeTest is Test {
     //  [X] it returns the zero address for the destination chain
     // [X] it returns the trusted remote for the destination chain
 
-    function test_getTrustedRemoteSVM_destinationChainNotSet_reverts() public {
-        // Expect revert
-        _expectRevertTrustedRemoteNotSet();
+    function test_getTrustedRemoteSVM_destinationChainNotSet() public {
+        // Assert state
+        _assertEVMRemoteNotSet();
 
-        // Call function
-        bridge.getTrustedRemoteSVM(DESTINATION_CHAIN_SELECTOR);
+        _assertSVMRemoteNotSet();
     }
 
-    function test_getTrustedRemoteSVM_destinationChainUnset_reverts()
+    function test_getTrustedRemoteSVM_destinationChainUnset()
         public
         givenDestinationSVMChainHasTrustedRemote
         givenDestinationSVMChainHasTrustedRemoteUnset
     {
-        // Expect revert
-        _expectRevertTrustedRemoteNotSet();
+        // Assert state
+        _assertEVMRemoteNotSet();
 
-        // Call function
-        bridge.getTrustedRemoteSVM(DESTINATION_CHAIN_SELECTOR);
+        _assertSVMRemoteNotSet();
     }
 
     function test_getTrustedRemoteSVM_zeroAddress() public {
@@ -1633,19 +1637,19 @@ contract CCIPCrossChainBridgeTest is Test {
         _setTrustedRemoteSVM(DESTINATION_CHAIN_SELECTOR, bytes32(0));
 
         // Call function
-        assertEq(
-            bridge.getTrustedRemoteSVM(DESTINATION_CHAIN_SELECTOR),
-            bytes32(0),
-            "trustedRemoteSVM"
+        ICCIPCrossChainBridge.TrustedRemoteSVM memory svmRemote = bridge.getTrustedRemoteSVM(
+            DESTINATION_CHAIN_SELECTOR
         );
+        assertEq(svmRemote.remoteAddress, bytes32(0), "svmAddress");
+        assertEq(svmRemote.isSet, true, "svmIsSet");
     }
 
     function test_getTrustedRemoteSVM() public givenDestinationSVMChainHasTrustedRemote {
         // Call function
-        assertEq(
-            bridge.getTrustedRemoteSVM(DESTINATION_CHAIN_SELECTOR),
-            SVM_TRUSTED_REMOTE,
-            "trustedRemoteSVM"
+        ICCIPCrossChainBridge.TrustedRemoteSVM memory svmRemote = bridge.getTrustedRemoteSVM(
+            DESTINATION_CHAIN_SELECTOR
         );
+        assertEq(svmRemote.remoteAddress, SVM_TRUSTED_REMOTE, "svmAddress");
+        assertEq(svmRemote.isSet, true, "svmIsSet");
     }
 }

--- a/src/test/periphery/CCIPCrossChainBridge.t.sol
+++ b/src/test/periphery/CCIPCrossChainBridge.t.sol
@@ -733,7 +733,9 @@ contract CCIPCrossChainBridgeTest is Test {
     //  [X] it reverts
     // given the contract is not enabled
     //  [X] it reverts
-    // given the source bridge is not trusted
+    // given the source bridge/sender is not trusted
+    //  [X] it reverts
+    // given the source bridge/sender is the zero address
     //  [X] it reverts
     // when the message has multiple tokens
     //  [X] it reverts
@@ -786,8 +788,39 @@ contract CCIPCrossChainBridgeTest is Test {
         bridge.receiveMessage(message);
     }
 
-    function test_receiveMessage_sourceBridgeNotTrusted_reverts() public givenContractIsEnabled {
+    function test_receiveMessage_senderNotTrusted_reverts() public givenContractIsEnabled {
         Client.Any2EVMMessage memory message = _getAnyToEVMMessage();
+
+        // Expect revert
+        vm.expectRevert(ICCIPCrossChainBridge.Bridge_SourceNotTrusted.selector);
+
+        // Call function
+        vm.prank(address(bridge));
+        bridge.receiveMessage(message);
+    }
+
+    function test_receiveMessage_senderZeroAddress_trustedRemoteNotSet_reverts()
+        public
+        givenContractIsEnabled
+    {
+        Client.Any2EVMMessage memory message = _getAnyToEVMMessage();
+        message.sender = abi.encode(address(0));
+
+        // Expect revert
+        vm.expectRevert(ICCIPCrossChainBridge.Bridge_SourceNotTrusted.selector);
+
+        // Call function
+        vm.prank(address(bridge));
+        bridge.receiveMessage(message);
+    }
+
+    function test_receiveMessage_senderZeroAddress_reverts()
+        public
+        givenContractIsEnabled
+        givenSourceEVMChainHasTrustedRemote
+    {
+        Client.Any2EVMMessage memory message = _getAnyToEVMMessage();
+        message.sender = abi.encode(address(0));
 
         // Expect revert
         vm.expectRevert(ICCIPCrossChainBridge.Bridge_SourceNotTrusted.selector);


### PR DESCRIPTION
- Implement distinct set/unset trusted remote functions
- Check whether a trusted remote is set (via `isSet`), instead of using the zero address
- Resolves https://github.com/electisec/olympus-ccip-report/issues/2
- Resolves https://github.com/electisec/olympus-ccip-report/issues/1