### PR TITLE
Convertible Deposits: Audit: Handle zero emissions [19]

### DIFF
--- a/src/policies/EmissionManager.sol
+++ b/src/policies/EmissionManager.sol
@@ -205,6 +205,9 @@ contract EmissionManager is IEmissionManager, IPeriodicTask, Policy, PolicyEnabl
         (, , uint256 emission) = getNextEmission();
 
         // Update the parameters for the convertible deposit auction
+        // This call can revert, however it is mitigated by:
+        // - CDAuctioneer will accept a target (emission) of 0
+        // - getSizeFor() will return a tick size of 1 wei when the target is 0
         cdAuctioneer.setAuctionParameters(
             emission,
             getSizeFor(emission),

--- a/src/policies/EmissionManager.sol
+++ b/src/policies/EmissionManager.sol
@@ -572,9 +572,14 @@ contract EmissionManager is IEmissionManager, IPeriodicTask, Policy, PolicyEnabl
     }
 
     /// @notice get CD auction tick size for a given target
+    /// @dev    If the target is 0 (no emissions target), a size of 1 will be returned
+    ///
     /// @param  target size of day's CD auction
     /// @return size of tick
     function getSizeFor(uint256 target) public view returns (uint256) {
+        // CDAuctioneer will not accept a tick size of 0, so return the minimum accepted amount. This will effectively disable auctions, as the price would go vertical.
+        if (target == 0) return 1;
+
         return (target * tickSizeScalar) / ONE_HUNDRED_PERCENT;
     }
 

--- a/src/policies/deposits/ConvertibleDepositAuctioneer.sol
+++ b/src/policies/deposits/ConvertibleDepositAuctioneer.sol
@@ -385,6 +385,11 @@ contract ConvertibleDepositAuctioneer is
     /// @param  ohmOut_     The amount of OHM that has been converted in the current day
     /// @return newTickSize The new tick size
     function _getNewTickSize(uint256 ohmOut_) internal view returns (uint256 newTickSize) {
+        // If the day target is zero, the tick size is always standard
+        if (_auctionParameters.target == 0) {
+            return _auctionParameters.tickSize;
+        }
+
         // Calculate the multiplier
         uint256 multiplier = ohmOut_ / _auctionParameters.target;
 
@@ -453,6 +458,9 @@ contract ConvertibleDepositAuctioneer is
     ///             - Calculate the added capacity based on the time passed since the last bid, and add it to the current capacity to get the new capacity
     ///             - Until the new capacity is <= to the standard tick size, reduce the capacity by the standard tick size and reduce the price by the tick step
     ///             - If the calculated price is ever lower than the minimum price, the new price is set to the minimum price and the capacity is set to the standard tick size
+    ///
+    ///             Notes:
+    ///             - If the target is 0, the price will not decay and the capacity will not change. It will only decay when a target is set again to a non-zero value.
     ///
     ///             This function reverts if:
     ///             - The contract is not enabled
@@ -638,14 +646,13 @@ contract ConvertibleDepositAuctioneer is
     // ========== ADMIN FUNCTIONS ========== //
 
     function _setAuctionParameters(uint256 target_, uint256 tickSize_, uint256 minPrice_) internal {
+        // The target can be zero
+
         // Tick size must be non-zero
         if (tickSize_ == 0) revert ConvertibleDepositAuctioneer_InvalidParams("tick size");
 
         // Min price must be non-zero
         if (minPrice_ == 0) revert ConvertibleDepositAuctioneer_InvalidParams("min price");
-
-        // Target must be non-zero
-        if (target_ == 0) revert ConvertibleDepositAuctioneer_InvalidParams("target");
 
         _auctionParameters = AuctionParameters(target_, tickSize_, minPrice_);
 
@@ -770,7 +777,6 @@ contract ConvertibleDepositAuctioneer is
     ///             - The caller does not have the ROLE_EMISSION_MANAGER role
     ///             - The new tick size is 0
     ///             - The new min price is 0
-    ///             - The new target is 0
     function setAuctionParameters(
         uint256 target_,
         uint256 tickSize_,

--- a/src/test/mocks/MockConvertibleDepositAuctioneer.sol
+++ b/src/test/mocks/MockConvertibleDepositAuctioneer.sol
@@ -76,6 +76,10 @@ contract MockConvertibleDepositAuctioneer is IConvertibleDepositAuctioneer, Poli
         uint256 newSize,
         uint256 newMinPrice
     ) external override {
+        // Mimic behaviour of the real auctioneer with error handling
+        if (newSize == 0) revert("tick size zero");
+        if (newMinPrice == 0) revert("min price zero");
+
         target = newTarget;
         tickSize = newSize;
         minPrice = newMinPrice;

--- a/src/test/policies/ConvertibleDepositAuctioneer/bid.t.sol
+++ b/src/test/policies/ConvertibleDepositAuctioneer/bid.t.sol
@@ -1248,4 +1248,193 @@ contract ConvertibleDepositAuctioneerBidTest is ConvertibleDepositAuctioneerTest
             receiptTokenId
         );
     }
+
+    // given the day target is 0
+    //  when the bid amount converts to an amount less than the tick capacity
+    //   [X] the price does not change
+    //   [X] the capacity is reduced
+    //  when the bid amount converts to an amount equal to the tick capacity
+    //   [X] the price is increased
+    //   [X] the capacity is the standard tick size
+    //  [ ] the price is increased
+
+    function test_givenTargetZero_whenConvertedAmountLessThanTickCapacity(
+        uint256 bidAmount_
+    )
+        public
+        givenEnabled
+        givenDepositPeriodEnabled(PERIOD_MONTHS)
+        givenAddressHasReserveToken(recipient, 150e18)
+        givenReserveTokenSpendingIsApproved(recipient, address(depositManager), 150e18)
+    {
+        // We want a bid amount that will result in a converted amount less than the tick size
+        // Given bid amount * 1e9 / 15e18 = converted amount
+        // When bid amount = 15e9, the converted amount = 1
+        // When bid amount = 150e18, the converted amount = 10e9
+        // When bid amount = 15e18-1, the converted amount = 9999999999
+        uint256 bidAmount = bound(bidAmount_, 15e9, 150e18 - 1);
+
+        // Calculate the expected converted amount
+        uint256 expectedConvertedAmount = (bidAmount * 1e9) / 15e18;
+
+        // Check preview
+        uint256 previewOhmOut = auctioneer.previewBid(PERIOD_MONTHS, bidAmount);
+
+        // Assert that the preview is as expected
+        assertEq(previewOhmOut, expectedConvertedAmount, "preview converted amount");
+
+        // Expect event
+        _expectBidEvent(bidAmount, previewOhmOut, 0);
+
+        // Call function
+        vm.prank(recipient);
+        (uint256 ohmOut, uint256 positionId, uint256 receiptTokenId) = auctioneer.bid(
+            PERIOD_MONTHS,
+            bidAmount,
+            1,
+            false,
+            false
+        );
+
+        // Assert returned values
+        _assertConvertibleDepositPosition(
+            bidAmount,
+            expectedConvertedAmount,
+            150e18 - bidAmount,
+            0,
+            0,
+            ohmOut,
+            positionId,
+            receiptTokenId
+        );
+
+        // Assert tick
+        IConvertibleDepositAuctioneer.Tick memory tick = auctioneer.getPreviousTick(PERIOD_MONTHS);
+        assertEq(tick.capacity, TICK_SIZE - expectedConvertedAmount, "tick capacity");
+        assertEq(tick.price, MIN_PRICE, "tick price");
+    }
+
+    function test_givenTargetZero_whenConvertedAmountEqualToTickCapacity()
+        public
+        givenEnabled
+        givenDepositPeriodEnabled(PERIOD_MONTHS)
+        givenAddressHasReserveToken(recipient, 150e18)
+        givenReserveTokenSpendingIsApproved(recipient, address(depositManager), 150e18)
+    {
+        // We want a bid amount that will result in a converted amount equal than the tick size
+        // Given bid amount * 1e9 / 15e18 = converted amount
+        // When bid amount = 150e18, the converted amount = 10e9
+        uint256 bidAmount = 150e18;
+
+        // Calculate the expected converted amount
+        uint256 expectedConvertedAmount = (bidAmount * 1e9) / 15e18;
+
+        // Calculate the expected tick price
+        uint256 expectedTickPrice = FullMath.mulDivUp(MIN_PRICE, TICK_STEP, 100e2);
+
+        // Check preview
+        uint256 previewOhmOut = auctioneer.previewBid(PERIOD_MONTHS, bidAmount);
+
+        // Assert that the preview is as expected
+        assertEq(previewOhmOut, expectedConvertedAmount, "preview converted amount");
+
+        // Expect event
+        _expectBidEvent(bidAmount, previewOhmOut, 0);
+
+        // Call function
+        vm.prank(recipient);
+        (uint256 ohmOut, uint256 positionId, uint256 receiptTokenId) = auctioneer.bid(
+            PERIOD_MONTHS,
+            bidAmount,
+            1,
+            false,
+            false
+        );
+
+        // Assert returned values
+        _assertConvertibleDepositPosition(
+            bidAmount,
+            expectedConvertedAmount,
+            150e18 - bidAmount,
+            0,
+            0,
+            ohmOut,
+            positionId,
+            receiptTokenId
+        );
+
+        // Assert tick
+        IConvertibleDepositAuctioneer.Tick memory tick = auctioneer.getPreviousTick(PERIOD_MONTHS);
+        assertEq(tick.capacity, TICK_SIZE, "tick capacity");
+        assertEq(tick.price, expectedTickPrice, "tick price");
+    }
+
+    function test_givenTargetZero_whenConvertedAmountGreaterThanTickCapacity(
+        uint256 bidAmount
+    )
+        public
+        givenEnabled
+        givenDepositPeriodEnabled(PERIOD_MONTHS)
+        givenAddressHasReserveToken(recipient, 200e18)
+        givenReserveTokenSpendingIsApproved(recipient, address(depositManager), 200e18)
+    {
+        // We want a bid amount that will result in a converted amount greater than the tick size
+        // Given bid amount * 1e9 / 15e18 = converted amount
+        // The initial tick price is MIN_PRICE, 15e18
+        // The second tick price is MIN_PRICE * 1.1, 165e17
+        // When bid amount = 151e18:
+        // - 150e18 is converted into 10e9 at a price of 15e18
+        // - 1e18 is converted into 60606060 at a price of 165e17
+        bidAmount = bound(bidAmount, 151e18, 200e18);
+
+        // Calculate the expected converted amount
+        uint256 expectedConvertedAmount;
+        uint256 expectedCapacity;
+        {
+            uint256 expectedConvertedAmountTickTwo = ((bidAmount - 150e18) * 1e9) / 165e17;
+            expectedConvertedAmount = TICK_SIZE + expectedConvertedAmountTickTwo;
+            expectedCapacity = TICK_SIZE - expectedConvertedAmountTickTwo;
+        }
+
+        // Calculate the expected tick price
+        uint256 expectedTickPrice = FullMath.mulDivUp(MIN_PRICE, TICK_STEP, 100e2);
+
+        {
+            // Check preview
+            uint256 previewOhmOut = auctioneer.previewBid(PERIOD_MONTHS, bidAmount);
+
+            // Assert that the preview is as expected
+            assertEq(previewOhmOut, expectedConvertedAmount, "preview converted amount");
+
+            // Expect event
+            _expectBidEvent(bidAmount, previewOhmOut, 0);
+        }
+
+        // Call function
+        vm.prank(recipient);
+        (uint256 ohmOut, uint256 positionId, uint256 receiptTokenId) = auctioneer.bid(
+            PERIOD_MONTHS,
+            bidAmount,
+            1,
+            false,
+            false
+        );
+
+        // Assert returned values
+        _assertConvertibleDepositPosition(
+            bidAmount,
+            expectedConvertedAmount,
+            200e18 - bidAmount,
+            0,
+            0,
+            ohmOut,
+            positionId,
+            receiptTokenId
+        );
+
+        // Assert tick
+        IConvertibleDepositAuctioneer.Tick memory tick = auctioneer.getPreviousTick(PERIOD_MONTHS);
+        assertEq(tick.capacity, expectedCapacity, "tick capacity");
+        assertEq(tick.price, expectedTickPrice, "tick price");
+    }
 }

--- a/src/test/policies/ConvertibleDepositAuctioneer/getCurrentTick.t.sol
+++ b/src/test/policies/ConvertibleDepositAuctioneer/getCurrentTick.t.sol
@@ -53,6 +53,31 @@ contract ConvertibleDepositAuctioneerCurrentTickTest is ConvertibleDepositAuctio
         assertEq(tick.price, expectedTickPrice, "price");
     }
 
+    //  given the target is zero
+    //   [X] the tick price remains at the min price
+    //   [X] the tick capacity remains at the standard tick size
+
+    function test_fullCapacity_targetZero(
+        uint48 secondsPassed_
+    )
+        public
+        givenEnabledWithParameters(0, TICK_SIZE, MIN_PRICE)
+        givenDepositPeriodEnabled(PERIOD_MONTHS)
+    {
+        uint48 secondsPassed = uint48(bound(secondsPassed_, 1, 7 days));
+
+        // Warp to change the block timestamp
+        vm.warp(block.timestamp + secondsPassed);
+
+        // Call function
+        IConvertibleDepositAuctioneer.Tick memory tick = auctioneer.getCurrentTick(PERIOD_MONTHS);
+
+        // Assert current tick
+        // As the day target is zero, no new capacity is added, hence the values stay the same
+        assertEq(tick.capacity, TICK_SIZE, "capacity");
+        assertEq(tick.price, MIN_PRICE, "price");
+    }
+
     //  [X] the tick price remains at the min price
     //  [X] the tick capacity remains at the standard tick size
 
@@ -830,5 +855,36 @@ contract ConvertibleDepositAuctioneerCurrentTickTest is ConvertibleDepositAuctio
             expectedPrice,
             "Price should decay exactly once using initial tick size"
         );
+    }
+
+    // given the day target is zero
+    //  given the tick price is above the minimum
+    //   [X] the tick price does not change
+    //   [X] the tick size does not change
+
+    function test_givenTickPriceAboveMinimum_targetZero(
+        uint48 secondsPassed_
+    )
+        public
+        givenEnabledWithParameters(0, TICK_SIZE, MIN_PRICE)
+        givenDepositPeriodEnabled(PERIOD_MONTHS)
+        givenRecipientHasBid(1000e18)
+    {
+        uint48 secondsPassed = uint48(bound(secondsPassed_, 1, 7 days));
+
+        IConvertibleDepositAuctioneer.Tick memory previousTick = auctioneer.getPreviousTick(
+            PERIOD_MONTHS
+        );
+
+        // Warp to change the block timestamp
+        vm.warp(block.timestamp + secondsPassed);
+
+        // Call function
+        IConvertibleDepositAuctioneer.Tick memory tick = auctioneer.getCurrentTick(PERIOD_MONTHS);
+
+        // Assert current tick
+        // As the day target is zero, no new capacity is added, hence the values stay the same
+        assertEq(tick.capacity, previousTick.capacity, "capacity");
+        assertEq(tick.price, previousTick.price, "price");
     }
 }

--- a/src/test/policies/ConvertibleDepositAuctioneer/setAuctionParameters.t.sol
+++ b/src/test/policies/ConvertibleDepositAuctioneer/setAuctionParameters.t.sol
@@ -20,26 +20,6 @@ contract ConvertibleDepositAuctioneerAuctionParametersTest is ConvertibleDeposit
         auctioneer.setAuctionParameters(100, 100, 100);
     }
 
-    // when the new target is 0
-    //  [X] it reverts
-
-    function test_targetZero_reverts() public givenEnabled {
-        uint256 newTickSize = 11e9;
-        uint256 newMinPrice = 14e18;
-
-        // Expect revert
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IConvertibleDepositAuctioneer.ConvertibleDepositAuctioneer_InvalidParams.selector,
-                "target"
-            )
-        );
-
-        // Call function
-        vm.prank(emissionManager);
-        auctioneer.setAuctionParameters(0, newTickSize, newMinPrice);
-    }
-
     // when the new tick size is 0
     //  [X] it reverts
 
@@ -72,6 +52,25 @@ contract ConvertibleDepositAuctioneerAuctionParametersTest is ConvertibleDeposit
         // Call function
         vm.prank(emissionManager);
         auctioneer.setAuctionParameters(21e9, 11e9, 0);
+    }
+
+    // when the new target is 0
+    //  [X] it sets the parameters
+
+    function test_targetZero() public givenEnabled {
+        uint256 newTickSize = 11e9;
+        uint256 newMinPrice = 14e18;
+
+        // Call function
+        vm.prank(emissionManager);
+        auctioneer.setAuctionParameters(0, newTickSize, newMinPrice);
+
+        // Assert state
+        _assertAuctionParameters(0, newTickSize, newMinPrice);
+        // No assets defined, so tick is not initialized
+        _assertPreviousTick(0, 0, newTickSize, 0);
+        // _assertAuctionResultsEmpty(0);
+        // _assertAuctionResultsNextIndex(0);
     }
 
     // given the contract is not initialized

--- a/src/test/policies/EmissionManager.t.sol
+++ b/src/test/policies/EmissionManager.t.sol
@@ -643,6 +643,27 @@ contract EmissionManagerTest is Test {
             "Market counter should not increment"
         );
 
+        // Verify the auctioneer parameters
+        {
+            // Target == getNextEmission().emission
+            (, , uint256 emission) = emissionManager.getNextEmission();
+
+            assertEq(cdAuctioneer.target(), emission, "Target should be the emission");
+
+            // Tick size == getSizeFor(emission)
+            assertEq(
+                cdAuctioneer.tickSize(),
+                emissionManager.getSizeFor(emission),
+                "Tick size should be the emission"
+            );
+
+            // Min price == getMinPriceFor(emission)
+            assertEq(cdAuctioneer.minPrice(), expectedMinPrice, "Min price");
+
+            assertEq(emission, 0, "target should be zero");
+            assertEq(cdAuctioneer.tickSize(), 1, "tick size should be 1");
+        }
+
         // Confirm that the token balances are still 0
         assertEq(ohm.balanceOf(address(emissionManager)), 0, "OHM balance should be 0");
         assertEq(reserve.balanceOf(address(emissionManager)), 0, "Reserve balance should be 0");
@@ -3032,5 +3053,19 @@ contract EmissionManagerTest is Test {
 
         // Expect the premium to be 200%
         assertEq(premium, 200e16, "Premium should be 200%");
+    }
+
+    // getSizeFor tests
+
+    function test_getSizeFor_zero() public view {
+        assertEq(emissionManager.getSizeFor(0), 1, "getSizeFor");
+    }
+
+    function test_getSizeFor(uint256 target_) public view {
+        target_ = bound(target_, 1, 1000e9);
+
+        uint256 expectedSize = (target_ * tickSizeScalar) / 1e18;
+
+        assertEq(emissionManager.getSizeFor(target_), expectedSize, "getSizeFor");
     }
 }


### PR DESCRIPTION
Fixes the ConvertibleDepositAuctioneer so that if the EmissionsManager determines that there are to be no emissions for that day, the auctioneer does not revert, but effectively disables the auction (no day target, and a tick size of 1 wei).