### PR TITLE
Convertible Deposits: Periodic Tasks

### DIFF
--- a/ROLES.md
+++ b/ROLES.md
@@ -12,6 +12,7 @@ This document describes the roles that are used in the Olympus protocol.
 | admin | CoolerTreasuryBorrower | Allows setting parameters on the CoolerTreasuryBorrower |
 | admin | EmissionManager | Adjust yield, activate the policy |
 | admin | EmissionManager | Set configuration parameters, activate the policy |
+| admin | Heart| Reset the heartbeat, enable the contract, disable the contract, set the distributor, set auction rewards |
 | admin | MonoCooler | Allows setting parameters on the MonoCooler |
 | bondmanager_admin | BondManager | Create/close bond markets, set parameters |
 | bridge_admin | CrossChainBridge | Allows configuring the CrossChainBridge |
@@ -30,6 +31,7 @@ This document describes the roles that are used in the Olympus protocol.
 | emergency | CoolerLtvOracle | Allows enable/disable on the CoolerLtvOracle |
 | emergency | CoolerTreasuryBorrower | Allows enable/disable on the CoolerTreasuryBorrower |
 | emergency | EmissionManager | Deactivate the EmissionManager |
+| emergency | Heart | Deactivate the contract |
 | emergency | MonoCooler | Allows enable/disable on the MonoCooler |
 | emergency_restart | Emergency | Reactivates the TRSRY and/or MINTR modules |
 | emergency_shutdown | Clearinghouse | Allows shutting down the protocol in an emergency |
@@ -38,9 +40,9 @@ This document describes the roles that are used in the Olympus protocol.
 | heart | Operator | Call the operate() function |
 | heart | ReserveMigrator | Allows migrating reserves from one reserve token to another |
 | heart | YieldRepurchaseFacility | Creates a new YRF market |
-| heart_admin | Heart | Allows configuring heart parameters and activation/deactivation |
 | loan_consolidator_admin | LoanConsolidator | Allows configuring the LoanConsolidator |
 | manager | DepositManager | Configure/enable/disable deposit assets |
+| manager | Heart | Reset the heartbeat |
 | operator_admin | Operator | Activate/deactivate the functionality |
 | operator_policy | Operator | Set spreads, threshold factor, and cushion factor |
 | operator_reporter | Operator | Report bond purchases |

--- a/audit/2025-01_convertible-deposits/scopefile.txt
+++ b/audit/2025-01_convertible-deposits/scopefile.txt
@@ -1,5 +1,6 @@
 src/bases/BaseAssetManager.sol
 src/bases/BaseDepositRedemptionVault.sol
+src/bases/BasePeriodicTaskManager.sol
 src/external/clones/CloneERC20.sol
 src/libraries/CloneableReceiptToken.sol
 src/libraries/DecimalString.sol

--- a/shell/full_install.sh
+++ b/shell/full_install.sh
@@ -14,6 +14,9 @@ echo "*** Setting up submodules"
 git submodule init
 git submodule update
 
+echo "*** Forge Version"
+forge --version
+
 echo "*** Running forge install"
 forge install
 

--- a/src/bases/BasePeriodicTaskManager.sol
+++ b/src/bases/BasePeriodicTaskManager.sol
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.15;
+
+// Interfaces
+import {IPeriodicTask} from "src/interfaces/IPeriodicTask.sol";
+import {IPeriodicTaskManager} from "src/bases/interfaces/IPeriodicTaskManager.sol";
+import {IERC165} from "@openzeppelin-4.8.0/interfaces/IERC165.sol";
+
+// Libraries
+import {AddressStorageArray} from "src/libraries/AddressStorageArray.sol";
+
+// Bophades
+import {PolicyEnabler} from "src/policies/utils/PolicyEnabler.sol";
+
+abstract contract BasePeriodicTaskManager is IPeriodicTaskManager, PolicyEnabler {
+    using AddressStorageArray for address[];
+
+    // ========== STATE VARIABLES ========== //
+
+    /// @notice The periodic tasks
+    address[] internal _periodicTaskAddresses;
+
+    /// @notice An optional custom selector for each periodic task
+    /// @dev    If the selector is set (non-zero), the task will be executed using the custom selector
+    ///         instead of the `IPeriodicTask.execute` function
+    mapping(address => bytes4) internal _periodicTaskCustomSelectors;
+
+    // ========== TASK CONFIGURATION ========== //
+
+    function _addPeriodicTask(address task_, bytes4 customSelector_, uint256 index_) internal {
+        // Validate that the task is not already added
+        if (hasPeriodicTask(task_)) revert PeriodicTaskManager_TaskAlreadyExists(task_);
+
+        // Validate that the task is not a zero address
+        if (task_ == address(0)) revert PeriodicTaskManager_InvalidTaskAddress();
+
+        // If there is no custom selector, validate that the task implements the IPeriodicTask interface
+        if (customSelector_ == bytes4(0)) {
+            // Validate that the task implements the IPeriodicTask interface
+            if (!IERC165(task_).supportsInterface(type(IPeriodicTask).interfaceId))
+                revert PeriodicTaskManager_InvalidTaskAddress();
+        } else {
+            _periodicTaskCustomSelectors[task_] = customSelector_;
+        }
+
+        // Insert the task at the index
+        // This will also validate that the index is within bounds
+        _periodicTaskAddresses.insert(task_, index_);
+
+        // Emit the event
+        emit PeriodicTaskAdded(task_, customSelector_, index_);
+    }
+
+    /// @inheritdoc IPeriodicTaskManager
+    /// @dev        This function reverts if:
+    ///             - The caller is not the admin
+    ///             - The task is already added
+    ///             - The task is not a valid periodic task
+    ///
+    function addPeriodicTask(address task_) external override onlyAdminRole {
+        _addPeriodicTask(task_, bytes4(0), _periodicTaskAddresses.length);
+    }
+
+    /// @inheritdoc IPeriodicTaskManager
+    /// @dev        This function reverts if:
+    ///             - The caller is not the admin
+    ///             - The task is already added
+    ///             - The task is not a valid periodic task
+    ///             - The index is out of bounds
+    function addPeriodicTaskAtIndex(
+        address task_,
+        bytes4 customSelector_,
+        uint256 index_
+    ) external override onlyAdminRole {
+        _addPeriodicTask(task_, customSelector_, index_);
+    }
+
+    function _removePeriodicTask(uint256 index_) internal {
+        // Get the task at the index
+        address task = _periodicTaskAddresses[index_];
+
+        // Remove the task at the index
+        _periodicTaskAddresses.remove(index_);
+
+        // Clear the custom selector for the task
+        delete _periodicTaskCustomSelectors[task];
+
+        // Emit the event
+        emit PeriodicTaskRemoved(task, index_);
+    }
+
+    /// @inheritdoc IPeriodicTaskManager
+    /// @dev        This function reverts if:
+    ///             - The caller is not the admin
+    ///             - The task is not added
+    function removePeriodicTask(address task_) external override onlyAdminRole {
+        // Get the index of the task
+        uint256 index = getPeriodicTaskIndex(task_);
+
+        // Validate that the task exists
+        if (index == type(uint256).max) revert PeriodicTaskManager_TaskNotFound(task_);
+
+        // Remove the task at the index
+        _removePeriodicTask(index);
+    }
+
+    /// @inheritdoc IPeriodicTaskManager
+    /// @dev        This function reverts if:
+    ///             - The caller is not the admin
+    ///             - The index is out of bounds
+    function removePeriodicTaskAtIndex(uint256 index_) external override onlyAdminRole {
+        // Remove the task at the index
+        _removePeriodicTask(index_);
+    }
+
+    // ========== TASK EXECUTION ========== //
+
+    function _executePeriodicTasks() internal {
+        for (uint256 i = 0; i < _periodicTaskAddresses.length; i++) {
+            // Get the custom selector for the task
+            bytes4 customSelector = _periodicTaskCustomSelectors[_periodicTaskAddresses[i]];
+
+            // If there is no custom selector, execute the task using the `IPeriodicTask.execute` function
+            if (customSelector == bytes4(0)) {
+                IPeriodicTask(_periodicTaskAddresses[i]).execute();
+            }
+            // Otherwise, execute the task using the custom selector
+            else {
+                // Call the custom selector
+                (bool success, bytes memory data) = _periodicTaskAddresses[i].call(
+                    abi.encodeWithSelector(customSelector)
+                );
+
+                // If the call fails, revert
+                if (!success)
+                    revert PeriodicTaskManager_CustomSelectorFailed(
+                        _periodicTaskAddresses[i],
+                        customSelector,
+                        data
+                    );
+            }
+        }
+    }
+
+    // ========== VIEW FUNCTIONS ========== //
+
+    /// @inheritdoc IPeriodicTaskManager
+    function getPeriodicTaskCount() external view override returns (uint256) {
+        return _periodicTaskAddresses.length;
+    }
+
+    /// @inheritdoc IPeriodicTaskManager
+    function getPeriodicTaskAtIndex(
+        uint256 index_
+    ) external view override returns (address, bytes4) {
+        address task = _periodicTaskAddresses[index_];
+
+        return (task, _periodicTaskCustomSelectors[task]);
+    }
+
+    /// @inheritdoc IPeriodicTaskManager
+    function getPeriodicTasks() external view override returns (address[] memory, bytes4[] memory) {
+        address[] memory tasks = new address[](_periodicTaskAddresses.length);
+        bytes4[] memory customSelectors = new bytes4[](_periodicTaskAddresses.length);
+
+        for (uint256 i = 0; i < _periodicTaskAddresses.length; i++) {
+            tasks[i] = _periodicTaskAddresses[i];
+            customSelectors[i] = _periodicTaskCustomSelectors[_periodicTaskAddresses[i]];
+        }
+
+        return (tasks, customSelectors);
+    }
+
+    /// @inheritdoc IPeriodicTaskManager
+    ///
+    /// @return _index  The index of the task, or type(uint256).max if not found
+    function getPeriodicTaskIndex(address task_) public view override returns (uint256 _index) {
+        uint256 length = _periodicTaskAddresses.length;
+        _index = type(uint256).max;
+        for (uint256 i = 0; i < length; i++) {
+            if (_periodicTaskAddresses[i] == task_) {
+                _index = i;
+                break;
+            }
+        }
+
+        return _index;
+    }
+
+    /// @inheritdoc IPeriodicTaskManager
+    function hasPeriodicTask(address task_) public view override returns (bool) {
+        return getPeriodicTaskIndex(task_) != type(uint256).max;
+    }
+}

--- a/src/bases/interfaces/IPeriodicTaskManager.sol
+++ b/src/bases/interfaces/IPeriodicTaskManager.sol
@@ -26,8 +26,11 @@ interface IPeriodicTaskManager {
     /// @notice Error thrown when trying to add a task that already exists
     error PeriodicTaskManager_TaskAlreadyExists(address task_);
 
-    /// @notice Error thrown when the provided task address is invalid
-    error PeriodicTaskManager_InvalidTaskAddress();
+    /// @notice Error thrown when the provided task address is zero
+    error PeriodicTaskManager_ZeroAddress();
+
+    /// @notice Error thrown when the provided task does not implement the IPeriodicTask interface
+    error PeriodicTaskManager_NotPeriodicTask(address task_);
 
     /// @notice Error thrown when a custom selector fails
     error PeriodicTaskManager_CustomSelectorFailed(

--- a/src/bases/interfaces/IPeriodicTaskManager.sol
+++ b/src/bases/interfaces/IPeriodicTaskManager.sol
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+/// @title  IPeriodicTaskManager
+/// @notice Interface for a contract that can manage periodic tasks with ordering capabilities
+interface IPeriodicTaskManager {
+    // ========== EVENTS ========== //
+
+    /// @notice Emitted when a periodic task is added
+    ///
+    /// @param task_ The address of the periodic task
+    /// @param index_ The index where the task was added
+    event PeriodicTaskAdded(address indexed task_, bytes4 customSelector_, uint256 indexed index_);
+
+    /// @notice Emitted when a periodic task is removed
+    ///
+    /// @param task_ The address of the periodic task
+    /// @param index_ The index where the task was removed from
+    event PeriodicTaskRemoved(address indexed task_, uint256 indexed index_);
+
+    // ========== ERRORS ========== //
+
+    /// @notice Error thrown when trying to remove a task that doesn't exist
+    error PeriodicTaskManager_TaskNotFound(address task_);
+
+    /// @notice Error thrown when trying to add a task that already exists
+    error PeriodicTaskManager_TaskAlreadyExists(address task_);
+
+    /// @notice Error thrown when the provided task address is invalid
+    error PeriodicTaskManager_InvalidTaskAddress();
+
+    /// @notice Error thrown when a custom selector fails
+    error PeriodicTaskManager_CustomSelectorFailed(
+        address task_,
+        bytes4 customSelector_,
+        bytes reason_
+    );
+
+    // ========== TASK MANAGEMENT FUNCTIONS ========== //
+
+    /// @notice Adds a periodic task to the end of the task list
+    /// @dev    This function should be protected by a role check for the "admin" role
+    ///
+    /// @param  task_ The periodic task to add
+    function addPeriodicTask(address task_) external;
+
+    /// @notice Adds a periodic task at a specific index in the task list
+    /// @dev    This function should be protected by a role check for the "admin" role
+    /// @dev    If the index is greater than the current length, the task will be added at the end
+    ///
+    /// @param  task_           The periodic task to add
+    /// @param  customSelector_ The custom selector to use for the task (or 0)
+    /// @param  index_          The index where to insert the task
+    function addPeriodicTaskAtIndex(address task_, bytes4 customSelector_, uint256 index_) external;
+
+    /// @notice Removes a periodic task from the task list
+    /// @dev    This function should be protected by a role check for the "admin" role
+    ///
+    /// @param  task_ The periodic task to remove
+    function removePeriodicTask(address task_) external;
+
+    /// @notice Removes a periodic task at a specific index
+    /// @dev    This function should be protected by a role check for the "admin" role
+    ///
+    /// @param  index_ The index of the task to remove
+    function removePeriodicTaskAtIndex(uint256 index_) external;
+
+    // ========== VIEW FUNCTIONS ========== //
+
+    /// @notice Gets the total number of periodic tasks
+    ///
+    /// @return _taskCount  The number of periodic tasks
+    function getPeriodicTaskCount() external view returns (uint256 _taskCount);
+
+    /// @notice Gets a periodic task at a specific index
+    ///
+    /// @param  index_          The index of the task to get
+    /// @return _task           The address of the periodic task at the specified index
+    /// @return _customSelector The custom selector for the task (or 0)
+    function getPeriodicTaskAtIndex(
+        uint256 index_
+    ) external view returns (address _task, bytes4 _customSelector);
+
+    /// @notice Gets all periodic tasks
+    ///
+    /// @return _tasks              An array of all periodic tasks in order
+    /// @return _customSelectors    An array of all custom selectors in order
+    function getPeriodicTasks()
+        external
+        view
+        returns (address[] memory _tasks, bytes4[] memory _customSelectors);
+
+    /// @notice Gets the index of a specific periodic task
+    ///
+    /// @param  task_   The periodic task to find
+    /// @return _index  The index of the task, or type(uint256).max if not found
+    function getPeriodicTaskIndex(address task_) external view returns (uint256 _index);
+
+    /// @notice Checks if a periodic task exists in the manager
+    ///
+    /// @param  task_   The periodic task to check
+    /// @return _exists True if the task exists, false otherwise
+    function hasPeriodicTask(address task_) external view returns (bool _exists);
+}

--- a/src/interfaces/IPeriodicTask.sol
+++ b/src/interfaces/IPeriodicTask.sol
@@ -12,4 +12,7 @@ interface IPeriodicTask {
     /// @dev    - The implementing function should avoid reverting, as that would cause the calling contract to revert.
     /// @dev    - The implementing function should be protected by a role check for the "heart" role.
     function execute() external;
+
+    /// @notice ERC165 interface support
+    function supportsInterface(bytes4 interfaceId) external view returns (bool);
 }

--- a/src/interfaces/IPeriodicTask.sol
+++ b/src/interfaces/IPeriodicTask.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
 
 /// @title  IPeriodicTask

--- a/src/libraries/AddressStorageArray.sol
+++ b/src/libraries/AddressStorageArray.sol
@@ -4,15 +4,19 @@ pragma solidity >=0.8.0;
 /// @title  AddressStorageArray
 /// @notice A library for managing a storage array of addresses, with support for insertion and removal at a specific index
 library AddressStorageArray {
-    error AddressStorageArray_IndexOutOfBounds();
+    error AddressStorageArray_IndexOutOfBounds(uint256 index, uint256 length);
 
     /// @notice Inserts an address at a specific index
     function insert(address[] storage array, address value_, uint256 index_) internal {
         // Validate that the index is within the bounds or the end of the array
-        if (index_ > array.length) revert AddressStorageArray_IndexOutOfBounds();
+        if (index_ > array.length)
+            revert AddressStorageArray_IndexOutOfBounds(index_, array.length);
+
+        // Add a new element to the end of the array
+        array.push(address(0));
 
         // Shift all elements after the index to the right
-        for (uint256 i = array.length; i > index_; i--) {
+        for (uint256 i = array.length - 1; i > index_; i--) {
             array[i] = array[i - 1];
         }
 
@@ -21,9 +25,13 @@ library AddressStorageArray {
     }
 
     /// @notice Removes an address at a specific index
-    function remove(address[] storage array, uint256 index_) internal {
+    function remove(address[] storage array, uint256 index_) internal returns (address) {
         // Validate that the index is within the bounds of the array
-        if (index_ >= array.length) revert AddressStorageArray_IndexOutOfBounds();
+        if (index_ >= array.length)
+            revert AddressStorageArray_IndexOutOfBounds(index_, array.length);
+
+        // Get the value at the index
+        address removedValue = array[index_];
 
         // Shift all elements after the index to the left
         for (uint256 i = index_; i < array.length - 1; i++) {
@@ -32,5 +40,8 @@ library AddressStorageArray {
 
         // Remove the last (empty) element
         array.pop();
+
+        // Return the removed value
+        return removedValue;
     }
 }

--- a/src/libraries/AddressStorageArray.sol
+++ b/src/libraries/AddressStorageArray.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+/// @title  AddressStorageArray
+/// @notice A library for managing a storage array of addresses, with support for insertion and removal at a specific index
+library AddressStorageArray {
+    error AddressStorageArray_IndexOutOfBounds();
+
+    /// @notice Inserts an address at a specific index
+    function insert(address[] storage array, address value_, uint256 index_) internal {
+        // Validate that the index is within the bounds or the end of the array
+        if (index_ > array.length) revert AddressStorageArray_IndexOutOfBounds();
+
+        // Shift all elements after the index to the right
+        for (uint256 i = array.length; i > index_; i--) {
+            array[i] = array[i - 1];
+        }
+
+        // Insert the value at the index
+        array[index_] = value_;
+    }
+
+    /// @notice Removes an address at a specific index
+    function remove(address[] storage array, uint256 index_) internal {
+        // Validate that the index is within the bounds of the array
+        if (index_ >= array.length) revert AddressStorageArray_IndexOutOfBounds();
+
+        // Shift all elements after the index to the left
+        for (uint256 i = index_; i < array.length - 1; i++) {
+            array[i] = array[i + 1];
+        }
+
+        // Remove the last (empty) element
+        array.pop();
+    }
+}

--- a/src/policies/CDFacility.sol
+++ b/src/policies/CDFacility.sol
@@ -24,6 +24,10 @@ contract CDFacility is Policy, IConvertibleDepositFacility, IPeriodicTask, BaseD
 
     bytes32 public constant ROLE_AUCTIONEER = "cd_auctioneer";
 
+    /// @notice The role assigned to the Heart contract.
+    ///         This enables the Heart contract to call specific functions on this contract.
+    bytes32 public constant ROLE_HEART = "heart";
+
     // ========== STATE VARIABLES ========== //
 
     /// @notice The MINTR module.

--- a/src/policies/CDFacility.sol
+++ b/src/policies/CDFacility.sol
@@ -19,7 +19,12 @@ import {BaseDepositRedemptionVault} from "src/bases/BaseDepositRedemptionVault.s
 /// @title  Convertible Deposit Facility
 /// @notice Implementation of the {IConvertibleDepositFacility} interface
 ///         It is a general-purpose contract that can be used to create, mint, convert, redeem, and reclaim receipt tokens
-contract CDFacility is Policy, IConvertibleDepositFacility, IPeriodicTask, BaseDepositRedemptionVault {
+contract CDFacility is
+    Policy,
+    IConvertibleDepositFacility,
+    IPeriodicTask,
+    BaseDepositRedemptionVault
+{
     // ========== CONSTANTS ========== //
 
     bytes32 public constant ROLE_AUCTIONEER = "cd_auctioneer";
@@ -398,9 +403,12 @@ contract CDFacility is Policy, IConvertibleDepositFacility, IPeriodicTask, BaseD
 
     // ========== ERC165 ========== //
 
-    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override(BaseDepositRedemptionVault, IPeriodicTask) returns (bool) {
         return
             interfaceId == type(IConvertibleDepositFacility).interfaceId ||
+            interfaceId == type(IPeriodicTask).interfaceId ||
             super.supportsInterface(interfaceId);
     }
 }

--- a/src/policies/CDFacility.sol
+++ b/src/policies/CDFacility.sol
@@ -381,6 +381,8 @@ contract CDFacility is Policy, IConvertibleDepositFacility, BaseDepositRedemptio
         return address(MINTR.ohm());
     }
 
+    // TODO IPeriodicTask
+
     // ========== ERC165 ========== //
 
     function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {

--- a/src/policies/EmissionManager.sol
+++ b/src/policies/EmissionManager.sol
@@ -392,7 +392,7 @@ contract EmissionManager is IEmissionManager, IPeriodicTask, Policy, PolicyEnabl
     }
 
     /// @notice Rescue any ERC20 token sent to this contract and send it to the TRSRY
-    /// @dev This function is restricted to the emissions_admin role
+    /// @dev This function is restricted to the ADMIN role
     /// @param token_ The address of the ERC20 token to rescue
     function rescue(address token_) external onlyAdminRole {
         ERC20 token = ERC20(token_);

--- a/src/policies/EmissionManager.sol
+++ b/src/policies/EmissionManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0
-pragma solidity 0.8.15;
+pragma solidity >=0.8.15;
 
 // Libraries
 import {ERC20} from "solmate/tokens/ERC20.sol";
@@ -568,7 +568,9 @@ contract EmissionManager is IEmissionManager, IPeriodicTask, Policy, PolicyEnabl
 
     // ========== ERC165 ========== //
 
-    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override(PolicyEnabler, IPeriodicTask) returns (bool) {
         return
             interfaceId == type(IPeriodicTask).interfaceId ||
             interfaceId == type(IEmissionManager).interfaceId ||

--- a/src/policies/EmissionManager.sol
+++ b/src/policies/EmissionManager.sol
@@ -13,6 +13,7 @@ import {IgOHM} from "interfaces/IgOHM.sol";
 import {IEmissionManager} from "policies/interfaces/IEmissionManager.sol";
 import {IConvertibleDepositAuctioneer} from "src/policies/interfaces/IConvertibleDepositAuctioneer.sol";
 import {IGenericClearinghouse} from "policies/interfaces/IGenericClearinghouse.sol";
+import {IPeriodicTask} from "src/interfaces/IPeriodicTask.sol";
 
 // Bophades
 import {Kernel, Keycode, Permissions, Policy, toKeycode} from "src/Kernel.sol";
@@ -24,7 +25,7 @@ import {CHREGv1} from "modules/CHREG/CHREG.v1.sol";
 import {PolicyEnabler} from "src/policies/utils/PolicyEnabler.sol";
 
 // solhint-disable max-states-count
-contract EmissionManager is IEmissionManager, Policy, PolicyEnabler {
+contract EmissionManager is IEmissionManager, IPeriodicTask, Policy, PolicyEnabler {
     using FullMath for uint256;
     using TransferHelper for ERC20;
 
@@ -172,9 +173,9 @@ contract EmissionManager is IEmissionManager, Policy, PolicyEnabler {
         return (major, minor);
     }
 
-    // ========== HEARTBEAT ========== //
+    // ========== PERIODIC TASK ========== //
 
-    /// @inheritdoc IEmissionManager
+    /// @inheritdoc IPeriodicTask
     function execute() external onlyRole(ROLE_HEART) {
         // Don't do anything if disabled
         if (!isEnabled) return;
@@ -563,5 +564,14 @@ contract EmissionManager is IEmissionManager, Policy, PolicyEnabler {
     /// @return minPrice for CD auction
     function getMinPriceFor(uint256 price) public view returns (uint256) {
         return (price * minPriceScalar) / ONE_HUNDRED_PERCENT;
+    }
+
+    // ========== ERC165 ========== //
+
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+        return
+            interfaceId == type(IPeriodicTask).interfaceId ||
+            interfaceId == type(IEmissionManager).interfaceId ||
+            super.supportsInterface(interfaceId);
     }
 }

--- a/src/policies/Heart.sol
+++ b/src/policies/Heart.sol
@@ -35,9 +35,6 @@ import {Kernel, Policy, Keycode, Permissions, toKeycode} from "src/Kernel.sol";
 contract OlympusHeart is IHeart, Policy, PolicyEnabler, ReentrancyGuard, BasePeriodicTaskManager {
     using TransferHelper for ERC20;
 
-    // [X] Use PolicyEnabler
-    // [ ] Use PolicyAdmin
-
     // =========  STATE ========= //
 
     /// @notice Timestamp of the last beat (UTC, in seconds)
@@ -177,7 +174,8 @@ contract OlympusHeart is IHeart, Policy, PolicyEnabler, ReentrancyGuard, BasePer
     }
 
     /// @inheritdoc IHeart
-    function resetBeat() external onlyRole("heart_admin") {
+    /// @dev        This function is gated to the ADMIN or MANAGER roles
+    function resetBeat() external onlyManagerOrAdminRole {
         _resetBeat();
     }
 
@@ -187,7 +185,8 @@ contract OlympusHeart is IHeart, Policy, PolicyEnabler, ReentrancyGuard, BasePer
     }
 
     /// @inheritdoc IHeart
-    function setDistributor(address distributor_) external onlyRole("heart_admin") {
+    /// @dev        This function is gated to the ADMIN role
+    function setDistributor(address distributor_) external onlyAdminRole {
         distributor = IDistributor(distributor_);
         _syncBeatWithDistributor();
     }
@@ -199,10 +198,11 @@ contract OlympusHeart is IHeart, Policy, PolicyEnabler, ReentrancyGuard, BasePer
     }
 
     /// @inheritdoc IHeart
+    /// @dev        This function is gated to the ADMIN role
     function setRewardAuctionParams(
         uint256 maxReward_,
         uint48 auctionDuration_
-    ) external onlyRole("heart_admin") notWhileBeatAvailable {
+    ) external onlyAdminRole notWhileBeatAvailable {
         // auction duration should be less than or equal to frequency, otherwise frequency will be used
         if (auctionDuration_ > frequency()) revert Heart_InvalidParams();
 

--- a/src/policies/Heart.sol
+++ b/src/policies/Heart.sol
@@ -139,6 +139,9 @@ contract OlympusHeart is IHeart, Policy, PolicyEnabler, ReentrancyGuard, BasePer
         // This cannot be a periodic task, because it requires a policy with permission to call the updateMovingAverage function
         PRICE.updateMovingAverage();
 
+        // Trigger the rebase
+        distributor.triggerRebase();
+
         // Execute periodic tasks
         _executePeriodicTasks();
 

--- a/src/policies/Heart.sol
+++ b/src/policies/Heart.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0
-pragma solidity 0.8.15;
+pragma solidity >=0.8.15;
 
 // External libraries
 import {ReentrancyGuard} from "@solmate-6.2.0/utils/ReentrancyGuard.sol";
@@ -10,18 +10,16 @@ import {TransferHelper} from "src/libraries/TransferHelper.sol";
 
 // Interfaces
 import {IDistributor} from "src/policies/interfaces/IDistributor.sol";
-import {IOperator} from "src/policies/interfaces/IOperator.sol";
-import {IYieldRepo} from "src/policies/interfaces/IYieldRepo.sol";
 import {IHeart} from "src/policies/interfaces/IHeart.sol";
-import {IReserveMigrator} from "src/policies/interfaces/IReserveMigrator.sol";
-import {IEmissionManager} from "src/policies/interfaces/IEmissionManager.sol";
 
 // Modules
 import {ROLESv1} from "src/modules/ROLES/ROLES.v1.sol";
 import {RolesConsumer} from "src/modules/ROLES/OlympusRoles.sol";
 import {PRICEv1} from "src/modules/PRICE/PRICE.v1.sol";
 import {MINTRv1} from "src/modules/MINTR/MINTR.v1.sol";
-import {TRSRYv1} from "src/modules/TRSRY/TRSRY.v1.sol";
+
+// Bophades
+import {BasePeriodicTaskManager} from "src/bases/BasePeriodicTaskManager.sol";
 
 // Kernel
 import {Kernel, Policy, Keycode, Permissions, toKeycode} from "src/Kernel.sol";
@@ -33,8 +31,12 @@ import {Kernel, Policy, Keycode, Permissions, toKeycode} from "src/Kernel.sol";
 ///         market operations use up to date information.
 ///         This version implements an auction style reward system where the reward is linearly increasing up to a max reward.
 ///         Rewards are issued in OHM.
-contract OlympusHeart is IHeart, Policy, RolesConsumer, ReentrancyGuard {
+contract OlympusHeart is IHeart, Policy, ReentrancyGuard, BasePeriodicTaskManager {
     using TransferHelper for ERC20;
+
+    // [ ] Use PolicyEnabler
+    // [ ] Use PolicyAdmin
+    // [ ] Migrate tasks to IPeriodicTask
 
     // =========  STATE ========= //
 
@@ -53,14 +55,9 @@ contract OlympusHeart is IHeart, Policy, RolesConsumer, ReentrancyGuard {
     // Modules
     PRICEv1 internal PRICE;
     MINTRv1 internal MINTR;
-    TRSRYv1 internal TRSRY;
 
     // Policies
-    IOperator public operator;
     IDistributor public distributor;
-    IYieldRepo public yieldRepo;
-    IReserveMigrator public reserveMigrator;
-    IEmissionManager public emissionManager;
 
     //============================================================================================//
     //                                      POLICY SETUP                                          //
@@ -70,19 +67,11 @@ contract OlympusHeart is IHeart, Policy, RolesConsumer, ReentrancyGuard {
     ///      Therefore, manually ensure that the value is valid when deploying the contract.
     constructor(
         Kernel kernel_,
-        IOperator operator_,
         IDistributor distributor_,
-        IYieldRepo yieldRepo_,
-        IReserveMigrator reserveMigrator_,
-        IEmissionManager emissionManager_,
         uint256 maxReward_,
         uint48 auctionDuration_
     ) Policy(kernel_) {
-        operator = operator_;
         distributor = distributor_;
-        yieldRepo = yieldRepo_;
-        reserveMigrator = reserveMigrator_;
-        emissionManager = emissionManager_;
 
         active = true;
         auctionDuration = auctionDuration_;
@@ -93,26 +82,23 @@ contract OlympusHeart is IHeart, Policy, RolesConsumer, ReentrancyGuard {
 
     /// @inheritdoc Policy
     function configureDependencies() external override returns (Keycode[] memory dependencies) {
-        dependencies = new Keycode[](4);
+        dependencies = new Keycode[](3);
         dependencies[0] = toKeycode("PRICE");
         dependencies[1] = toKeycode("ROLES");
         dependencies[2] = toKeycode("MINTR");
-        dependencies[3] = toKeycode("TRSRY");
 
         PRICE = PRICEv1(getModuleAddress(dependencies[0]));
         ROLES = ROLESv1(getModuleAddress(dependencies[1]));
         MINTR = MINTRv1(getModuleAddress(dependencies[2]));
-        TRSRY = TRSRYv1(getModuleAddress(dependencies[3]));
 
         (uint8 MINTR_MAJOR, ) = MINTR.VERSION();
         (uint8 PRICE_MAJOR, ) = PRICE.VERSION();
         (uint8 ROLES_MAJOR, ) = ROLES.VERSION();
-        (uint8 TRSRY_MAJOR, ) = TRSRY.VERSION();
 
         // Ensure Modules are using the expected major version.
         // Modules should be sorted in alphabetical order.
-        bytes memory expected = abi.encode([1, 1, 1, 1]);
-        if (MINTR_MAJOR != 1 || PRICE_MAJOR != 1 || ROLES_MAJOR != 1 || TRSRY_MAJOR != 1)
+        bytes memory expected = abi.encode([1, 1, 1]);
+        if (MINTR_MAJOR != 1 || PRICE_MAJOR != 1 || ROLES_MAJOR != 1)
             revert Policy_WrongModuleVersion(expected);
 
         // Sync beat with distributor if called from kernel
@@ -155,22 +141,26 @@ contract OlympusHeart is IHeart, Policy, RolesConsumer, ReentrancyGuard {
         if (currentTime < lastBeat + frequency()) revert Heart_OutOfCycle();
 
         // Update the moving average on the Price module
+        // This cannot be a periodic task, because it requires a policy with permission to call the updateMovingAverage function
         PRICE.updateMovingAverage();
 
-        // Migrate reserves, if necessary
-        reserveMigrator.migrate();
+        // // Migrate reserves, if necessary
+        // reserveMigrator.migrate();
 
-        // Trigger price range update and market operations
-        operator.operate();
+        // // Trigger price range update and market operations
+        // operator.operate();
 
-        // Trigger protocol loop
-        yieldRepo.endEpoch();
+        // // Trigger protocol loop
+        // yieldRepo.endEpoch();
 
-        // Trigger rebase
-        distributor.triggerRebase();
+        // // Trigger rebase
+        // distributor.triggerRebase();
 
-        // Trigger emission manager
-        emissionManager.execute();
+        // // Trigger emission manager
+        // emissionManager.execute();
+
+        // Execute periodic tasks
+        _executePeriodicTasks();
 
         // Calculate the reward (0 <= reward <= maxReward) for the keeper
         uint256 reward = currentReward();
@@ -220,29 +210,9 @@ contract OlympusHeart is IHeart, Policy, RolesConsumer, ReentrancyGuard {
     }
 
     /// @inheritdoc IHeart
-    function setOperator(address operator_) external onlyRole("heart_admin") {
-        operator = IOperator(operator_);
-    }
-
-    /// @inheritdoc IHeart
     function setDistributor(address distributor_) external onlyRole("heart_admin") {
         distributor = IDistributor(distributor_);
         _syncBeatWithDistributor();
-    }
-
-    /// @inheritdoc IHeart
-    function setYieldRepo(address yieldRepo_) external onlyRole("heart_admin") {
-        yieldRepo = IYieldRepo(yieldRepo_);
-    }
-
-    /// @inheritdoc IHeart
-    function setReserveMigrator(address reserveMigrator_) external onlyRole("heart_admin") {
-        reserveMigrator = IReserveMigrator(reserveMigrator_);
-    }
-
-    /// @inheritdoc IHeart
-    function setEmissionManager(address emissionManager_) external onlyRole("heart_admin") {
-        emissionManager = IEmissionManager(emissionManager_);
     }
 
     modifier notWhileBeatAvailable() {

--- a/src/policies/YieldDepositFacility.sol
+++ b/src/policies/YieldDepositFacility.sol
@@ -8,7 +8,7 @@ import {FullMath} from "src/libraries/FullMath.sol";
 import {IYieldDepositFacility} from "src/policies/interfaces/IYieldDepositFacility.sol";
 import {IERC20} from "src/interfaces/IERC20.sol";
 import {IERC4626} from "src/interfaces/IERC4626.sol";
-import {IPeriodicTask} from "src/policies/interfaces/IPeriodicTask.sol";
+import {IPeriodicTask} from "src/interfaces/IPeriodicTask.sol";
 import {IAssetManager} from "src/bases/interfaces/IAssetManager.sol";
 import {IDepositManager} from "src/policies/interfaces/IDepositManager.sol";
 import {IDepositPositionManager} from "src/modules/DEPOS/IDepositPositionManager.sol";

--- a/src/policies/YieldDepositFacility.sol
+++ b/src/policies/YieldDepositFacility.sol
@@ -451,7 +451,9 @@ contract YieldDepositFacility is
 
     // ========== ERC165 ========== //
 
-    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override(BaseDepositRedemptionVault, IPeriodicTask) returns (bool) {
         return
             interfaceId == type(IYieldDepositFacility).interfaceId ||
             interfaceId == type(IPeriodicTask).interfaceId ||

--- a/src/policies/interfaces/IEmissionManager.sol
+++ b/src/policies/interfaces/IEmissionManager.sol
@@ -65,11 +65,4 @@ interface IEmissionManager {
         uint256 minPriceScalar;
         uint48 restartTimeframe;
     }
-
-    // ========== EXECUTE ========== //
-
-    /// @notice calculate and execute sale, if applicable, once per day (every 3 beats)
-    /// @dev this function is restricted to the heart role and is called on each heart beat
-    /// @dev if the contract is not active, the function does nothing
-    function execute() external;
 }

--- a/src/policies/interfaces/IHeart.sol
+++ b/src/policies/interfaces/IHeart.sol
@@ -40,30 +40,10 @@ interface IHeart {
     /// @dev    Emergency stop function for the heart
     function deactivate() external;
 
-    /// @notice Updates the Operator contract address that the Heart calls on a beat
-    /// @notice Access restricted
-    /// @param  operator_ The address of the new Operator contract
-    function setOperator(address operator_) external;
-
     /// @notice Updates the Distributor contract address that the Heart calls on a beat
     /// @notice Access restricted
     /// @param  distributor_ The address of the new Distributor contract
     function setDistributor(address distributor_) external;
-
-    /// @notice Updates the YieldRepo contract address that the Heart calls on a beat
-    /// @notice Access restricted
-    /// @param  yieldRepo_ The address of the new YieldRepo contract
-    function setYieldRepo(address yieldRepo_) external;
-
-    /// @notice Updates the ReserveMigrator contract address that the Heart calls on a beat
-    /// @notice Access restricted
-    /// @param  reserveMigrator_ The address of the new ReserveMigrator contract
-    function setReserveMigrator(address reserveMigrator_) external;
-
-    /// @notice Updates the EmissionManager contract address that the Heart calls on a beat
-    /// @notice Access restricted
-    /// @param  emissionManager_ The address of the new EmissionManager contract
-    function setEmissionManager(address emissionManager_) external;
 
     /// @notice Sets the max reward amount, and auction duration for the beat function
     /// @notice Access restricted

--- a/src/policies/interfaces/IHeart.sol
+++ b/src/policies/interfaces/IHeart.sol
@@ -30,16 +30,6 @@ interface IHeart {
     /// @notice Access restricted
     function resetBeat() external;
 
-    /// @notice Turns the heart on and resets the beat
-    /// @notice Access restricted
-    /// @dev    This function is used to restart the heart after a pause
-    function activate() external;
-
-    /// @notice Turns the heart off
-    /// @notice Access restricted
-    /// @dev    Emergency stop function for the heart
-    function deactivate() external;
-
     /// @notice Updates the Distributor contract address that the Heart calls on a beat
     /// @notice Access restricted
     /// @param  distributor_ The address of the new Distributor contract

--- a/src/scripts/deploy/DeployV2.sol
+++ b/src/scripts/deploy/DeployV2.sol
@@ -686,26 +686,13 @@ contract OlympusDeploy is Script {
         // Log heart parameters
         console2.log("OlympusHeart parameters:");
         console2.log("   kernel", address(kernel));
-        console2.log("   operator", address(operator));
         console2.log("   zeroDistributor", address(zeroDistributor));
-        console2.log("   yieldRepo", address(yieldRepo));
-        console2.log("   reserveMigrator", address(reserveMigrator));
-        console2.log("   emissionManager", address(emissionManager));
         console2.log("   maxReward", maxReward);
         console2.log("   auctionDuration", auctionDuration);
 
         // Deploy OlympusHeart policy
         vm.broadcast();
-        heart = new OlympusHeart(
-            kernel,
-            operator,
-            zeroDistributor,
-            yieldRepo,
-            reserveMigrator,
-            emissionManager,
-            maxReward,
-            auctionDuration
-        );
+        heart = new OlympusHeart(kernel, zeroDistributor, maxReward, auctionDuration);
         console2.log("OlympusHeart deployed at:", address(heart));
 
         return address(heart);

--- a/src/scripts/ops/batches/USDSMigration.sol
+++ b/src/scripts/ops/batches/USDSMigration.sol
@@ -92,7 +92,7 @@ contract USDSMigration is OlyBatch {
     function run(bool send_) external isDaoBatch(send_) {
         // 1. Deactivate existing contracts that are being replaced locally
         // 1a. Deactivate OlympusHeart
-        addToBatch(oldHeart, abi.encodeWithSelector(OlympusHeart.deactivate.selector));
+        addToBatch(oldHeart, abi.encodeWithSignature("deactivate()"));
         // 1b. Deactivate Operator
         addToBatch(oldOperator, abi.encodeWithSelector(Operator.deactivate.selector));
         // 1c. Shutdown YieldRepurchaseFacility

--- a/src/scripts/ops/batches/YieldRepoInstall.sol
+++ b/src/scripts/ops/batches/YieldRepoInstall.sol
@@ -34,7 +34,7 @@ contract YieldRepoInstall is OlyBatch {
         // Yield Repo Install Script
 
         // 0. Deactivate the old heart
-        addToBatch(oldHeart, abi.encodeWithSelector(OlympusHeart.deactivate.selector));
+        addToBatch(oldHeart, abi.encodeWithSignature("deactivate()"));
 
         // A. Kernel Actions
         // A.1. Uninstall the old heart from the kernel

--- a/src/test/bases/PeriodicTaskManager/MockCustomPeriodicTask.sol
+++ b/src/test/bases/PeriodicTaskManager/MockCustomPeriodicTask.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.15;
+
+contract MockCustomPeriodicTask {
+    uint256 public count;
+    bool public _revert;
+
+    error MockCustomPeriodicTask_Revert();
+
+    function customExecute() external {
+        if (_revert) revert MockCustomPeriodicTask_Revert();
+
+        count++;
+    }
+
+    function setRevert(bool revert_) external {
+        _revert = revert_;
+    }
+}

--- a/src/test/bases/PeriodicTaskManager/MockPeriodicTask.sol
+++ b/src/test/bases/PeriodicTaskManager/MockPeriodicTask.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.15;
+
+import {IPeriodicTask} from "src/interfaces/IPeriodicTask.sol";
+
+contract MockPeriodicTask is IPeriodicTask {
+    uint256 public count;
+    bool public _revert;
+
+    error MockPeriodicTask_Revert();
+
+    function execute() external override {
+        if (_revert) revert MockPeriodicTask_Revert();
+
+        count++;
+    }
+
+    function supportsInterface(bytes4 interfaceId) external pure override returns (bool) {
+        return interfaceId == type(IPeriodicTask).interfaceId;
+    }
+
+    function setRevert(bool revert_) external {
+        _revert = revert_;
+    }
+}

--- a/src/test/bases/PeriodicTaskManager/MockPeriodicTaskManager.sol
+++ b/src/test/bases/PeriodicTaskManager/MockPeriodicTaskManager.sol
@@ -22,4 +22,8 @@ contract MockPeriodicTaskManager is Policy, BasePeriodicTaskManager {
         override
         returns (Permissions[] memory permissions)
     {}
+
+    function executeAllTasks() external {
+        _executePeriodicTasks();
+    }
 }

--- a/src/test/bases/PeriodicTaskManager/MockPeriodicTaskManager.sol
+++ b/src/test/bases/PeriodicTaskManager/MockPeriodicTaskManager.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.15;
+
+import {BasePeriodicTaskManager} from "src/bases/BasePeriodicTaskManager.sol";
+
+import {Kernel, Policy, Keycode, toKeycode, Permissions} from "src/Kernel.sol";
+import {ROLESv1} from "src/modules/ROLES/ROLES.v1.sol";
+
+contract MockPeriodicTaskManager is Policy, BasePeriodicTaskManager {
+    constructor(Kernel kernel_) Policy(kernel_) {}
+
+    function configureDependencies() external override returns (Keycode[] memory dependencies) {
+        dependencies = new Keycode[](1);
+        dependencies[0] = toKeycode("ROLES");
+
+        ROLES = ROLESv1(getModuleAddress(toKeycode("ROLES")));
+    }
+
+    function requestPermissions()
+        external
+        view
+        override
+        returns (Permissions[] memory permissions)
+    {}
+}

--- a/src/test/bases/PeriodicTaskManager/PeriodicTaskManagerTest.sol
+++ b/src/test/bases/PeriodicTaskManager/PeriodicTaskManagerTest.sol
@@ -3,10 +3,15 @@ pragma solidity >=0.8.15;
 
 import {Test} from "@forge-std-1.9.6/Test.sol";
 
-import {Kernel, Actions, Keycode, toKeycode} from "src/Kernel.sol";
+import {Kernel, Actions} from "src/Kernel.sol";
 import {MockPeriodicTaskManager} from "src/test/bases/PeriodicTaskManager/MockPeriodicTaskManager.sol";
+import {ROLESv1} from "src/modules/ROLES/ROLES.v1.sol";
 import {OlympusRoles} from "src/modules/ROLES/OlympusRoles.sol";
 import {RolesAdmin} from "src/policies/RolesAdmin.sol";
+import {IPeriodicTaskManager} from "src/bases/interfaces/IPeriodicTaskManager.sol";
+import {MockPeriodicTask} from "src/test/bases/PeriodicTaskManager/MockPeriodicTask.sol";
+import {MockCustomPeriodicTask} from "src/test/bases/PeriodicTaskManager/MockCustomPeriodicTask.sol";
+import {AddressStorageArray} from "src/libraries/AddressStorageArray.sol";
 
 abstract contract PeriodicTaskManagerTest is Test {
     MockPeriodicTaskManager public periodicTaskManager;
@@ -17,16 +22,22 @@ abstract contract PeriodicTaskManagerTest is Test {
     address public OWNER;
     address public ADMIN;
 
+    MockPeriodicTask public periodicTaskA;
+    MockPeriodicTask public periodicTaskB;
+    MockPeriodicTask public periodicTaskC;
+    MockCustomPeriodicTask public customPeriodicTask;
+
     function setUp() public {
         OWNER = makeAddr("OWNER");
         ADMIN = makeAddr("ADMIN");
 
-        vm.prank(OWNER);
+        vm.startPrank(OWNER);
         kernel = new Kernel();
 
         ROLES = new OlympusRoles(kernel);
         rolesAdmin = new RolesAdmin(kernel);
         periodicTaskManager = new MockPeriodicTaskManager(kernel);
+        vm.stopPrank();
 
         // Install contracts
         vm.startPrank(OWNER);
@@ -39,5 +50,110 @@ abstract contract PeriodicTaskManagerTest is Test {
         vm.startPrank(OWNER);
         rolesAdmin.grantRole(bytes32("admin"), ADMIN);
         vm.stopPrank();
+
+        periodicTaskA = new MockPeriodicTask();
+        periodicTaskB = new MockPeriodicTask();
+        periodicTaskC = new MockPeriodicTask();
+        customPeriodicTask = new MockCustomPeriodicTask();
+    }
+
+    modifier givenPeriodicTaskIsAdded(address task_) {
+        vm.prank(ADMIN);
+        periodicTaskManager.addPeriodicTask(task_);
+        _;
+    }
+
+    modifier givenCustomPeriodicTaskIsAdded(address task_) {
+        uint256 taskCount = periodicTaskManager.getPeriodicTaskCount();
+
+        vm.prank(ADMIN);
+        periodicTaskManager.addPeriodicTaskAtIndex(
+            task_,
+            MockCustomPeriodicTask.customExecute.selector,
+            taskCount
+        );
+        _;
+    }
+
+    function _expectRevertNotAdmin() internal {
+        vm.expectRevert(
+            abi.encodeWithSelector(ROLESv1.ROLES_RequireRole.selector, bytes32("admin"))
+        );
+    }
+
+    function _expectRevertZeroAddress() internal {
+        vm.expectRevert(
+            abi.encodeWithSelector(IPeriodicTaskManager.PeriodicTaskManager_ZeroAddress.selector)
+        );
+    }
+
+    function _expectRevertIndexOutOfBounds(uint256 index_, uint256 length_) internal {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AddressStorageArray.AddressStorageArray_IndexOutOfBounds.selector,
+                index_,
+                length_
+            )
+        );
+    }
+
+    function _expectRevertTaskAlreadyExists(address task_) internal {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPeriodicTaskManager.PeriodicTaskManager_TaskAlreadyExists.selector,
+                task_
+            )
+        );
+    }
+
+    function _expectRevertTaskNotFound(address task_) internal {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPeriodicTaskManager.PeriodicTaskManager_TaskNotFound.selector,
+                task_
+            )
+        );
+    }
+
+    function _expectRevertNotPeriodicTask(address task_) internal {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPeriodicTaskManager.PeriodicTaskManager_NotPeriodicTask.selector,
+                task_
+            )
+        );
+    }
+
+    function _assertPeriodicTasks(
+        address[] memory tasks_,
+        bytes4[] memory customSelectors_
+    ) internal view {
+        assertEq(periodicTaskManager.getPeriodicTaskCount(), tasks_.length, "periodicTaskCount");
+
+        // Compare index by index
+        for (uint256 i = 0; i < tasks_.length; i++) {
+            (address task, bytes4 customSelector) = periodicTaskManager.getPeriodicTaskAtIndex(i);
+            assertEq(task, tasks_[i], string.concat("atIndex tasks[", vm.toString(i), "]"));
+            assertEq(
+                customSelector,
+                customSelectors_[i],
+                string.concat("atIndex customSelectors[", vm.toString(i), "]")
+            );
+        }
+
+        // Compare the full array
+        (address[] memory tasks, bytes4[] memory customSelectors) = periodicTaskManager
+            .getPeriodicTasks();
+        for (uint256 i = 0; i < tasks_.length; i++) {
+            assertEq(tasks[i], tasks_[i], string.concat("tasks[", vm.toString(i), "]"));
+            assertEq(
+                customSelectors[i],
+                customSelectors_[i],
+                string.concat("customSelectors[", vm.toString(i), "]")
+            );
+        }
+
+        assertEq(tasks.length, tasks_.length, "tasks.length");
+        assertEq(customSelectors.length, customSelectors_.length, "customSelectors.length");
     }
 }

--- a/src/test/bases/PeriodicTaskManager/PeriodicTaskManagerTest.sol
+++ b/src/test/bases/PeriodicTaskManager/PeriodicTaskManagerTest.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.15;
+
+import {Test} from "@forge-std-1.9.6/Test.sol";
+
+import {Kernel, Actions, Keycode, toKeycode} from "src/Kernel.sol";
+import {MockPeriodicTaskManager} from "src/test/bases/PeriodicTaskManager/MockPeriodicTaskManager.sol";
+import {OlympusRoles} from "src/modules/ROLES/OlympusRoles.sol";
+import {RolesAdmin} from "src/policies/RolesAdmin.sol";
+
+abstract contract PeriodicTaskManagerTest is Test {
+    MockPeriodicTaskManager public periodicTaskManager;
+    Kernel public kernel;
+    OlympusRoles public ROLES;
+    RolesAdmin public rolesAdmin;
+
+    address public OWNER;
+    address public ADMIN;
+
+    function setUp() public {
+        OWNER = makeAddr("OWNER");
+        ADMIN = makeAddr("ADMIN");
+
+        vm.prank(OWNER);
+        kernel = new Kernel();
+
+        ROLES = new OlympusRoles(kernel);
+        rolesAdmin = new RolesAdmin(kernel);
+        periodicTaskManager = new MockPeriodicTaskManager(kernel);
+
+        // Install contracts
+        vm.startPrank(OWNER);
+        kernel.executeAction(Actions.InstallModule, address(ROLES));
+        kernel.executeAction(Actions.ActivatePolicy, address(rolesAdmin));
+        kernel.executeAction(Actions.ActivatePolicy, address(periodicTaskManager));
+        vm.stopPrank();
+
+        // Grant permissions
+        vm.startPrank(OWNER);
+        rolesAdmin.grantRole(bytes32("admin"), ADMIN);
+        vm.stopPrank();
+    }
+}

--- a/src/test/bases/PeriodicTaskManager/addPeriodicTask.t.sol
+++ b/src/test/bases/PeriodicTaskManager/addPeriodicTask.t.sol
@@ -1,25 +1,85 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.15;
 
-import {Test} from "@forge-std-1.9.6/Test.sol";
-
 import {PeriodicTaskManagerTest} from "src/test/bases/PeriodicTaskManager/PeriodicTaskManagerTest.sol";
 
 contract PeriodicTaskManagerAddPeriodicTaskTest is PeriodicTaskManagerTest {
     // ========== TESTS ========== //
     // given the caller is not the admin
-    //  [ ] it reverts
+    //  [X] it reverts
+
+    function test_givenCallerNotAdmin_reverts() public {
+        _expectRevertNotAdmin();
+
+        vm.prank(OWNER);
+        periodicTaskManager.addPeriodicTask(address(periodicTaskA));
+    }
+
     // when the task address is zero
-    //  [ ] it reverts
+    //  [X] it reverts
+
+    function test_givenTaskAddressIsZero_reverts() public {
+        _expectRevertZeroAddress();
+
+        vm.prank(ADMIN);
+        periodicTaskManager.addPeriodicTask(address(0));
+    }
+
     // given the task is already added
-    //  [ ] it reverts
+    //  [X] it reverts
+
+    function test_givenTaskIsAlreadyAdded_reverts()
+        public
+        givenPeriodicTaskIsAdded(address(periodicTaskA))
+    {
+        _expectRevertTaskAlreadyExists(address(periodicTaskA));
+
+        vm.prank(ADMIN);
+        periodicTaskManager.addPeriodicTask(address(periodicTaskA));
+    }
+
     // given the task does not implement the IPeriodicTask interface
-    //  [ ] it reverts
+    //  [X] it reverts
+
+    function test_givenNotPeriodicTask_reverts() public {
+        _expectRevertNotPeriodicTask(address(customPeriodicTask));
+
+        vm.prank(ADMIN);
+        periodicTaskManager.addPeriodicTask(address(customPeriodicTask));
+    }
+
     // given there are no tasks in the manager
-    //  [ ] it inserts the task at index 0
-    //  [ ] the array length is 1
-    //  [ ] the custom selector for the task is 0
-    // [ ] it inserts the task at the next index
-    // [ ] the array length is incremented
-    // [ ] the custom selector for the task is 0
+    //  [X] it inserts the task at index 0
+    //  [X] the array length is 1
+    //  [X] the custom selector for the task is 0
+
+    function test_givenNoTasks() public {
+        address[] memory expectedTasks = new address[](1);
+        expectedTasks[0] = address(periodicTaskA);
+        bytes4[] memory expectedCustomSelectors = new bytes4[](1);
+        expectedCustomSelectors[0] = bytes4(0);
+
+        vm.prank(ADMIN);
+        periodicTaskManager.addPeriodicTask(address(periodicTaskA));
+
+        _assertPeriodicTasks(expectedTasks, expectedCustomSelectors);
+    }
+
+    // [X] it inserts the task at the next index
+    // [X] the array length is incremented
+    // [X] the custom selector for the task is 0
+
+    function test_givenTasks() public givenPeriodicTaskIsAdded(address(periodicTaskA)) {
+        address[] memory expectedTasks = new address[](2);
+        expectedTasks[0] = address(periodicTaskA);
+        expectedTasks[1] = address(periodicTaskB);
+        bytes4[] memory expectedCustomSelectors = new bytes4[](2);
+        expectedCustomSelectors[0] = bytes4(0);
+        expectedCustomSelectors[1] = bytes4(0);
+
+        vm.prank(ADMIN);
+        periodicTaskManager.addPeriodicTask(address(periodicTaskB));
+
+        _assertPeriodicTasks(expectedTasks, expectedCustomSelectors);
+    }
 }

--- a/src/test/bases/PeriodicTaskManager/addPeriodicTask.t.sol
+++ b/src/test/bases/PeriodicTaskManager/addPeriodicTask.t.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.15;
+
+import {Test} from "@forge-std-1.9.6/Test.sol";
+
+import {PeriodicTaskManagerTest} from "src/test/bases/PeriodicTaskManager/PeriodicTaskManagerTest.sol";
+
+contract PeriodicTaskManagerAddPeriodicTaskTest is PeriodicTaskManagerTest {
+    // ========== TESTS ========== //
+    // given the caller is not the admin
+    //  [ ] it reverts
+    // when the task address is zero
+    //  [ ] it reverts
+    // given the task is already added
+    //  [ ] it reverts
+    // given the task does not implement the IPeriodicTask interface
+    //  [ ] it reverts
+    // given there are no tasks in the manager
+    //  [ ] it inserts the task at index 0
+    //  [ ] the array length is 1
+    //  [ ] the custom selector for the task is 0
+    // [ ] it inserts the task at the next index
+    // [ ] the array length is incremented
+    // [ ] the custom selector for the task is 0
+}

--- a/src/test/bases/PeriodicTaskManager/addPeriodicTaskAtIndex.t.sol
+++ b/src/test/bases/PeriodicTaskManager/addPeriodicTaskAtIndex.t.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.15;
+
+import {Test} from "@forge-std-1.9.6/Test.sol";
+
+import {PeriodicTaskManagerTest} from "src/test/bases/PeriodicTaskManager/PeriodicTaskManagerTest.sol";
+
+contract PeriodicTaskManagerAddPeriodicTaskAtIndexTest is PeriodicTaskManagerTest {
+    // ========== TESTS ========== //
+    // given the caller is not the admin
+    //  [ ] it reverts
+    // when the task address is zero
+    //  [ ] it reverts
+    // given the index is greater than the array length
+    //  [ ] it reverts
+    // when the custom selector is not 0
+    //  given the task is already added
+    //   [ ] it reverts
+    //  [ ] it inserts the task at the index
+    //  [ ] the array length is incremented
+    //  [ ] the elements after the index are shifted to the right
+    //  [ ] the custom selector for the task is the custom selector parameter
+    // given the task does not implement the IPeriodicTask interface
+    //  [ ] it reverts
+    // given the task is already added
+    //  [ ] it reverts
+    // [ ] it inserts the task at the index
+    // [ ] the array length is incremented
+    // [ ] the elements after the index are shifted to the right
+    // [ ] the custom selector for the task is 0
+}

--- a/src/test/bases/PeriodicTaskManager/addPeriodicTaskAtIndex.t.sol
+++ b/src/test/bases/PeriodicTaskManager/addPeriodicTaskAtIndex.t.sol
@@ -1,31 +1,339 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.15;
 
-import {Test} from "@forge-std-1.9.6/Test.sol";
-
 import {PeriodicTaskManagerTest} from "src/test/bases/PeriodicTaskManager/PeriodicTaskManagerTest.sol";
+import {MockCustomPeriodicTask} from "src/test/bases/PeriodicTaskManager/MockCustomPeriodicTask.sol";
 
 contract PeriodicTaskManagerAddPeriodicTaskAtIndexTest is PeriodicTaskManagerTest {
     // ========== TESTS ========== //
     // given the caller is not the admin
-    //  [ ] it reverts
+    //  [X] it reverts
+
+    function test_givenCallerNotAdmin_reverts() public {
+        _expectRevertNotAdmin();
+
+        vm.prank(OWNER);
+        periodicTaskManager.addPeriodicTaskAtIndex(address(periodicTaskA), bytes4(0), 0);
+    }
+
     // when the task address is zero
-    //  [ ] it reverts
+    //  [X] it reverts
+
+    function test_givenTaskAddressIsZero_reverts() public {
+        _expectRevertZeroAddress();
+
+        vm.prank(ADMIN);
+        periodicTaskManager.addPeriodicTaskAtIndex(address(0), bytes4(0), 0);
+    }
+
     // given the index is greater than the array length
-    //  [ ] it reverts
+    //  [X] it reverts
+
+    function test_givenIndexIsGreaterThanArrayLength_reverts(
+        uint256 tasksCount_,
+        uint256 index_
+    ) public {
+        tasksCount_ = bound(tasksCount_, 0, 1);
+        index_ = bound(index_, tasksCount_ + 1, type(uint256).max);
+
+        // Insert any required tasks
+        if (tasksCount_ > 0) {
+            vm.prank(ADMIN);
+            periodicTaskManager.addPeriodicTask(address(periodicTaskA));
+        }
+
+        _expectRevertIndexOutOfBounds(index_, tasksCount_);
+
+        vm.prank(ADMIN);
+        periodicTaskManager.addPeriodicTaskAtIndex(address(periodicTaskB), bytes4(0), index_);
+    }
+
     // when the custom selector is not 0
     //  given the task is already added
-    //   [ ] it reverts
-    //  [ ] it inserts the task at the index
-    //  [ ] the array length is incremented
-    //  [ ] the elements after the index are shifted to the right
-    //  [ ] the custom selector for the task is the custom selector parameter
+    //   [X] it reverts
+
+    function test_customSelectorNotZero_givenTaskAlreadyAdded_reverts()
+        public
+        givenCustomPeriodicTaskIsAdded(address(customPeriodicTask))
+    {
+        _expectRevertTaskAlreadyExists(address(customPeriodicTask));
+
+        vm.prank(ADMIN);
+        periodicTaskManager.addPeriodicTaskAtIndex(
+            address(customPeriodicTask),
+            MockCustomPeriodicTask.customExecute.selector,
+            1
+        );
+    }
+
+    //  given there are no tasks
+    //   [X] it inserts the task at the first index
+    //   [X] the array length is incremented
+    //   [X] the custom selector for the task is the custom selector parameter
+
+    function test_customSelectorNotZero_givenNoTasks() public {
+        address[] memory expectedTasks = new address[](1);
+        expectedTasks[0] = address(customPeriodicTask);
+        bytes4[] memory expectedCustomSelectors = new bytes4[](1);
+        expectedCustomSelectors[0] = MockCustomPeriodicTask.customExecute.selector;
+
+        vm.prank(ADMIN);
+        periodicTaskManager.addPeriodicTaskAtIndex(
+            address(customPeriodicTask),
+            MockCustomPeriodicTask.customExecute.selector,
+            0
+        );
+
+        _assertPeriodicTasks(expectedTasks, expectedCustomSelectors);
+    }
+
+    //  [X] it inserts the task at the index
+    //  [X] the array length is incremented
+    //  [X] the elements after the index are shifted to the right
+    //  [X] the custom selector for the task is the custom selector parameter
+
+    function test_customSelectorNotZero_indexZero()
+        public
+        givenPeriodicTaskIsAdded(address(periodicTaskA))
+        givenPeriodicTaskIsAdded(address(periodicTaskB))
+        givenPeriodicTaskIsAdded(address(periodicTaskC))
+    {
+        address[] memory expectedTasks = new address[](4);
+        expectedTasks[0] = address(customPeriodicTask);
+        expectedTasks[1] = address(periodicTaskA);
+        expectedTasks[2] = address(periodicTaskB);
+        expectedTasks[3] = address(periodicTaskC);
+        bytes4[] memory expectedCustomSelectors = new bytes4[](4);
+        expectedCustomSelectors[0] = MockCustomPeriodicTask.customExecute.selector;
+        expectedCustomSelectors[1] = bytes4(0);
+        expectedCustomSelectors[2] = bytes4(0);
+        expectedCustomSelectors[3] = bytes4(0);
+
+        vm.prank(ADMIN);
+        periodicTaskManager.addPeriodicTaskAtIndex(
+            address(customPeriodicTask),
+            MockCustomPeriodicTask.customExecute.selector,
+            0
+        );
+
+        _assertPeriodicTasks(expectedTasks, expectedCustomSelectors);
+    }
+
+    function test_customSelectorNotZero_indexOne()
+        public
+        givenPeriodicTaskIsAdded(address(periodicTaskA))
+        givenPeriodicTaskIsAdded(address(periodicTaskB))
+        givenPeriodicTaskIsAdded(address(periodicTaskC))
+    {
+        address[] memory expectedTasks = new address[](4);
+        expectedTasks[0] = address(periodicTaskA);
+        expectedTasks[1] = address(customPeriodicTask);
+        expectedTasks[2] = address(periodicTaskB);
+        expectedTasks[3] = address(periodicTaskC);
+        bytes4[] memory expectedCustomSelectors = new bytes4[](4);
+        expectedCustomSelectors[0] = bytes4(0);
+        expectedCustomSelectors[1] = MockCustomPeriodicTask.customExecute.selector;
+        expectedCustomSelectors[2] = bytes4(0);
+        expectedCustomSelectors[3] = bytes4(0);
+
+        vm.prank(ADMIN);
+        periodicTaskManager.addPeriodicTaskAtIndex(
+            address(customPeriodicTask),
+            MockCustomPeriodicTask.customExecute.selector,
+            1
+        );
+
+        _assertPeriodicTasks(expectedTasks, expectedCustomSelectors);
+    }
+
+    function test_customSelectorNotZero_indexTwo()
+        public
+        givenPeriodicTaskIsAdded(address(periodicTaskA))
+        givenPeriodicTaskIsAdded(address(periodicTaskB))
+        givenPeriodicTaskIsAdded(address(periodicTaskC))
+    {
+        address[] memory expectedTasks = new address[](4);
+        expectedTasks[0] = address(periodicTaskA);
+        expectedTasks[1] = address(periodicTaskB);
+        expectedTasks[2] = address(customPeriodicTask);
+        expectedTasks[3] = address(periodicTaskC);
+        bytes4[] memory expectedCustomSelectors = new bytes4[](4);
+        expectedCustomSelectors[0] = bytes4(0);
+        expectedCustomSelectors[1] = bytes4(0);
+        expectedCustomSelectors[2] = MockCustomPeriodicTask.customExecute.selector;
+        expectedCustomSelectors[3] = bytes4(0);
+
+        vm.prank(ADMIN);
+        periodicTaskManager.addPeriodicTaskAtIndex(
+            address(customPeriodicTask),
+            MockCustomPeriodicTask.customExecute.selector,
+            2
+        );
+
+        _assertPeriodicTasks(expectedTasks, expectedCustomSelectors);
+    }
+
+    function test_customSelectorNotZero_indexThree()
+        public
+        givenPeriodicTaskIsAdded(address(periodicTaskA))
+        givenPeriodicTaskIsAdded(address(periodicTaskB))
+        givenPeriodicTaskIsAdded(address(periodicTaskC))
+    {
+        address[] memory expectedTasks = new address[](4);
+        expectedTasks[0] = address(periodicTaskA);
+        expectedTasks[1] = address(periodicTaskB);
+        expectedTasks[2] = address(periodicTaskC);
+        expectedTasks[3] = address(customPeriodicTask);
+        bytes4[] memory expectedCustomSelectors = new bytes4[](4);
+        expectedCustomSelectors[0] = bytes4(0);
+        expectedCustomSelectors[1] = bytes4(0);
+        expectedCustomSelectors[2] = bytes4(0);
+        expectedCustomSelectors[3] = MockCustomPeriodicTask.customExecute.selector;
+
+        vm.prank(ADMIN);
+        periodicTaskManager.addPeriodicTaskAtIndex(
+            address(customPeriodicTask),
+            MockCustomPeriodicTask.customExecute.selector,
+            3
+        );
+
+        _assertPeriodicTasks(expectedTasks, expectedCustomSelectors);
+    }
+
     // given the task does not implement the IPeriodicTask interface
-    //  [ ] it reverts
+    //  [X] it reverts
+
+    function test_givenTaskDoesNotImplementInterface_reverts() public {
+        _expectRevertNotPeriodicTask(address(customPeriodicTask));
+
+        vm.prank(ADMIN);
+        periodicTaskManager.addPeriodicTaskAtIndex(address(customPeriodicTask), bytes4(0), 0);
+    }
+
     // given the task is already added
-    //  [ ] it reverts
-    // [ ] it inserts the task at the index
-    // [ ] the array length is incremented
-    // [ ] the elements after the index are shifted to the right
-    // [ ] the custom selector for the task is 0
+    //  [X] it reverts
+
+    function test_givenTaskIsAlreadyAdded_reverts()
+        public
+        givenPeriodicTaskIsAdded(address(periodicTaskA))
+    {
+        _expectRevertTaskAlreadyExists(address(periodicTaskA));
+
+        vm.prank(ADMIN);
+        periodicTaskManager.addPeriodicTaskAtIndex(address(periodicTaskA), bytes4(0), 0);
+    }
+
+    // given there are no tasks
+    //  [X] it inserts the task at the first index
+    //  [X] the array length is incremented
+    //  [X] the custom selector for the task is 0
+
+    function test_givenNoTasks() public {
+        address[] memory expectedTasks = new address[](1);
+        expectedTasks[0] = address(periodicTaskA);
+        bytes4[] memory expectedCustomSelectors = new bytes4[](1);
+        expectedCustomSelectors[0] = bytes4(0);
+
+        vm.prank(ADMIN);
+        periodicTaskManager.addPeriodicTaskAtIndex(address(periodicTaskA), bytes4(0), 0);
+
+        _assertPeriodicTasks(expectedTasks, expectedCustomSelectors);
+    }
+
+    // [X] it inserts the task at the index
+    // [X] the array length is incremented
+    // [X] the elements after the index are shifted to the right
+    // [X] the custom selector for the task is 0
+
+    function test_indexZero()
+        public
+        givenPeriodicTaskIsAdded(address(periodicTaskA))
+        givenPeriodicTaskIsAdded(address(periodicTaskB))
+        givenCustomPeriodicTaskIsAdded(address(customPeriodicTask))
+    {
+        address[] memory expectedTasks = new address[](4);
+        expectedTasks[0] = address(periodicTaskC);
+        expectedTasks[1] = address(periodicTaskA);
+        expectedTasks[2] = address(periodicTaskB);
+        expectedTasks[3] = address(customPeriodicTask);
+        bytes4[] memory expectedCustomSelectors = new bytes4[](4);
+        expectedCustomSelectors[0] = bytes4(0);
+        expectedCustomSelectors[1] = bytes4(0);
+        expectedCustomSelectors[2] = bytes4(0);
+        expectedCustomSelectors[3] = MockCustomPeriodicTask.customExecute.selector;
+
+        vm.prank(ADMIN);
+        periodicTaskManager.addPeriodicTaskAtIndex(address(periodicTaskC), bytes4(0), 0);
+
+        _assertPeriodicTasks(expectedTasks, expectedCustomSelectors);
+    }
+
+    function test_indexOne()
+        public
+        givenPeriodicTaskIsAdded(address(periodicTaskA))
+        givenPeriodicTaskIsAdded(address(periodicTaskB))
+        givenCustomPeriodicTaskIsAdded(address(customPeriodicTask))
+    {
+        address[] memory expectedTasks = new address[](4);
+        expectedTasks[0] = address(periodicTaskA);
+        expectedTasks[1] = address(periodicTaskC);
+        expectedTasks[2] = address(periodicTaskB);
+        expectedTasks[3] = address(customPeriodicTask);
+        bytes4[] memory expectedCustomSelectors = new bytes4[](4);
+        expectedCustomSelectors[0] = bytes4(0);
+        expectedCustomSelectors[1] = bytes4(0);
+        expectedCustomSelectors[2] = bytes4(0);
+        expectedCustomSelectors[3] = MockCustomPeriodicTask.customExecute.selector;
+
+        vm.prank(ADMIN);
+        periodicTaskManager.addPeriodicTaskAtIndex(address(periodicTaskC), bytes4(0), 1);
+
+        _assertPeriodicTasks(expectedTasks, expectedCustomSelectors);
+    }
+
+    function test_indexTwo()
+        public
+        givenPeriodicTaskIsAdded(address(periodicTaskA))
+        givenPeriodicTaskIsAdded(address(periodicTaskB))
+        givenCustomPeriodicTaskIsAdded(address(customPeriodicTask))
+    {
+        address[] memory expectedTasks = new address[](4);
+        expectedTasks[0] = address(periodicTaskA);
+        expectedTasks[1] = address(periodicTaskB);
+        expectedTasks[2] = address(periodicTaskC);
+        expectedTasks[3] = address(customPeriodicTask);
+        bytes4[] memory expectedCustomSelectors = new bytes4[](4);
+        expectedCustomSelectors[0] = bytes4(0);
+        expectedCustomSelectors[1] = bytes4(0);
+        expectedCustomSelectors[2] = bytes4(0);
+        expectedCustomSelectors[3] = MockCustomPeriodicTask.customExecute.selector;
+
+        vm.prank(ADMIN);
+        periodicTaskManager.addPeriodicTaskAtIndex(address(periodicTaskC), bytes4(0), 2);
+
+        _assertPeriodicTasks(expectedTasks, expectedCustomSelectors);
+    }
+
+    function test_indexThree()
+        public
+        givenPeriodicTaskIsAdded(address(periodicTaskA))
+        givenPeriodicTaskIsAdded(address(periodicTaskB))
+        givenCustomPeriodicTaskIsAdded(address(customPeriodicTask))
+    {
+        address[] memory expectedTasks = new address[](4);
+        expectedTasks[0] = address(periodicTaskA);
+        expectedTasks[1] = address(periodicTaskB);
+        expectedTasks[2] = address(customPeriodicTask);
+        expectedTasks[3] = address(periodicTaskC);
+        bytes4[] memory expectedCustomSelectors = new bytes4[](4);
+        expectedCustomSelectors[0] = bytes4(0);
+        expectedCustomSelectors[1] = bytes4(0);
+        expectedCustomSelectors[2] = MockCustomPeriodicTask.customExecute.selector;
+        expectedCustomSelectors[3] = bytes4(0);
+
+        vm.prank(ADMIN);
+        periodicTaskManager.addPeriodicTaskAtIndex(address(periodicTaskC), bytes4(0), 3);
+
+        _assertPeriodicTasks(expectedTasks, expectedCustomSelectors);
+    }
 }

--- a/src/test/bases/PeriodicTaskManager/execute.t.sol
+++ b/src/test/bases/PeriodicTaskManager/execute.t.sol
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.15;
+
+import {PeriodicTaskManagerTest} from "src/test/bases/PeriodicTaskManager/PeriodicTaskManagerTest.sol";
+import {MockPeriodicTask} from "src/test/bases/PeriodicTaskManager/MockPeriodicTask.sol";
+import {MockCustomPeriodicTask} from "src/test/bases/PeriodicTaskManager/MockCustomPeriodicTask.sol";
+import {IPeriodicTaskManager} from "src/bases/interfaces/IPeriodicTaskManager.sol";
+import {IPeriodicTask} from "src/interfaces/IPeriodicTask.sol";
+
+contract PeriodicTaskManagerExecuteTest is PeriodicTaskManagerTest {
+    // ========== TESTS ========== //
+    // given there are no tasks
+    //  [X] it does nothing
+
+    function test_givenNoTasks() public {
+        // Execute the periodic tasks
+        periodicTaskManager.executeAllTasks();
+
+        // Assert that the periodic tasks were not executed
+        assertEq(periodicTaskA.count(), 0, "periodicTaskA.count");
+        assertEq(periodicTaskB.count(), 0, "periodicTaskB.count");
+        assertEq(periodicTaskC.count(), 0, "periodicTaskC.count");
+        assertEq(customPeriodicTask.count(), 0, "customPeriodicTask.count");
+    }
+
+    // given a standard periodic task reverts
+    //  [X] it reverts
+
+    function test_givenPeriodicTaskReverts_reverts()
+        public
+        givenPeriodicTaskIsAdded(address(periodicTaskA))
+        givenPeriodicTaskIsAdded(address(periodicTaskB))
+        givenPeriodicTaskIsAdded(address(periodicTaskC))
+        givenCustomPeriodicTaskIsAdded(address(customPeriodicTask))
+    {
+        // Set the revert flag for the periodic task
+        periodicTaskA.setRevert(true);
+
+        // Expect revert
+        vm.expectRevert(abi.encodeWithSelector(MockPeriodicTask.MockPeriodicTask_Revert.selector));
+
+        // Execute the periodic tasks
+        periodicTaskManager.executeAllTasks();
+    }
+
+    // given a custom periodic tasks reverts
+    //  [X] it reverts
+
+    function test_givenCustomPeriodicTaskReverts_reverts()
+        public
+        givenPeriodicTaskIsAdded(address(periodicTaskA))
+        givenPeriodicTaskIsAdded(address(periodicTaskB))
+        givenPeriodicTaskIsAdded(address(periodicTaskC))
+        givenCustomPeriodicTaskIsAdded(address(customPeriodicTask))
+    {
+        // Set the revert flag for the periodic task
+        customPeriodicTask.setRevert(true);
+
+        // Expect revert
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPeriodicTaskManager.PeriodicTaskManager_CustomSelectorFailed.selector,
+                address(customPeriodicTask),
+                MockCustomPeriodicTask.customExecute.selector,
+                abi.encodeWithSelector(
+                    MockCustomPeriodicTask.MockCustomPeriodicTask_Revert.selector
+                )
+            )
+        );
+
+        // Execute the periodic tasks
+        periodicTaskManager.executeAllTasks();
+    }
+
+    // given the custom selector is not implemented
+    //  [X] it reverts
+
+    function test_givenCustomSelectorIsNotImplemented_reverts()
+        public
+        givenPeriodicTaskIsAdded(address(periodicTaskA))
+        givenPeriodicTaskIsAdded(address(periodicTaskB))
+        givenPeriodicTaskIsAdded(address(periodicTaskC))
+    {
+        // Add a custom periodic task with a non-existent selector
+        vm.prank(ADMIN);
+        periodicTaskManager.addPeriodicTaskAtIndex(
+            address(customPeriodicTask),
+            IPeriodicTask.execute.selector,
+            3
+        );
+
+        // Expect revert
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPeriodicTaskManager.PeriodicTaskManager_CustomSelectorFailed.selector,
+                address(customPeriodicTask),
+                IPeriodicTask.execute.selector,
+                ""
+            )
+        );
+
+        // Execute the periodic tasks
+        periodicTaskManager.executeAllTasks();
+    }
+
+    // [X] it runs the periodic tasks
+
+    function test_success()
+        public
+        givenPeriodicTaskIsAdded(address(periodicTaskA))
+        givenPeriodicTaskIsAdded(address(periodicTaskB))
+        givenPeriodicTaskIsAdded(address(periodicTaskC))
+        givenCustomPeriodicTaskIsAdded(address(customPeriodicTask))
+    {
+        // Execute the periodic tasks
+        periodicTaskManager.executeAllTasks();
+
+        // Assert that the periodic tasks were not executed
+        assertEq(periodicTaskA.count(), 1, "periodicTaskA.count");
+        assertEq(periodicTaskB.count(), 1, "periodicTaskB.count");
+        assertEq(periodicTaskC.count(), 1, "periodicTaskC.count");
+        assertEq(customPeriodicTask.count(), 1, "customPeriodicTask.count");
+    }
+}

--- a/src/test/bases/PeriodicTaskManager/removePeriodicTask.t.sol
+++ b/src/test/bases/PeriodicTaskManager/removePeriodicTask.t.sol
@@ -1,23 +1,200 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.15;
 
-import {Test} from "@forge-std-1.9.6/Test.sol";
-
 import {PeriodicTaskManagerTest} from "src/test/bases/PeriodicTaskManager/PeriodicTaskManagerTest.sol";
+import {MockCustomPeriodicTask} from "src/test/bases/PeriodicTaskManager/MockCustomPeriodicTask.sol";
 
 contract PeriodicTaskManagerRemovePeriodicTaskTest is PeriodicTaskManagerTest {
     // ========== TESTS ========== //
     // given the caller is not the admin
-    //  [ ] it reverts
+    //  [X] it reverts
+
+    function test_givenCallerIsNotAdmin_reverts() public {
+        _expectRevertNotAdmin();
+
+        vm.prank(OWNER);
+        periodicTaskManager.removePeriodicTask(address(periodicTaskA));
+    }
+
     // given the task is not added
-    //  [ ] it reverts
+    //  [X] it reverts
+
+    function test_givenTaskIsNotAdded_reverts() public {
+        _expectRevertTaskNotFound(address(periodicTaskA));
+
+        vm.prank(ADMIN);
+        periodicTaskManager.removePeriodicTask(address(periodicTaskA));
+    }
+
     // given the task has a custom selector
-    //  [ ] it removes the task
-    //  [ ] the array length is decremented
-    //  [ ] the elements after the index are shifted to the left
-    //  [ ] the custom selector for the task is cleared
-    // [ ] it removes the task
-    // [ ] the array length is decremented
-    // [ ] the elements after the index are shifted to the left
-    // [ ] the custom selector for the task is cleared
+    //  [X] it removes the task
+    //  [X] the array length is decremented
+    //  [X] the elements after the index are shifted to the left
+    //  [X] the custom selector for the task is removed
+
+    function test_givenCustomSelectorTask_indexZero()
+        public
+        givenCustomPeriodicTaskIsAdded(address(customPeriodicTask))
+        givenPeriodicTaskIsAdded(address(periodicTaskA))
+        givenPeriodicTaskIsAdded(address(periodicTaskB))
+        givenPeriodicTaskIsAdded(address(periodicTaskC))
+    {
+        address[] memory expectedTasks = new address[](3);
+        expectedTasks[0] = address(periodicTaskA);
+        expectedTasks[1] = address(periodicTaskB);
+        expectedTasks[2] = address(periodicTaskC);
+
+        bytes4[] memory expectedCustomSelectors = new bytes4[](3);
+        expectedCustomSelectors[0] = bytes4(0);
+        expectedCustomSelectors[1] = bytes4(0);
+        expectedCustomSelectors[2] = bytes4(0);
+
+        vm.prank(ADMIN);
+        periodicTaskManager.removePeriodicTask(address(customPeriodicTask));
+
+        _assertPeriodicTasks(expectedTasks, expectedCustomSelectors);
+    }
+
+    function test_givenCustomSelectorTask_indexOne()
+        public
+        givenPeriodicTaskIsAdded(address(periodicTaskA))
+        givenCustomPeriodicTaskIsAdded(address(customPeriodicTask))
+        givenPeriodicTaskIsAdded(address(periodicTaskB))
+        givenPeriodicTaskIsAdded(address(periodicTaskC))
+    {
+        address[] memory expectedTasks = new address[](3);
+        expectedTasks[0] = address(periodicTaskA);
+        expectedTasks[1] = address(periodicTaskB);
+        expectedTasks[2] = address(periodicTaskC);
+
+        bytes4[] memory expectedCustomSelectors = new bytes4[](3);
+        expectedCustomSelectors[0] = bytes4(0);
+        expectedCustomSelectors[1] = bytes4(0);
+        expectedCustomSelectors[2] = bytes4(0);
+
+        vm.prank(ADMIN);
+        periodicTaskManager.removePeriodicTask(address(customPeriodicTask));
+
+        _assertPeriodicTasks(expectedTasks, expectedCustomSelectors);
+    }
+
+    function test_givenCustomSelectorTask_indexTwo()
+        public
+        givenPeriodicTaskIsAdded(address(periodicTaskA))
+        givenPeriodicTaskIsAdded(address(periodicTaskB))
+        givenCustomPeriodicTaskIsAdded(address(customPeriodicTask))
+        givenPeriodicTaskIsAdded(address(periodicTaskC))
+    {
+        address[] memory expectedTasks = new address[](3);
+        expectedTasks[0] = address(periodicTaskA);
+        expectedTasks[1] = address(periodicTaskB);
+        expectedTasks[2] = address(periodicTaskC);
+
+        bytes4[] memory expectedCustomSelectors = new bytes4[](3);
+        expectedCustomSelectors[0] = bytes4(0);
+        expectedCustomSelectors[1] = bytes4(0);
+        expectedCustomSelectors[2] = bytes4(0);
+
+        vm.prank(ADMIN);
+        periodicTaskManager.removePeriodicTask(address(customPeriodicTask));
+
+        _assertPeriodicTasks(expectedTasks, expectedCustomSelectors);
+    }
+
+    function test_givenCustomSelectorTask_indexThree()
+        public
+        givenPeriodicTaskIsAdded(address(periodicTaskA))
+        givenPeriodicTaskIsAdded(address(periodicTaskB))
+        givenPeriodicTaskIsAdded(address(periodicTaskC))
+        givenCustomPeriodicTaskIsAdded(address(customPeriodicTask))
+    {
+        address[] memory expectedTasks = new address[](3);
+        expectedTasks[0] = address(periodicTaskA);
+        expectedTasks[1] = address(periodicTaskB);
+        expectedTasks[2] = address(periodicTaskC);
+
+        bytes4[] memory expectedCustomSelectors = new bytes4[](3);
+        expectedCustomSelectors[0] = bytes4(0);
+        expectedCustomSelectors[1] = bytes4(0);
+        expectedCustomSelectors[2] = bytes4(0);
+
+        vm.prank(ADMIN);
+        periodicTaskManager.removePeriodicTask(address(customPeriodicTask));
+
+        _assertPeriodicTasks(expectedTasks, expectedCustomSelectors);
+    }
+
+    // [X] it removes the task
+    // [X] the array length is decremented
+    // [X] the elements after the index are shifted to the left
+    // [X] the custom selector for the task is cleared
+
+    function test_givenDifferentCustomSelectorTask_indexZero()
+        public
+        givenPeriodicTaskIsAdded(address(periodicTaskA))
+        givenPeriodicTaskIsAdded(address(periodicTaskB))
+        givenPeriodicTaskIsAdded(address(periodicTaskC))
+        givenCustomPeriodicTaskIsAdded(address(customPeriodicTask))
+    {
+        address[] memory expectedTasks = new address[](3);
+        expectedTasks[0] = address(periodicTaskB);
+        expectedTasks[1] = address(periodicTaskC);
+        expectedTasks[2] = address(customPeriodicTask);
+
+        bytes4[] memory expectedCustomSelectors = new bytes4[](3);
+        expectedCustomSelectors[0] = bytes4(0);
+        expectedCustomSelectors[1] = bytes4(0);
+        expectedCustomSelectors[2] = MockCustomPeriodicTask.customExecute.selector;
+
+        vm.prank(ADMIN);
+        periodicTaskManager.removePeriodicTask(address(periodicTaskA));
+
+        _assertPeriodicTasks(expectedTasks, expectedCustomSelectors);
+    }
+
+    function test_givenDifferentCustomSelectorTask_indexOne()
+        public
+        givenPeriodicTaskIsAdded(address(periodicTaskA))
+        givenPeriodicTaskIsAdded(address(periodicTaskB))
+        givenPeriodicTaskIsAdded(address(periodicTaskC))
+        givenCustomPeriodicTaskIsAdded(address(customPeriodicTask))
+    {
+        address[] memory expectedTasks = new address[](3);
+        expectedTasks[0] = address(periodicTaskA);
+        expectedTasks[1] = address(periodicTaskC);
+        expectedTasks[2] = address(customPeriodicTask);
+
+        bytes4[] memory expectedCustomSelectors = new bytes4[](3);
+        expectedCustomSelectors[0] = bytes4(0);
+        expectedCustomSelectors[1] = bytes4(0);
+        expectedCustomSelectors[2] = MockCustomPeriodicTask.customExecute.selector;
+
+        vm.prank(ADMIN);
+        periodicTaskManager.removePeriodicTask(address(periodicTaskB));
+
+        _assertPeriodicTasks(expectedTasks, expectedCustomSelectors);
+    }
+
+    function test_givenDifferentCustomSelectorTask_indexTwo()
+        public
+        givenPeriodicTaskIsAdded(address(periodicTaskA))
+        givenPeriodicTaskIsAdded(address(periodicTaskB))
+        givenPeriodicTaskIsAdded(address(periodicTaskC))
+        givenCustomPeriodicTaskIsAdded(address(customPeriodicTask))
+    {
+        address[] memory expectedTasks = new address[](3);
+        expectedTasks[0] = address(periodicTaskA);
+        expectedTasks[1] = address(periodicTaskB);
+        expectedTasks[2] = address(customPeriodicTask);
+
+        bytes4[] memory expectedCustomSelectors = new bytes4[](3);
+        expectedCustomSelectors[0] = bytes4(0);
+        expectedCustomSelectors[1] = bytes4(0);
+        expectedCustomSelectors[2] = MockCustomPeriodicTask.customExecute.selector;
+
+        vm.prank(ADMIN);
+        periodicTaskManager.removePeriodicTask(address(periodicTaskC));
+
+        _assertPeriodicTasks(expectedTasks, expectedCustomSelectors);
+    }
 }

--- a/src/test/bases/PeriodicTaskManager/removePeriodicTask.t.sol
+++ b/src/test/bases/PeriodicTaskManager/removePeriodicTask.t.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.15;
+
+import {Test} from "@forge-std-1.9.6/Test.sol";
+
+import {PeriodicTaskManagerTest} from "src/test/bases/PeriodicTaskManager/PeriodicTaskManagerTest.sol";
+
+contract PeriodicTaskManagerRemovePeriodicTaskTest is PeriodicTaskManagerTest {
+    // ========== TESTS ========== //
+    // given the caller is not the admin
+    //  [ ] it reverts
+    // given the task is not added
+    //  [ ] it reverts
+    // given the task has a custom selector
+    //  [ ] it removes the task
+    //  [ ] the array length is decremented
+    //  [ ] the elements after the index are shifted to the left
+    //  [ ] the custom selector for the task is cleared
+    // [ ] it removes the task
+    // [ ] the array length is decremented
+    // [ ] the elements after the index are shifted to the left
+    // [ ] the custom selector for the task is cleared
+}

--- a/src/test/bases/PeriodicTaskManager/removePeriodicTaskAtIndex.t.sol
+++ b/src/test/bases/PeriodicTaskManager/removePeriodicTaskAtIndex.t.sol
@@ -1,23 +1,206 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.15;
 
-import {Test} from "@forge-std-1.9.6/Test.sol";
-
 import {PeriodicTaskManagerTest} from "src/test/bases/PeriodicTaskManager/PeriodicTaskManagerTest.sol";
+import {MockCustomPeriodicTask} from "src/test/bases/PeriodicTaskManager/MockCustomPeriodicTask.sol";
 
 contract PeriodicTaskManagerRemovePeriodicTaskAtIndexTest is PeriodicTaskManagerTest {
     // ========== TESTS ========== //
     // given the caller is not the admin
-    //  [ ] it reverts
+    //  [X] it reverts
+
+    function test_givenCallerIsNotAdmin_reverts() public {
+        _expectRevertNotAdmin();
+
+        vm.prank(OWNER);
+        periodicTaskManager.removePeriodicTaskAtIndex(0);
+    }
+
     // given the index is out of bounds
-    //  [ ] it reverts
+    //  [X] it reverts
+
+    function test_givenIndexIsOutOfBounds_reverts(uint256 index_) public {
+        index_ = bound(index_, 1, type(uint256).max);
+
+        // Insert required tasks
+        vm.prank(ADMIN);
+        periodicTaskManager.addPeriodicTask(address(periodicTaskA));
+
+        _expectRevertIndexOutOfBounds(index_, 1);
+
+        vm.prank(ADMIN);
+        periodicTaskManager.removePeriodicTaskAtIndex(index_);
+    }
+
     // given the task has a custom selector
-    //  [ ] it removes the task
-    //  [ ] the array length is decremented
-    //  [ ] the elements after the index are shifted to the left
-    //  [ ] the custom selector for the task is cleared
-    // [ ] it removes the task
-    // [ ] the array length is decremented
-    // [ ] the elements after the index are shifted to the left
-    // [ ] the custom selector for the task is cleared
+    //  [X] it removes the task
+    //  [X] the array length is decremented
+    //  [X] the elements after the index are shifted to the left
+    //  [X] the custom selector for the task is cleared
+
+    function test_givenCustomSelectorTask_indexZero()
+        public
+        givenCustomPeriodicTaskIsAdded(address(customPeriodicTask))
+        givenPeriodicTaskIsAdded(address(periodicTaskA))
+        givenPeriodicTaskIsAdded(address(periodicTaskB))
+        givenPeriodicTaskIsAdded(address(periodicTaskC))
+    {
+        address[] memory expectedTasks = new address[](3);
+        expectedTasks[0] = address(periodicTaskA);
+        expectedTasks[1] = address(periodicTaskB);
+        expectedTasks[2] = address(periodicTaskC);
+
+        bytes4[] memory expectedCustomSelectors = new bytes4[](3);
+        expectedCustomSelectors[0] = bytes4(0);
+        expectedCustomSelectors[1] = bytes4(0);
+        expectedCustomSelectors[2] = bytes4(0);
+
+        vm.prank(ADMIN);
+        periodicTaskManager.removePeriodicTaskAtIndex(0);
+
+        _assertPeriodicTasks(expectedTasks, expectedCustomSelectors);
+    }
+
+    function test_givenCustomSelectorTask_indexOne()
+        public
+        givenPeriodicTaskIsAdded(address(periodicTaskA))
+        givenCustomPeriodicTaskIsAdded(address(customPeriodicTask))
+        givenPeriodicTaskIsAdded(address(periodicTaskB))
+        givenPeriodicTaskIsAdded(address(periodicTaskC))
+    {
+        address[] memory expectedTasks = new address[](3);
+        expectedTasks[0] = address(periodicTaskA);
+        expectedTasks[1] = address(periodicTaskB);
+        expectedTasks[2] = address(periodicTaskC);
+
+        bytes4[] memory expectedCustomSelectors = new bytes4[](3);
+        expectedCustomSelectors[0] = bytes4(0);
+        expectedCustomSelectors[1] = bytes4(0);
+        expectedCustomSelectors[2] = bytes4(0);
+
+        vm.prank(ADMIN);
+        periodicTaskManager.removePeriodicTaskAtIndex(1);
+
+        _assertPeriodicTasks(expectedTasks, expectedCustomSelectors);
+    }
+
+    function test_givenCustomSelectorTask_indexTwo()
+        public
+        givenPeriodicTaskIsAdded(address(periodicTaskA))
+        givenPeriodicTaskIsAdded(address(periodicTaskB))
+        givenCustomPeriodicTaskIsAdded(address(customPeriodicTask))
+        givenPeriodicTaskIsAdded(address(periodicTaskC))
+    {
+        address[] memory expectedTasks = new address[](3);
+        expectedTasks[0] = address(periodicTaskA);
+        expectedTasks[1] = address(periodicTaskB);
+        expectedTasks[2] = address(periodicTaskC);
+
+        bytes4[] memory expectedCustomSelectors = new bytes4[](3);
+        expectedCustomSelectors[0] = bytes4(0);
+        expectedCustomSelectors[1] = bytes4(0);
+        expectedCustomSelectors[2] = bytes4(0);
+
+        vm.prank(ADMIN);
+        periodicTaskManager.removePeriodicTaskAtIndex(2);
+
+        _assertPeriodicTasks(expectedTasks, expectedCustomSelectors);
+    }
+
+    function test_givenCustomSelectorTask_indexThree()
+        public
+        givenPeriodicTaskIsAdded(address(periodicTaskA))
+        givenPeriodicTaskIsAdded(address(periodicTaskB))
+        givenPeriodicTaskIsAdded(address(periodicTaskC))
+        givenCustomPeriodicTaskIsAdded(address(customPeriodicTask))
+    {
+        address[] memory expectedTasks = new address[](3);
+        expectedTasks[0] = address(periodicTaskA);
+        expectedTasks[1] = address(periodicTaskB);
+        expectedTasks[2] = address(periodicTaskC);
+
+        bytes4[] memory expectedCustomSelectors = new bytes4[](3);
+        expectedCustomSelectors[0] = bytes4(0);
+        expectedCustomSelectors[1] = bytes4(0);
+        expectedCustomSelectors[2] = bytes4(0);
+
+        vm.prank(ADMIN);
+        periodicTaskManager.removePeriodicTaskAtIndex(3);
+
+        _assertPeriodicTasks(expectedTasks, expectedCustomSelectors);
+    }
+
+    // [X] it removes the task
+    // [X] the array length is decremented
+    // [X] the elements after the index are shifted to the left
+    // [X] the custom selector for the task is cleared
+
+    function test_givenDifferentCustomSelectorTask_indexZero()
+        public
+        givenPeriodicTaskIsAdded(address(periodicTaskA))
+        givenPeriodicTaskIsAdded(address(periodicTaskB))
+        givenPeriodicTaskIsAdded(address(periodicTaskC))
+        givenCustomPeriodicTaskIsAdded(address(customPeriodicTask))
+    {
+        address[] memory expectedTasks = new address[](3);
+        expectedTasks[0] = address(periodicTaskB);
+        expectedTasks[1] = address(periodicTaskC);
+        expectedTasks[2] = address(customPeriodicTask);
+
+        bytes4[] memory expectedCustomSelectors = new bytes4[](3);
+        expectedCustomSelectors[0] = bytes4(0);
+        expectedCustomSelectors[1] = bytes4(0);
+        expectedCustomSelectors[2] = MockCustomPeriodicTask.customExecute.selector;
+
+        vm.prank(ADMIN);
+        periodicTaskManager.removePeriodicTaskAtIndex(0);
+
+        _assertPeriodicTasks(expectedTasks, expectedCustomSelectors);
+    }
+
+    function test_givenDifferentCustomSelectorTask_indexOne()
+        public
+        givenPeriodicTaskIsAdded(address(periodicTaskA))
+        givenPeriodicTaskIsAdded(address(periodicTaskB))
+        givenPeriodicTaskIsAdded(address(periodicTaskC))
+        givenCustomPeriodicTaskIsAdded(address(customPeriodicTask))
+    {
+        address[] memory expectedTasks = new address[](3);
+        expectedTasks[0] = address(periodicTaskA);
+        expectedTasks[1] = address(periodicTaskC);
+        expectedTasks[2] = address(customPeriodicTask);
+
+        bytes4[] memory expectedCustomSelectors = new bytes4[](3);
+        expectedCustomSelectors[0] = bytes4(0);
+        expectedCustomSelectors[1] = bytes4(0);
+        expectedCustomSelectors[2] = MockCustomPeriodicTask.customExecute.selector;
+
+        vm.prank(ADMIN);
+        periodicTaskManager.removePeriodicTaskAtIndex(1);
+
+        _assertPeriodicTasks(expectedTasks, expectedCustomSelectors);
+    }
+
+    function test_givenDifferentCustomSelectorTask_indexTwo()
+        public
+        givenPeriodicTaskIsAdded(address(periodicTaskA))
+        givenPeriodicTaskIsAdded(address(periodicTaskB))
+        givenPeriodicTaskIsAdded(address(periodicTaskC))
+        givenCustomPeriodicTaskIsAdded(address(customPeriodicTask))
+    {
+        address[] memory expectedTasks = new address[](3);
+        expectedTasks[0] = address(periodicTaskA);
+        expectedTasks[1] = address(periodicTaskB);
+        expectedTasks[2] = address(customPeriodicTask);
+
+        bytes4[] memory expectedCustomSelectors = new bytes4[](3);
+        expectedCustomSelectors[0] = bytes4(0);
+        expectedCustomSelectors[1] = bytes4(0);
+        expectedCustomSelectors[2] = MockCustomPeriodicTask.customExecute.selector;
+
+        vm.prank(ADMIN);
+        periodicTaskManager.removePeriodicTaskAtIndex(2);
+
+        _assertPeriodicTasks(expectedTasks, expectedCustomSelectors);
+    }
 }

--- a/src/test/bases/PeriodicTaskManager/removePeriodicTaskAtIndex.t.sol
+++ b/src/test/bases/PeriodicTaskManager/removePeriodicTaskAtIndex.t.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.15;
+
+import {Test} from "@forge-std-1.9.6/Test.sol";
+
+import {PeriodicTaskManagerTest} from "src/test/bases/PeriodicTaskManager/PeriodicTaskManagerTest.sol";
+
+contract PeriodicTaskManagerRemovePeriodicTaskAtIndexTest is PeriodicTaskManagerTest {
+    // ========== TESTS ========== //
+    // given the caller is not the admin
+    //  [ ] it reverts
+    // given the index is out of bounds
+    //  [ ] it reverts
+    // given the task has a custom selector
+    //  [ ] it removes the task
+    //  [ ] the array length is decremented
+    //  [ ] the elements after the index are shifted to the left
+    //  [ ] the custom selector for the task is cleared
+    // [ ] it removes the task
+    // [ ] the array length is decremented
+    // [ ] the elements after the index are shifted to the left
+    // [ ] the custom selector for the task is cleared
+}

--- a/src/test/libraries/AddressStorageArray.t.sol
+++ b/src/test/libraries/AddressStorageArray.t.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import {Test} from "forge-std/Test.sol";
+import {AddressStorageArray} from "src/libraries/AddressStorageArray.sol";
+
+contract AddressStorageArrayTest is Test {
+    // ========== TESTS ========== //
+    // insert
+    // given there are no elements in the array
+    //  when index is >= 1
+    //   [ ] it reverts
+    //  [ ] it inserts the value at index 0
+    //  [ ] the array length is 1
+    // when index is > the array length
+    //  [ ] it reverts
+    // [ ] it inserts the value at the index
+    // [ ] it does not shift the elements before the index
+    // [ ] it shifts the elements after the index to the right
+    // [ ] the array length is incremented
+    // remove
+    // given there are no elements in the array
+    //  [ ] it reverts
+    // when index is >= the array length
+    //  [ ] it reverts
+    // [ ] it removes the value at the index
+    // [ ] it does not shift the elements before the index
+    // [ ] it shifts the elements after the index to the left
+    // [ ] the array length is decremented
+}

--- a/src/test/libraries/AddressStorageArray.t.sol
+++ b/src/test/libraries/AddressStorageArray.t.sol
@@ -1,30 +1,176 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity >=0.8.15;
 
-import {Test} from "forge-std/Test.sol";
+import {Test} from "@forge-std-1.9.6/Test.sol";
 import {AddressStorageArray} from "src/libraries/AddressStorageArray.sol";
 
 contract AddressStorageArrayTest is Test {
+    using AddressStorageArray for address[];
+
+    address[] public array;
+
+    function _expectRevertIndexOutOfBounds(uint256 index_, uint256 length_) internal {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AddressStorageArray.AddressStorageArray_IndexOutOfBounds.selector,
+                index_,
+                length_
+            )
+        );
+    }
+
     // ========== TESTS ========== //
     // insert
     // given there are no elements in the array
     //  when index is >= 1
-    //   [ ] it reverts
-    //  [ ] it inserts the value at index 0
-    //  [ ] the array length is 1
+    //   [X] it reverts
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function test_insert_noElements_whenIndexGreaterThanLength_reverts(uint256 index_) public {
+        index_ = bound(index_, 1, type(uint256).max);
+
+        _expectRevertIndexOutOfBounds(index_, 0);
+
+        array.insert(address(1), index_);
+    }
+
+    //  [X] it inserts the value at index 0
+    //  [X] the array length is 1
+
+    function test_insert_noElements() public {
+        array.insert(address(1), 0);
+
+        assertEq(array.length, 1);
+        assertEq(array[0], address(1));
+    }
+
     // when index is > the array length
-    //  [ ] it reverts
-    // [ ] it inserts the value at the index
-    // [ ] it does not shift the elements before the index
-    // [ ] it shifts the elements after the index to the right
-    // [ ] the array length is incremented
+    //  [X] it reverts
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function test_insert_whenIndexGreaterThanLength_reverts(uint256 index_) public {
+        index_ = bound(index_, 2, type(uint256).max);
+
+        array.push(address(1));
+
+        _expectRevertIndexOutOfBounds(index_, 1);
+
+        array.insert(address(2), index_);
+    }
+
+    // [X] it inserts the value at the index
+    // [X] it does not shift the elements before the index
+    // [X] it shifts the elements after the index to the right
+    // [X] the array length is incremented
+
+    function test_insert_indexZero() public {
+        array.push(address(1));
+        array.push(address(2));
+
+        array.insert(address(3), 0);
+
+        assertEq(array.length, 3);
+        assertEq(array[0], address(3));
+        assertEq(array[1], address(1));
+        assertEq(array[2], address(2));
+    }
+
+    function test_insert_indexOne() public {
+        array.push(address(1));
+        array.push(address(2));
+
+        array.insert(address(3), 1);
+
+        assertEq(array.length, 3);
+        assertEq(array[0], address(1));
+        assertEq(array[1], address(3));
+        assertEq(array[2], address(2));
+    }
+
+    function test_insert_indexTwo() public {
+        array.push(address(1));
+        array.push(address(2));
+
+        array.insert(address(3), 2);
+
+        assertEq(array.length, 3);
+        assertEq(array[0], address(1));
+        assertEq(array[1], address(2));
+        assertEq(array[2], address(3));
+    }
+
     // remove
     // given there are no elements in the array
-    //  [ ] it reverts
+    //  [X] it reverts
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function test_remove_noElements_whenIndexGreaterThanLength_reverts(uint256 index_) public {
+        index_ = bound(index_, 0, type(uint256).max);
+
+        _expectRevertIndexOutOfBounds(index_, 0);
+
+        array.remove(index_);
+    }
+
     // when index is >= the array length
-    //  [ ] it reverts
-    // [ ] it removes the value at the index
-    // [ ] it does not shift the elements before the index
-    // [ ] it shifts the elements after the index to the left
-    // [ ] the array length is decremented
+    //  [X] it reverts
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function test_remove_whenIndexGreaterThanLength_reverts(uint256 index_) public {
+        index_ = bound(index_, 1, type(uint256).max);
+
+        array.push(address(1));
+
+        _expectRevertIndexOutOfBounds(index_, 1);
+
+        array.remove(index_);
+    }
+
+    // [X] it removes the value at the index
+    // [X] it does not shift the elements before the index
+    // [X] it shifts the elements after the index to the left
+    // [X] the array length is decremented
+    // [X] it returns the removed value
+
+    function test_remove_indexZero() public {
+        array.push(address(1));
+        array.push(address(2));
+        array.push(address(3));
+
+        address removedValue = array.remove(0);
+
+        assertEq(removedValue, address(1), "removed value");
+
+        assertEq(array.length, 2, "array length");
+        assertEq(array[0], address(2), "array[0]");
+        assertEq(array[1], address(3), "array[1]");
+    }
+
+    function test_remove_indexOne() public {
+        array.push(address(1));
+        array.push(address(2));
+        array.push(address(3));
+
+        address removedValue = array.remove(1);
+
+        assertEq(removedValue, address(2), "removed value");
+
+        assertEq(array.length, 2, "array length");
+        assertEq(array[0], address(1), "array[0]");
+        assertEq(array[1], address(3), "array[1]");
+    }
+
+    function test_remove_indexTwo() public {
+        array.push(address(1));
+        array.push(address(2));
+        array.push(address(3));
+
+        address removedValue = array.remove(2);
+
+        assertEq(removedValue, address(3), "removed value");
+
+        assertEq(array.length, 2, "array length");
+        assertEq(array[0], address(1), "array[0]");
+        assertEq(array[1], address(2), "array[1]");
+    }
 }

--- a/src/test/mocks/MockEmissionManager.sol
+++ b/src/test/mocks/MockEmissionManager.sol
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.0;
 
-import {IEmissionManager} from "../../policies/interfaces/IEmissionManager.sol";
+import {IEmissionManager} from "src/policies/interfaces/IEmissionManager.sol";
+import {IPeriodicTask} from "src/interfaces/IPeriodicTask.sol";
 
-contract MockEmissionManager is IEmissionManager {
+contract MockEmissionManager is IEmissionManager, IPeriodicTask {
     constructor() {}
 
     function execute() external override {

--- a/src/test/mocks/MockEmissionManager.sol
+++ b/src/test/mocks/MockEmissionManager.sol
@@ -10,4 +10,10 @@ contract MockEmissionManager is IEmissionManager, IPeriodicTask {
     function execute() external override {
         // do nothing
     }
+
+    function supportsInterface(bytes4 interfaceId) external pure override returns (bool) {
+        return
+            interfaceId == type(IEmissionManager).interfaceId ||
+            interfaceId == type(IPeriodicTask).interfaceId;
+    }
 }

--- a/src/test/mocks/MockEmissionManager.sol
+++ b/src/test/mocks/MockEmissionManager.sol
@@ -5,10 +5,17 @@ import {IEmissionManager} from "src/policies/interfaces/IEmissionManager.sol";
 import {IPeriodicTask} from "src/interfaces/IPeriodicTask.sol";
 
 contract MockEmissionManager is IEmissionManager, IPeriodicTask {
+    uint256 public count;
+    bool internal _revert;
+
+    error MockEmissionManager_Revert();
+
     constructor() {}
 
     function execute() external override {
-        // do nothing
+        if (_revert) revert MockEmissionManager_Revert();
+
+        count++;
     }
 
     function supportsInterface(bytes4 interfaceId) external pure override returns (bool) {

--- a/src/test/policies/ConvertibleDepositFacility/claimAllYield.t.sol
+++ b/src/test/policies/ConvertibleDepositFacility/claimAllYield.t.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Unlicensed
+pragma solidity >=0.8.20;
+
+import {ConvertibleDepositFacilityTest} from "src/test/policies/ConvertibleDepositFacility/ConvertibleDepositFacilityTest.sol";
+
+contract ConvertibleDepositFacilityClaimYieldTest is ConvertibleDepositFacilityTest {
+    // ========== TESTS ========== //
+
+    // given the facility is disabled
+    //  [ ] it does nothing
+    // given there are no supported assets
+    //  [ ] it does nothing
+    // given an asset has no yield
+    //  [ ] it does nothing
+    // [ ] it transfers the token yields to the treasury
+    // [ ] it emits ClaimedYield events
+}

--- a/src/test/policies/ConvertibleDepositFacility/claimAllYield.t.sol
+++ b/src/test/policies/ConvertibleDepositFacility/claimAllYield.t.sol
@@ -5,7 +5,6 @@ import {ConvertibleDepositFacilityTest} from "src/test/policies/ConvertibleDepos
 
 contract ConvertibleDepositFacilityClaimYieldTest is ConvertibleDepositFacilityTest {
     // ========== TESTS ========== //
-
     // given the facility is disabled
     //  [ ] it does nothing
     // given there are no supported assets

--- a/src/test/policies/ConvertibleDepositFacility/claimYield.t.sol
+++ b/src/test/policies/ConvertibleDepositFacility/claimYield.t.sol
@@ -5,7 +5,6 @@ import {ConvertibleDepositFacilityTest} from "src/test/policies/ConvertibleDepos
 
 contract ConvertibleDepositFacilityClaimYieldTest is ConvertibleDepositFacilityTest {
     // ========== TESTS ========== //
-
     // given the facility is disabled
     //  [ ] it returns 0
     // given the asset is not supported

--- a/src/test/policies/ConvertibleDepositFacility/claimYield.t.sol
+++ b/src/test/policies/ConvertibleDepositFacility/claimYield.t.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Unlicensed
+pragma solidity >=0.8.20;
+
+import {ConvertibleDepositFacilityTest} from "src/test/policies/ConvertibleDepositFacility/ConvertibleDepositFacilityTest.sol";
+
+contract ConvertibleDepositFacilityClaimYieldTest is ConvertibleDepositFacilityTest {
+    // ========== TESTS ========== //
+
+    // given the facility is disabled
+    //  [ ] it returns 0
+    // given the asset is not supported
+    //  [ ] it returns 0
+    // given the yield is 0
+    //  [ ] it returns 0
+    // [ ] it transfers the yield to the treasury
+    // [ ] it emits the ClaimedYield event
+    // [ ] it returns the yield
+}

--- a/src/test/policies/ConvertibleDepositFacility/execute.t.sol
+++ b/src/test/policies/ConvertibleDepositFacility/execute.t.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Unlicensed
+pragma solidity >=0.8.20;
+
+import {ConvertibleDepositFacilityTest} from "src/test/policies/ConvertibleDepositFacility/ConvertibleDepositFacilityTest.sol";
+
+contract ConvertibleDepositFacilityClaimYieldTest is ConvertibleDepositFacilityTest {
+    // ========== TESTS ========== //
+
+    // given the facility is disabled
+    //  [ ] it does nothing
+    // given there are no supported assets
+    //  [ ] it does nothing
+    // given an asset has no yield
+    //  [ ] it does nothing
+    // [ ] it transfers the token yields to the treasury
+    // [ ] it emits ClaimedYield events
+}

--- a/src/test/policies/ConvertibleDepositFacility/execute.t.sol
+++ b/src/test/policies/ConvertibleDepositFacility/execute.t.sol
@@ -5,7 +5,6 @@ import {ConvertibleDepositFacilityTest} from "src/test/policies/ConvertibleDepos
 
 contract ConvertibleDepositFacilityClaimYieldTest is ConvertibleDepositFacilityTest {
     // ========== TESTS ========== //
-
     // given the facility is disabled
     //  [ ] it does nothing
     // given there are no supported assets

--- a/src/test/policies/DepositManager/addAssetPeriod.t.sol
+++ b/src/test/policies/DepositManager/addAssetPeriod.t.sol
@@ -5,7 +5,7 @@ import {DepositManagerTest} from "./DepositManagerTest.sol";
 import {IERC20} from "src/interfaces/IERC20.sol";
 import {IDepositManager} from "src/policies/interfaces/IDepositManager.sol";
 import {IAssetManager} from "src/bases/interfaces/IAssetManager.sol";
-import {uint2str} from "src/libraries/Uint2str.sol";
+import {uint2str} from "src/libraries/Uint2Str.sol";
 import {String} from "src/libraries/String.sol";
 
 contract DepositManagerAddAssetPeriodTest is DepositManagerTest {

--- a/src/test/policies/Heart.t.sol
+++ b/src/test/policies/Heart.t.sol
@@ -173,7 +173,6 @@ contract HeartTest is Test {
         );
         heart.addPeriodicTaskAtIndex(address(operator), IOperator.operate.selector, 1);
         heart.addPeriodicTaskAtIndex(address(yieldRepo), IYieldRepo.endEpoch.selector, 2);
-        heart.addPeriodicTaskAtIndex(address(distributor), IDistributor.triggerRebase.selector, 3);
         heart.addPeriodicTask(address(emissionManager));
         vm.stopPrank();
 


### PR DESCRIPTION
The Heart currently has hard-coded calls to contracts that require periodic operations (e.g. yield repo, reserve migration). This PR introduces the `BasePeriodicTaskManager` (which Heart inherits from), enabling the calls to be a configurable array of tasks with optional custom selectors (for contracts that have not been updated to use the `IPeriodicTask` interface).

This PR also:
- Migrates the Heart to use the PolicyEnabler mix-in for enabling/disabling contract functionality
- Migrates the Heart to use the PolicyAdmin mix-in for role gating