### PR TITLE
Convertible Deposits: Audit: ERC6909 wrap/unwrap griefing [4]

### DIFF
--- a/src/interfaces/IERC6909Wrappable.sol
+++ b/src/interfaces/IERC6909Wrappable.sol
@@ -15,22 +15,16 @@ interface IERC6909Wrappable {
 
     /// @notice Wraps an ERC6909 token to an ERC20 token
     ///
-    /// @param onBehalfOf_   The address to wrap the token on behalf of
     /// @param tokenId_      The ID of the ERC6909 token
     /// @param amount_       The amount of tokens to wrap
     /// @return wrappedToken The address of the wrapped ERC20 token
-    function wrap(
-        address onBehalfOf_,
-        uint256 tokenId_,
-        uint256 amount_
-    ) external returns (address wrappedToken);
+    function wrap(uint256 tokenId_, uint256 amount_) external returns (address wrappedToken);
 
     /// @notice Unwraps an ERC20 token to an ERC6909 token
     ///
-    /// @param onBehalfOf_   The address to unwrap the token on behalf of
     /// @param tokenId_      The ID of the ERC6909 token
     /// @param amount_       The amount of tokens to unwrap
-    function unwrap(address onBehalfOf_, uint256 tokenId_, uint256 amount_) external;
+    function unwrap(uint256 tokenId_, uint256 amount_) external;
 
     /// @notice Returns the address of the wrapped ERC20 token for a given token ID
     ///

--- a/src/interfaces/IERC6909Wrappable.sol
+++ b/src/interfaces/IERC6909Wrappable.sol
@@ -4,6 +4,22 @@ pragma solidity >=0.8.0;
 /// @title IERC6909Wrappable
 /// @notice Declares interface for an ERC6909 implementation that allows for wrapping and unwrapping ERC6909 tokens to and from ERC20 tokens
 interface IERC6909Wrappable {
+    // ========== EVENTS ========== //
+
+    event Wrapped(
+        uint256 indexed tokenId,
+        address indexed wrappedToken,
+        address indexed account,
+        uint256 amount
+    );
+
+    event Unwrapped(
+        uint256 indexed tokenId,
+        address indexed wrappedToken,
+        address indexed account,
+        uint256 amount
+    );
+
     // ========== ERRORS ========== //
 
     error ERC6909Wrappable_TokenIdAlreadyExists(uint256 tokenId);

--- a/src/libraries/ERC6909Wrappable.sol
+++ b/src/libraries/ERC6909Wrappable.sol
@@ -178,6 +178,10 @@ abstract contract ERC6909Wrappable is ERC6909Metadata, IERC6909Wrappable, IERC69
         // Mint the wrapped ERC20 token to the recipient
         IERC20BurnableMintable wrappedToken_ = _getWrappedToken(tokenId_);
         wrappedToken_.mintFor(msg.sender, amount_);
+
+        // Emit the Wrapped event
+        emit Wrapped(tokenId_, address(wrappedToken_), msg.sender, amount_);
+
         return address(wrappedToken_);
     }
 
@@ -195,6 +199,9 @@ abstract contract ERC6909Wrappable is ERC6909Metadata, IERC6909Wrappable, IERC69
 
         // Mint the ERC6909 token
         _mint(msg.sender, tokenId_, amount_);
+
+        // Emit the Unwrapped event
+        emit Unwrapped(tokenId_, _wrappedTokens[tokenId_], msg.sender, amount_);
     }
 
     // ========== TOKEN FUNCTIONS ========== //

--- a/src/libraries/ERC6909Wrappable.sol
+++ b/src/libraries/ERC6909Wrappable.sol
@@ -164,27 +164,23 @@ abstract contract ERC6909Wrappable is ERC6909Metadata, IERC6909Wrappable, IERC69
     }
 
     /// @inheritdoc IERC6909Wrappable
-    function wrap(
-        address onBehalfOf_,
-        uint256 tokenId_,
-        uint256 amount_
-    ) public returns (address wrappedToken) {
+    function wrap(uint256 tokenId_, uint256 amount_) public returns (address wrappedToken) {
         // Burn the ERC6909 token
-        _burn(onBehalfOf_, tokenId_, amount_, false);
+        _burn(msg.sender, tokenId_, amount_, false);
 
         // Mint the wrapped ERC20 token to the recipient
         IERC20BurnableMintable wrappedToken_ = _getWrappedToken(tokenId_);
-        wrappedToken_.mintFor(onBehalfOf_, amount_);
+        wrappedToken_.mintFor(msg.sender, amount_);
         return address(wrappedToken_);
     }
 
     /// @inheritdoc IERC6909Wrappable
-    function unwrap(address onBehalfOf_, uint256 tokenId_, uint256 amount_) public {
+    function unwrap(uint256 tokenId_, uint256 amount_) public {
         // Burn the wrapped ERC20 token
-        _burn(onBehalfOf_, tokenId_, amount_, true);
+        _burn(msg.sender, tokenId_, amount_, true);
 
         // Mint the ERC6909 token
-        _mint(onBehalfOf_, tokenId_, amount_);
+        _mint(msg.sender, tokenId_, amount_);
     }
 
     // ========== TOKEN FUNCTIONS ========== //

--- a/src/libraries/ERC6909Wrappable.sol
+++ b/src/libraries/ERC6909Wrappable.sol
@@ -164,6 +164,13 @@ abstract contract ERC6909Wrappable is ERC6909Metadata, IERC6909Wrappable, IERC69
     }
 
     /// @inheritdoc IERC6909Wrappable
+    /// @dev        This function will burn the ERC6909 token from the caller and mint the wrapped ERC20 token to the same address.
+    ///
+    ///             This function reverts if:
+    ///             - The token ID does not exist
+    ///             - The amount is zero
+    ///             - The caller has not approved this contract to spend the token
+    ///             - The caller has an insufficient balance of the token
     function wrap(uint256 tokenId_, uint256 amount_) public returns (address wrappedToken) {
         // Burn the ERC6909 token
         _burn(msg.sender, tokenId_, amount_, false);
@@ -175,6 +182,13 @@ abstract contract ERC6909Wrappable is ERC6909Metadata, IERC6909Wrappable, IERC69
     }
 
     /// @inheritdoc IERC6909Wrappable
+    /// @dev        This function will burn the wrapped ERC20 token from the caller and mint the ERC6909 token to the same address.
+    ///
+    ///             This function reverts if:
+    ///             - The token ID does not exist
+    ///             - The amount is zero
+    ///             - The caller has not approved this contract to spend the wrapped token
+    ///             - The caller has an insufficient balance of the wrapped token
     function unwrap(uint256 tokenId_, uint256 amount_) public {
         // Burn the wrapped ERC20 token
         _burn(msg.sender, tokenId_, amount_, true);

--- a/src/test/libraries/ERC6909Wrappable.t.sol
+++ b/src/test/libraries/ERC6909Wrappable.t.sol
@@ -423,7 +423,7 @@ contract ERC6909WrappableTest is Test {
         givenRecipientHasERC6909Tokens
         givenRecipientHasApprovedERC6909TokenSpending
     {
-        vm.assume(caller_ != alice);
+        vm.assume(caller_ != alice && caller_ != address(0));
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -553,7 +553,7 @@ contract ERC6909WrappableTest is Test {
         givenRecipientHasERC20Tokens
         givenRecipientHasApprovedWrappedTokenSpending
     {
-        vm.assume(caller_ != alice);
+        vm.assume(caller_ != alice && caller_ != address(0));
 
         vm.expectRevert(stdError.arithmeticError);
 

--- a/src/test/libraries/ERC6909Wrappable.t.sol
+++ b/src/test/libraries/ERC6909Wrappable.t.sol
@@ -371,7 +371,7 @@ contract ERC6909WrappableTest is Test {
         token.wrap(999, AMOUNT);
     }
 
-    // when the recipient has not approved the contract to spend the ERC6909 token
+    // when the owner has not approved the contract to spend the ERC6909 token
     //  [X] it reverts
     function test_wrap_whenRecipientHasNotApproved_reverts()
         public
@@ -394,7 +394,7 @@ contract ERC6909WrappableTest is Test {
 
     // when the caller does not have sufficient ERC6909 tokens
     //  [X] it reverts
-    function test_wrap_givenRecipientHasInsufficientERC6909Tokens_reverts()
+    function test_wrap_givenOwnerHasInsufficientERC6909Tokens_reverts()
         public
         givenERC20TokenExists
         givenRecipientHasApprovedERC6909TokenSpending
@@ -413,11 +413,37 @@ contract ERC6909WrappableTest is Test {
         token.wrap(TOKEN_ID, AMOUNT);
     }
 
+    // when the caller is not the owner
+    //  [X] it reverts
+    function test_wrap_differentCaller_reverts(
+        address caller_
+    )
+        public
+        givenERC20TokenExists
+        givenRecipientHasERC6909Tokens
+        givenRecipientHasApprovedERC6909TokenSpending
+    {
+        vm.assume(caller_ != alice);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ERC6909.ERC6909InsufficientAllowance.selector,
+                address(token),
+                0,
+                AMOUNT,
+                TOKEN_ID
+            )
+        );
+
+        vm.prank(caller_);
+        token.wrap(TOKEN_ID, AMOUNT);
+    }
+
     // given the ERC20 token has not been created
     //  [X] it creates the ERC20 token contract
     //  [X] the wrappedToken address is set correctly
-    //  [X] the ERC6909 token is burned from the recipient
-    //  [X] the ERC20 token is minted to the recipient
+    //  [X] the ERC6909 token is burned from the owner
+    //  [X] the ERC20 token is minted to the owner
     //  [X] the ERC6909 token supply is reduced
     //  [X] the ERC20 token supply is increased
     function test_wrap_givenERC20TokenHasNotBeenCreated()
@@ -441,8 +467,8 @@ contract ERC6909WrappableTest is Test {
     }
 
     // given the ERC20 token exists
-    //  [X] the ERC6909 token is burned from the recipient
-    //  [X] the ERC20 token is minted to the recipient
+    //  [X] the ERC6909 token is burned from the owner
+    //  [X] the ERC20 token is minted to the owner
     //  [X] the ERC6909 token supply is reduced
     //  [X] the ERC20 token supply is increased
     function test_wrap_givenERC20TokenExists()
@@ -490,7 +516,7 @@ contract ERC6909WrappableTest is Test {
         token.unwrap(999, AMOUNT);
     }
 
-    // when the recipient has not approved the contract to spend the ERC20 token
+    // when the owner has not approved the contract to spend the ERC20 token
     //  [X] it reverts
     function test_unwrap_whenRecipientHasNotApproved_reverts()
         public
@@ -503,10 +529,10 @@ contract ERC6909WrappableTest is Test {
         token.unwrap(TOKEN_ID, AMOUNT);
     }
 
-    // given the recipient has approved the contract to spend the ERC20 token
-    //  given the recipient does not have sufficient ERC20 tokens
+    // given the owner has approved the contract to spend the ERC20 token
+    //  given the owner does not have sufficient ERC20 tokens
     //   [X] it reverts
-    function test_unwrap_givenRecipientHasInsufficientERC20Tokens_reverts()
+    function test_unwrap_givenOwnerHasInsufficientERC20Tokens_reverts()
         public
         givenERC20TokenExists
         givenRecipientHasApprovedWrappedTokenSpending
@@ -517,11 +543,29 @@ contract ERC6909WrappableTest is Test {
         token.unwrap(TOKEN_ID, AMOUNT);
     }
 
-    //  [X] the ERC6909 token is minted to the recipient
-    //  [X] the ERC20 token is burned from the recipient
+    // when the caller is not the owner
+    //  [X] it reverts
+    function test_unwrap_differentCaller_reverts(
+        address caller_
+    )
+        public
+        givenERC20TokenExists
+        givenRecipientHasERC20Tokens
+        givenRecipientHasApprovedWrappedTokenSpending
+    {
+        vm.assume(caller_ != alice);
+
+        vm.expectRevert(stdError.arithmeticError);
+
+        vm.prank(caller_);
+        token.unwrap(TOKEN_ID, AMOUNT);
+    }
+
+    //  [X] the ERC6909 token is minted to the owner
+    //  [X] the ERC20 token is burned from the owner
     //  [X] the ERC6909 token supply is increased
     //  [X] the ERC20 token supply is decreased
-    function test_unwrap_givenRecipientHasApproved()
+    function test_unwrap_givenOwnerHasApproved()
         public
         givenERC20TokenExists
         givenRecipientHasERC20Tokens

--- a/src/test/libraries/ERC6909Wrappable.t.sol
+++ b/src/test/libraries/ERC6909Wrappable.t.sol
@@ -350,7 +350,9 @@ contract ERC6909WrappableTest is Test {
         vm.expectRevert(
             abi.encodeWithSelector(IERC6909Wrappable.ERC6909Wrappable_ZeroAmount.selector)
         );
-        token.wrap(alice, TOKEN_ID, 0);
+
+        vm.prank(alice);
+        token.wrap(TOKEN_ID, 0);
     }
 
     // when the tokenId is invalid
@@ -364,19 +366,9 @@ contract ERC6909WrappableTest is Test {
         vm.expectRevert(
             abi.encodeWithSelector(IERC6909Wrappable.ERC6909Wrappable_InvalidTokenId.selector, 999)
         );
-        token.wrap(alice, 999, AMOUNT);
-    }
 
-    // when the recipient is the zero address
-    //  [X] it reverts
-    function test_wrap_whenRecipientIsZeroAddress_reverts()
-        public
-        givenERC20TokenExists
-        givenRecipientHasERC6909Tokens
-        givenRecipientHasApprovedERC6909TokenSpending
-    {
-        vm.expectRevert(abi.encodeWithSelector(ERC6909.ERC6909InvalidSender.selector, address(0)));
-        token.wrap(address(0), TOKEN_ID, AMOUNT);
+        vm.prank(alice);
+        token.wrap(999, AMOUNT);
     }
 
     // when the recipient has not approved the contract to spend the ERC6909 token
@@ -395,7 +387,30 @@ contract ERC6909WrappableTest is Test {
                 TOKEN_ID
             )
         );
-        token.wrap(alice, TOKEN_ID, AMOUNT);
+
+        vm.prank(alice);
+        token.wrap(TOKEN_ID, AMOUNT);
+    }
+
+    // when the caller does not have sufficient ERC6909 tokens
+    //  [X] it reverts
+    function test_wrap_givenRecipientHasInsufficientERC6909Tokens_reverts()
+        public
+        givenERC20TokenExists
+        givenRecipientHasApprovedERC6909TokenSpending
+    {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ERC6909.ERC6909InsufficientBalance.selector,
+                alice,
+                0,
+                AMOUNT,
+                TOKEN_ID
+            )
+        );
+
+        vm.prank(alice);
+        token.wrap(TOKEN_ID, AMOUNT);
     }
 
     // given the ERC20 token has not been created
@@ -411,7 +426,8 @@ contract ERC6909WrappableTest is Test {
         givenRecipientHasApprovedERC6909TokenSpending
     {
         // Wrap the token
-        token.wrap(alice, TOKEN_ID, AMOUNT);
+        vm.prank(alice);
+        token.wrap(TOKEN_ID, AMOUNT);
 
         assertWrappedTokenExists(true);
 
@@ -436,7 +452,8 @@ contract ERC6909WrappableTest is Test {
         givenRecipientHasApprovedERC6909TokenSpending
     {
         // Wrap the token
-        address wrappedToken = token.wrap(alice, TOKEN_ID, AMOUNT);
+        vm.prank(alice);
+        address wrappedToken = token.wrap(TOKEN_ID, AMOUNT);
 
         assertWrappedTokenExists(true);
         assertEq(wrappedToken, token.getWrappedToken(TOKEN_ID), "Wrapped token address mismatch");
@@ -457,7 +474,9 @@ contract ERC6909WrappableTest is Test {
         vm.expectRevert(
             abi.encodeWithSelector(IERC6909Wrappable.ERC6909Wrappable_ZeroAmount.selector)
         );
-        token.unwrap(alice, TOKEN_ID, 0);
+
+        vm.prank(alice);
+        token.unwrap(TOKEN_ID, 0);
     }
 
     // when the tokenId is invalid
@@ -466,14 +485,9 @@ contract ERC6909WrappableTest is Test {
         vm.expectRevert(
             abi.encodeWithSelector(IERC6909Wrappable.ERC6909Wrappable_InvalidTokenId.selector, 999)
         );
-        token.unwrap(alice, 999, AMOUNT);
-    }
 
-    // when the recipient is the zero address
-    //  [X] it reverts
-    function test_unwrap_whenRecipientIsZeroAddress_reverts() public givenERC20TokenExists {
-        vm.expectRevert(abi.encodeWithSelector(ERC6909.ERC6909InvalidSender.selector, address(0)));
-        token.unwrap(address(0), TOKEN_ID, AMOUNT);
+        vm.prank(alice);
+        token.unwrap(999, AMOUNT);
     }
 
     // when the recipient has not approved the contract to spend the ERC20 token
@@ -484,7 +498,9 @@ contract ERC6909WrappableTest is Test {
         givenRecipientHasERC20Tokens
     {
         vm.expectRevert(stdError.arithmeticError);
-        token.unwrap(alice, TOKEN_ID, AMOUNT);
+
+        vm.prank(alice);
+        token.unwrap(TOKEN_ID, AMOUNT);
     }
 
     // given the recipient has approved the contract to spend the ERC20 token
@@ -496,7 +512,9 @@ contract ERC6909WrappableTest is Test {
         givenRecipientHasApprovedWrappedTokenSpending
     {
         vm.expectRevert(stdError.arithmeticError);
-        token.unwrap(alice, TOKEN_ID, AMOUNT);
+
+        vm.prank(alice);
+        token.unwrap(TOKEN_ID, AMOUNT);
     }
 
     //  [X] the ERC6909 token is minted to the recipient
@@ -510,7 +528,8 @@ contract ERC6909WrappableTest is Test {
         givenRecipientHasApprovedWrappedTokenSpending
     {
         // Unwrap the token
-        token.unwrap(alice, TOKEN_ID, AMOUNT);
+        vm.prank(alice);
+        token.unwrap(TOKEN_ID, AMOUNT);
 
         assertERC20Balance(alice, 0);
         assertERC20TotalSupply(0);


### PR DESCRIPTION
Prevents an unauthorised party from griefing a receipt token holder by wrapping/unwrapping receipt tokens from ERC6909 to ERC20 in the scenario where the holder has approved spending by the DepositManager (which issues the ERC6909 tokens).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wrapping and unwrapping tokens now operate directly on the caller's address, simplifying the user experience.
  * Added events to notify users when tokens are wrapped or unwrapped.

* **Bug Fixes**
  * Updated tests to reflect the new behavior, ensuring accurate validation of permissions and balances.

* **Refactor**
  * Removed the need to specify a recipient address when wrapping or unwrapping tokens; actions are now always performed for the caller.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->