### PR TITLE
CCIP Bridge: add per-chain override for the gas limit

### DIFF
--- a/src/periphery/bridge/CCIPCrossChainBridge.sol
+++ b/src/periphery/bridge/CCIPCrossChainBridge.sol
@@ -53,12 +53,9 @@ contract CCIPCrossChainBridge is CCIPReceiver, PeripheryEnabler, Owned, ICCIPCro
     /// @dev    When a message fails to receive, it is stored here to allow for retries.
     mapping(bytes32 => Client.Any2EVMMessage) internal _failedMessages;
 
-    // ========= CONSTANTS ========= //
-
-    uint32 internal constant _SVM_DEFAULT_COMPUTE_UNITS = 0;
-
-    /// @dev This is non-zero to allow for message handling by the bridge contract on the destination chain
-    uint32 internal constant _DEFAULT_GAS_LIMIT = 200_000;
+    /// @notice Mapping of destination chain selectors to gas limits
+    /// @dev    When sending, this is used to determine the gas limit for the message.
+    mapping(uint64 => uint32) internal _gasLimits;
 
     // ========= CONSTRUCTOR ========= //
 
@@ -100,11 +97,14 @@ contract CCIPCrossChainBridge is CCIPReceiver, PeripheryEnabler, Owned, ICCIPCro
             });
     }
 
-    function _getSVMExtraArgs(bytes32 to_) internal pure returns (bytes memory) {
+    function _getSVMExtraArgs(
+        uint64 dstChainSelector_,
+        bytes32 to_
+    ) internal view returns (bytes memory) {
         return
             Client._svmArgsToBytes(
                 Client.SVMExtraArgsV1({
-                    computeUnits: _SVM_DEFAULT_COMPUTE_UNITS,
+                    computeUnits: _gasLimits[dstChainSelector_],
                     accountIsWritableBitmap: 0,
                     allowOutOfOrderExecution: true,
                     tokenReceiver: to_,
@@ -113,11 +113,11 @@ contract CCIPCrossChainBridge is CCIPReceiver, PeripheryEnabler, Owned, ICCIPCro
             );
     }
 
-    function _getEVMExtraArgs() internal pure returns (bytes memory) {
+    function _getEVMExtraArgs(uint64 dstChainSelector_) internal view returns (bytes memory) {
         return
             Client._argsToBytes(
                 Client.GenericExtraArgsV2({
-                    gasLimit: _DEFAULT_GAS_LIMIT,
+                    gasLimit: _gasLimits[dstChainSelector_],
                     allowOutOfOrderExecution: true
                 })
             );
@@ -139,7 +139,7 @@ contract CCIPCrossChainBridge is CCIPReceiver, PeripheryEnabler, Owned, ICCIPCro
         // Data contains the actual recipient address
         data = abi.encode(to_);
         // Extra args
-        extraArgs = _getEVMExtraArgs();
+        extraArgs = _getEVMExtraArgs(dstChainSelector_);
 
         return (recipient, data, extraArgs);
     }
@@ -159,7 +159,7 @@ contract CCIPCrossChainBridge is CCIPReceiver, PeripheryEnabler, Owned, ICCIPCro
         // Data is empty
         data = "";
         // Extra args
-        extraArgs = _getSVMExtraArgs(to_);
+        extraArgs = _getSVMExtraArgs(dstChainSelector_, to_);
         return (recipient, data, extraArgs);
     }
 
@@ -256,6 +256,7 @@ contract CCIPCrossChainBridge is CCIPReceiver, PeripheryEnabler, Owned, ICCIPCro
     }
 
     /// @inheritdoc ICCIPCrossChainBridge
+    /// @dev        Unless specified for the chain through `setGasLimit()`, the gas limit will be 0
     function sendToSVM(
         uint64 dstChainSelector_,
         bytes32 to_,
@@ -273,6 +274,7 @@ contract CCIPCrossChainBridge is CCIPReceiver, PeripheryEnabler, Owned, ICCIPCro
     }
 
     /// @inheritdoc ICCIPCrossChainBridge
+    /// @dev        Unless specified for the chain through `setGasLimit()`, the gas limit will be 0
     function sendToEVM(
         uint64 dstChainSelector_,
         address to_,
@@ -489,6 +491,19 @@ contract CCIPCrossChainBridge is CCIPReceiver, PeripheryEnabler, Owned, ICCIPCro
         if (!trustedRemote.isSet) revert Bridge_TrustedRemoteNotSet();
 
         return trustedRemote.remoteAddress;
+    }
+
+    // ========= GAS LIMITS ========= //
+
+    /// @inheritdoc ICCIPCrossChainBridge
+    function setGasLimit(uint64 dstChainSelector_, uint32 gasLimit_) external onlyOwner {
+        _gasLimits[dstChainSelector_] = gasLimit_;
+        emit GasLimitSet(dstChainSelector_, gasLimit_);
+    }
+
+    /// @inheritdoc ICCIPCrossChainBridge
+    function getGasLimit(uint64 dstChainSelector_) external view returns (uint32) {
+        return _gasLimits[dstChainSelector_];
     }
 
     // ========= CONFIGURATION ========= //

--- a/src/periphery/interfaces/ICCIPCrossChainBridge.sol
+++ b/src/periphery/interfaces/ICCIPCrossChainBridge.sol
@@ -57,6 +57,8 @@ interface ICCIPCrossChainBridge {
 
     event TrustedRemoteSVMUnset(uint64 indexed dstChainSelector);
 
+    event GasLimitSet(uint64 indexed dstChainSelector, uint32 gasLimit);
+
     event MessageFailed(bytes32 messageId);
 
     event RetryMessageSuccess(bytes32 messageId);
@@ -180,6 +182,21 @@ interface ICCIPCrossChainBridge {
     ///
     /// @return to_                The destination address
     function getTrustedRemoteSVM(uint64 dstChainSelector_) external view returns (bytes32);
+
+    // ========= GAS LIMITS ========= //
+
+    /// @notice Sets the gas limit for the specified destination chain
+    ///
+    /// @param dstChainSelector_    The destination chain selector
+    /// @param gasLimit_            The gas limit
+    function setGasLimit(uint64 dstChainSelector_, uint32 gasLimit_) external;
+
+    /// @notice Gets the gas limit for the specified destination chain
+    ///
+    /// @param dstChainSelector_    The destination chain selector
+    ///
+    /// @return gasLimit_           The gas limit, or 0 if not set
+    function getGasLimit(uint64 dstChainSelector_) external view returns (uint32);
 
     // ========= CONFIGURATION ========= //
 

--- a/src/test/periphery/CCIPCrossChainBridge.t.sol
+++ b/src/test/periphery/CCIPCrossChainBridge.t.sol
@@ -48,6 +48,8 @@ contract CCIPCrossChainBridgeTest is Test {
 
     event TrustedRemoteSVMUnset(uint64 indexed dstChainSelector);
 
+    event GasLimitSet(uint64 indexed dstChainSelector, uint32 gasLimit);
+
     event MessageFailed(bytes32 messageId);
 
     event RetryMessageSuccess(bytes32 messageId);
@@ -314,6 +316,8 @@ contract CCIPCrossChainBridgeTest is Test {
     //  [X] it reverts
     // given the destination SVM chain's trusted remote is set to the zero address
     //  [X] the recipient address is the zero address
+    // given the destination chain has a gas limit set
+    //  [X] it uses the gas limit
     // [X] the recipient address is the trusted remote
     // [X] the SVM extra args compute units are the default compute units
     // [X] the SVM extra args writeable bitmap is 0
@@ -471,6 +475,63 @@ contract CCIPCrossChainBridgeTest is Test {
         assertEq(address(router).balance, FEE, "router ETH balance");
     }
 
+    function test_sendToSVM_gasLimitSet()
+        public
+        givenContractIsEnabled
+        givenDestinationSVMChainHasTrustedRemote
+        givenSenderHasApprovedSpendingOHM(AMOUNT)
+    {
+        // Set the gas limit
+        vm.prank(OWNER);
+        bridge.setGasLimit(DESTINATION_CHAIN_SELECTOR, 200_000);
+
+        // Expect event
+        vm.expectEmit();
+        emit Bridged(router.DEFAULT_MESSAGE_ID(), DESTINATION_CHAIN_SELECTOR, SENDER, AMOUNT, FEE);
+
+        // Call function
+        vm.prank(SENDER);
+        bridge.sendToSVM{value: FEE}(DESTINATION_CHAIN_SELECTOR, SVM_RECIPIENT, AMOUNT);
+
+        // Assert message parameters
+        assertEq(
+            router.destinationChainSelector(),
+            DESTINATION_CHAIN_SELECTOR,
+            "destinationChainSelector"
+        );
+        assertEq(router.messageReceiver(), abi.encodePacked(SVM_TRUSTED_REMOTE), "messageReceiver");
+        assertEq(router.messageData().length, 0, "messageData");
+        assertEq(router.messageFeeToken(), address(0), "messageFeeToken");
+        address[] memory tokens = router.getMessageTokens();
+        assertEq(tokens.length, 1, "tokens.length");
+        assertEq(tokens[0], address(OHM), "tokens[0]");
+        uint256[] memory amounts = router.getMessageTokenAmounts();
+        assertEq(amounts.length, 1, "amounts.length");
+        assertEq(amounts[0], AMOUNT, "amounts[0]");
+        bytes memory extraArgs = router.messageExtraArgs();
+        assertEq(
+            extraArgs,
+            Client._svmArgsToBytes(
+                Client.SVMExtraArgsV1({
+                    computeUnits: 200_000,
+                    accountIsWritableBitmap: 0,
+                    allowOutOfOrderExecution: true,
+                    tokenReceiver: SVM_RECIPIENT,
+                    accounts: new bytes32[](0)
+                })
+            ),
+            "extraArgs"
+        );
+
+        // Assert token balances
+        assertEq(OHM.balanceOf(SENDER), 0, "SENDER OHM balance");
+        assertEq(OHM.balanceOf(address(bridge)), 0, "bridge OHM balance");
+        assertEq(OHM.balanceOf(address(router)), AMOUNT, "router OHM balance");
+        assertEq(SENDER.balance, ETH_AMOUNT - FEE, "SENDER ETH balance");
+        assertEq(address(bridge).balance, 0, "bridge ETH balance");
+        assertEq(address(router).balance, FEE, "router ETH balance");
+    }
+
     function test_sendToSVM()
         public
         givenContractIsEnabled
@@ -539,6 +600,8 @@ contract CCIPCrossChainBridgeTest is Test {
     //  [X] it reverts
     // given the destination chain's trusted remote is set to the zero address
     //  [X] the recipient address is the zero address
+    // given the destination chain has a gas limit set
+    //  [X] it uses the gas limit
     // [X] the recipient address is the destination chain's CrossChainBridge address
     // [X] the data contains the actual recipient address
     // [X] the EVM extra args gas limit is the default gas limit
@@ -675,6 +738,58 @@ contract CCIPCrossChainBridgeTest is Test {
         assertEq(
             extraArgs,
             Client._argsToBytes(
+                Client.GenericExtraArgsV2({gasLimit: 0, allowOutOfOrderExecution: true})
+            ),
+            "extraArgs"
+        );
+
+        // Assert token balances
+        assertEq(OHM.balanceOf(SENDER), 0, "SENDER OHM balance");
+        assertEq(OHM.balanceOf(address(bridge)), 0, "bridge OHM balance");
+        assertEq(OHM.balanceOf(address(router)), AMOUNT, "router OHM balance");
+        assertEq(SENDER.balance, ETH_AMOUNT - FEE, "SENDER ETH balance");
+        assertEq(address(bridge).balance, 0, "bridge ETH balance");
+        assertEq(address(router).balance, FEE, "router ETH balance");
+    }
+
+    function test_sendToEVM_gasLimitSet()
+        public
+        givenContractIsEnabled
+        givenDestinationEVMChainHasTrustedRemote
+        givenSenderHasApprovedSpendingOHM(AMOUNT)
+    {
+        // Set the gas limit
+        vm.prank(OWNER);
+        bridge.setGasLimit(DESTINATION_CHAIN_SELECTOR, 200_000);
+
+        // Expect event
+        vm.expectEmit();
+        emit Bridged(router.DEFAULT_MESSAGE_ID(), DESTINATION_CHAIN_SELECTOR, SENDER, AMOUNT, FEE);
+
+        // Call function
+        vm.prank(SENDER);
+        bridge.sendToEVM{value: FEE}(DESTINATION_CHAIN_SELECTOR, EVM_RECIPIENT, AMOUNT);
+
+        // Assert message parameters
+        assertEq(
+            router.destinationChainSelector(),
+            DESTINATION_CHAIN_SELECTOR,
+            "destinationChainSelector"
+        );
+        assertEq(router.messageReceiver(), abi.encode(EVM_TRUSTED_REMOTE), "messageReceiver");
+        bytes memory messageData = router.messageData();
+        assertEq(abi.decode(messageData, (address)), EVM_RECIPIENT, "messageData");
+        assertEq(router.messageFeeToken(), address(0), "messageFeeToken");
+        address[] memory tokens = router.getMessageTokens();
+        assertEq(tokens.length, 1, "tokens.length");
+        assertEq(tokens[0], address(OHM), "tokens[0]");
+        uint256[] memory amounts = router.getMessageTokenAmounts();
+        assertEq(amounts.length, 1, "amounts.length");
+        assertEq(amounts[0], AMOUNT, "amounts[0]");
+        bytes memory extraArgs = router.messageExtraArgs();
+        assertEq(
+            extraArgs,
+            Client._argsToBytes(
                 Client.GenericExtraArgsV2({gasLimit: 200_000, allowOutOfOrderExecution: true})
             ),
             "extraArgs"
@@ -723,7 +838,7 @@ contract CCIPCrossChainBridgeTest is Test {
         assertEq(
             extraArgs,
             Client._argsToBytes(
-                Client.GenericExtraArgsV2({gasLimit: 200_000, allowOutOfOrderExecution: true})
+                Client.GenericExtraArgsV2({gasLimit: 0, allowOutOfOrderExecution: true})
             ),
             "extraArgs"
         );
@@ -1647,5 +1762,51 @@ contract CCIPCrossChainBridgeTest is Test {
             SVM_TRUSTED_REMOTE,
             "trustedRemoteSVM"
         );
+    }
+
+    // setGasLimit
+    // when the caller is not the owner
+    //  [X] it reverts
+    // [X] it sets the gas limit for the destination chain
+    // [X] it emits an event
+
+    function test_setGasLimit_callerNotOwner_reverts() public {
+        // Expect revert
+        vm.expectRevert("UNAUTHORIZED");
+
+        // Call function
+        vm.prank(SENDER);
+        bridge.setGasLimit(DESTINATION_CHAIN_SELECTOR, 200_000);
+    }
+
+    function test_setGasLimit(uint32 gasLimit_) public {
+        // Expect event
+        vm.expectEmit();
+        emit GasLimitSet(DESTINATION_CHAIN_SELECTOR, gasLimit_);
+
+        // Call function
+        vm.prank(OWNER);
+        bridge.setGasLimit(DESTINATION_CHAIN_SELECTOR, gasLimit_);
+
+        // Assert state
+        assertEq(bridge.getGasLimit(DESTINATION_CHAIN_SELECTOR), gasLimit_, "gasLimit");
+    }
+
+    // getGasLimit
+    // when the destination chain does not have a gas limit set
+    //  [X] it returns 0
+    // [X] it returns the gas limit
+
+    function test_getGasLimit_destinationChainNotSet_reverts() public view {
+        assertEq(bridge.getGasLimit(DESTINATION_CHAIN_SELECTOR), 0, "gasLimit");
+    }
+
+    function test_getGasLimit() public {
+        // Set the gas limit
+        vm.prank(OWNER);
+        bridge.setGasLimit(DESTINATION_CHAIN_SELECTOR, 200_000);
+
+        // Call function
+        assertEq(bridge.getGasLimit(DESTINATION_CHAIN_SELECTOR), 200_000, "gasLimit");
     }
 }

--- a/src/test/policies/bridge/CCIPBurnMintTokenPoolFork.t.sol
+++ b/src/test/policies/bridge/CCIPBurnMintTokenPoolFork.t.sol
@@ -209,6 +209,9 @@ contract CCIPBurnMintTokenPoolForkTest is Test {
             );
 
             _setTrustedRemote(mainnetBridge, polygonChainSelector, address(polygonBridge));
+
+            // Gas limit needed for bridging with data
+            _setGasLimit(mainnetBridge, polygonChainSelector, 200_000);
         }
 
         // Configure the polygon token pool
@@ -223,6 +226,9 @@ contract CCIPBurnMintTokenPoolForkTest is Test {
             );
 
             _setTrustedRemote(polygonBridge, mainnetChainSelector, address(mainnetBridge));
+
+            // Gas limit needed for bridging with data
+            _setGasLimit(polygonBridge, mainnetChainSelector, 200_000);
         }
 
         // Set the active chain to mainnet
@@ -288,6 +294,15 @@ contract CCIPBurnMintTokenPoolForkTest is Test {
     ) internal {
         vm.prank(ADMIN);
         bridge_.setTrustedRemoteEVM(chainSelector_, remote_);
+    }
+
+    function _setGasLimit(
+        CCIPCrossChainBridge bridge_,
+        uint64 chainSelector_,
+        uint32 gasLimit_
+    ) internal {
+        vm.prank(ADMIN);
+        bridge_.setGasLimit(chainSelector_, gasLimit_);
     }
 
     // ========= TESTS ========= //


### PR DESCRIPTION
There were certain assumptions about the gas limit, which could change in the future. This enables the default gas limit (0) to be overridden on a per-chain basis.