### PR TITLE
CCIP Bridge: supportsInterface

### DIFF
--- a/src/periphery/PeripheryEnabler.sol
+++ b/src/periphery/PeripheryEnabler.sol
@@ -88,4 +88,10 @@ abstract contract PeripheryEnabler is IEnabler {
         // Emit the disabled event
         emit Disabled();
     }
+
+    // ========= ERC165 ========= //
+
+    function supportsInterface(bytes4 interfaceId) public view virtual returns (bool) {
+        return interfaceId == type(IEnabler).interfaceId;
+    }
 }

--- a/src/periphery/bridge/CCIPCrossChainBridge.sol
+++ b/src/periphery/bridge/CCIPCrossChainBridge.sol
@@ -460,10 +460,13 @@ contract CCIPCrossChainBridge is CCIPReceiver, PeripheryEnabler, Owned, ICCIPCro
         return i_ccipRouter;
     }
 
-    function supportsInterface(bytes4 interfaceId_) public view virtual override returns (bool) {
+    function supportsInterface(
+        bytes4 interfaceId_
+    ) public view virtual override(CCIPReceiver, PeripheryEnabler) returns (bool) {
         return
             interfaceId_ == type(ICCIPCrossChainBridge).interfaceId ||
-            super.supportsInterface(interfaceId_);
+            CCIPReceiver.supportsInterface(interfaceId_) ||
+            PeripheryEnabler.supportsInterface(interfaceId_);
     }
 
     // ========= ENABLER FUNCTIONS ========= //

--- a/src/test/periphery/CCIPCrossChainBridge.t.sol
+++ b/src/test/periphery/CCIPCrossChainBridge.t.sol
@@ -1110,6 +1110,10 @@ contract CCIPCrossChainBridgeTest is Test {
     //  [X] it returns true
     // when the interface id is the ICCIPCrossChainBridge interface id
     //  [X] it returns true
+    // when the interface id is the IEnabler interface id
+    //  [X] it returns true
+    // when the interface id is the IERC165 interface id
+    //  [X] it returns true
     // [X] it returns false
 
     function test_supportsInterface() public view {
@@ -1123,6 +1127,7 @@ contract CCIPCrossChainBridgeTest is Test {
             true,
             "ICCIPCrossChainBridge"
         );
+        assertEq(bridge.supportsInterface(type(IEnabler).interfaceId), true, "IEnabler");
         assertEq(bridge.supportsInterface(type(IERC165).interfaceId), true, "IERC165");
         assertEq(bridge.supportsInterface(type(IERC20).interfaceId), false, "IERC20");
     }


### PR DESCRIPTION
- Improves `supportsInterface` to add support for `IEnabler`
- Resolves https://github.com/electisec/olympus-ccip-report/issues/3