### PR TITLE
Convertible Deposits: Audit: Auctioneer fixes [16]

### DIFF
--- a/src/policies/deposits/ConvertibleDepositAuctioneer.sol
+++ b/src/policies/deposits/ConvertibleDepositAuctioneer.sol
@@ -546,7 +546,10 @@ contract ConvertibleDepositAuctioneer is
     }
 
     /// @inheritdoc IConvertibleDepositAuctioneer
-    /// @dev        This function will revert if:
+    /// @dev        Notes:
+    ///             - Enabling a deposit period will reset the minimum price and tick size to the standard values
+    ///
+    ///             This function will revert if:
     ///             - The contract is not enabled
     ///             - The caller is not a manager or admin
     ///             - The deposit period is already enabled for this asset

--- a/src/policies/deposits/ConvertibleDepositAuctioneer.sol
+++ b/src/policies/deposits/ConvertibleDepositAuctioneer.sol
@@ -807,7 +807,10 @@ contract ConvertibleDepositAuctioneer is
     }
 
     /// @inheritdoc IConvertibleDepositAuctioneer
-    /// @dev        This function will revert if:
+    /// @dev        Notes:
+    ///             - Calling this function will erase the previous auction results, which in turn may affect the bond markets created to sell under-sold OHM capacity
+    ///
+    ///             This function will revert if:
     ///             - The caller does not have the ROLE_ADMIN role
     ///             - The new auction tracking period is 0
     ///

--- a/src/policies/deposits/ConvertibleDepositAuctioneer.sol
+++ b/src/policies/deposits/ConvertibleDepositAuctioneer.sol
@@ -547,9 +547,12 @@ contract ConvertibleDepositAuctioneer is
 
     /// @inheritdoc IConvertibleDepositAuctioneer
     /// @dev        This function will revert if:
+    ///             - The contract is not enabled
     ///             - The caller is not a manager or admin
     ///             - The deposit period is already enabled for this asset
-    function enableDepositPeriod(uint8 depositPeriod_) external override onlyManagerOrAdminRole {
+    function enableDepositPeriod(
+        uint8 depositPeriod_
+    ) external override onlyEnabled onlyManagerOrAdminRole {
         // Validate that the deposit period is not 0
         if (depositPeriod_ == 0)
             revert ConvertibleDepositAuctioneer_InvalidParams("deposit period");
@@ -589,7 +592,13 @@ contract ConvertibleDepositAuctioneer is
     }
 
     /// @inheritdoc IConvertibleDepositAuctioneer
-    function disableDepositPeriod(uint8 depositPeriod_) external override onlyManagerOrAdminRole {
+    /// @dev        This function will revert if:
+    ///             - The contract is not enabled
+    ///             - The caller is not a manager or admin
+    ///             - The deposit period is not enabled for this asset
+    function disableDepositPeriod(
+        uint8 depositPeriod_
+    ) external override onlyEnabled onlyManagerOrAdminRole {
         // Validate that the deposit period is enabled
         if (!_depositPeriodsEnabled[depositPeriod_]) {
             revert ConvertibleDepositAuctioneer_DepositPeriodNotEnabled(

--- a/src/test/policies/ConvertibleDepositAuctioneer/disableDepositPeriod.t.sol
+++ b/src/test/policies/ConvertibleDepositAuctioneer/disableDepositPeriod.t.sol
@@ -9,10 +9,22 @@ import {console2} from "forge-std/console2.sol";
 contract ConvertibleDepositAuctioneerDisableDepositPeriodTest is ConvertibleDepositAuctioneerTest {
     event DepositPeriodDisabled(address indexed depositAsset, uint8 depositPeriod);
 
+    // given the contract is not enabled
+    //  [X] it reverts
+
+    function test_givenContractNotEnabled_reverts() public {
+        // Expect revert
+        _expectNotEnabledRevert();
+
+        // Call function
+        vm.prank(admin);
+        auctioneer.disableDepositPeriod(PERIOD_MONTHS);
+    }
+
     // when the caller does not have the "admin" or "manager" role
     //  [X] it reverts
 
-    function test_callerDoesNotHaveAdminOrManagerRole_reverts(address caller_) public {
+    function test_callerDoesNotHaveAdminOrManagerRole_reverts(address caller_) public givenEnabled {
         // Ensure caller is not admin or manager
         vm.assume(caller_ != admin && caller_ != manager);
 

--- a/src/test/policies/ConvertibleDepositAuctioneer/enableDepositPeriod.t.sol
+++ b/src/test/policies/ConvertibleDepositAuctioneer/enableDepositPeriod.t.sol
@@ -15,7 +15,7 @@ contract ConvertibleDepositAuctioneerEnableDepositPeriodTest is ConvertibleDepos
     // when the caller does not have the "admin" or "manager" role
     //  [X] it reverts
 
-    function test_callerDoesNotHaveAdminOrManagerRole_reverts(address caller_) public {
+    function test_callerDoesNotHaveAdminOrManagerRole_reverts(address caller_) public givenEnabled {
         // Ensure caller is not admin or manager
         vm.assume(caller_ != admin && caller_ != manager);
 
@@ -28,24 +28,21 @@ contract ConvertibleDepositAuctioneerEnableDepositPeriodTest is ConvertibleDepos
     }
 
     // given the contract is not enabled
-    //  [X] it succeeds
+    //  [X] it reverts
 
-    function test_givenContractNotEnabled() public {
+    function test_givenContractNotEnabled_reverts() public {
+        // Expect revert
+        _expectNotEnabledRevert();
+
         // Call function
         vm.prank(admin);
         auctioneer.enableDepositPeriod(PERIOD_MONTHS);
-
-        // Assert state
-        _assertPeriodEnabled(PERIOD_MONTHS, 0);
-
-        // Check the tick is populated
-        _assertPreviousTick(0, 0, 0, uint48(block.timestamp));
     }
 
     // when the deposit period is zero
     //  [X] it reverts
 
-    function test_whenDepositPeriodIsZero_reverts() public {
+    function test_whenDepositPeriodIsZero_reverts() public givenEnabled {
         // Expect revert
         vm.expectRevert(
             abi.encodeWithSelector(


### PR DESCRIPTION
- Require the contract to be enabled when enabling/disabling a deposit period
- Improve notes/docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Tightened access control: deposit period toggling now requires the policy to be active and an authorized role, preventing actions when the policy is disabled.
- Documentation
  - Clarified that enabling a deposit period resets minimum price and tick size.
  - Noted that adjusting the auction tracking period clears previous auction results, which may affect related markets.
  - Stated that certain actions require the policy to be enabled.
- Tests
  - Added not-enabled revert tests and updated suites to run under an enabled precondition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->