### PR TITLE
Convertible Deposits: Audit: Avoid ERC777 re-entrancy [18]

### DIFF
--- a/src/bases/BaseAssetManager.sol
+++ b/src/bases/BaseAssetManager.sol
@@ -33,6 +33,8 @@ abstract contract BaseAssetManager is IAssetManager {
     /// @notice Deposit assets into the configured vault
     /// @dev    This function will pull the assets from the depositor and deposit them into the vault. If the vault is the zero address, the assets will be kept idle.
     ///
+    ///         To avoid susceptibility to ERC777 re-entrancy, this function should be called before any state changes.
+    ///
     ///         When an ERC4626 vault is configured for an asset, the amount of assets that can be withdrawn may be 1 less than what was originally deposited. To be conservative, this function returns the actual amount.
     ///
     ///         This function will revert if:

--- a/src/policies/deposits/DepositManager.sol
+++ b/src/policies/deposits/DepositManager.sol
@@ -163,6 +163,7 @@ contract DepositManager is
     {
         // Deposit into vault
         // This will revert if the asset is not configured
+        // This takes place before any state changes to avoid ERC777 re-entrancy
         (actualAmount, ) = _depositAsset(params_.asset, params_.depositor, params_.amount);
 
         // Mint the receipt token to the caller
@@ -609,6 +610,7 @@ contract DepositManager is
 
         // Transfer funds from payer to this contract
         // We ignore the actual amount deposited into the vault, as the payer will not be able to over-pay in case of an off-by-one issue
+        // This takes place before any state changes to avoid ERC777 re-entrancy
         _depositAsset(params_.asset, params_.payer, params_.amount);
 
         // Update borrowed amount


### PR DESCRIPTION
Shifts `safeTransferFrom()` calls to occur before state changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated loan repayment and extension flows to perform token transfers before state updates, reducing re-entrancy risk and improving transaction reliability.
  * Removed a duplicate token transfer during loan repayment to prevent potential over-charging.

* **Documentation**
  * Added guidance to perform asset transfers before state changes to mitigate ERC777 re-entrancy risks.
  * Clarified comments around deposit and repayment steps for greater transparency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->