### PR TITLE
Convertible Deposits: Audit: Gracefully handle failure in bond market creation [20]

### DIFF
--- a/src/policies/EmissionManager.sol
+++ b/src/policies/EmissionManager.sol
@@ -198,6 +198,7 @@ contract EmissionManager is IEmissionManager, IPeriodicTask, Policy, PolicyEnabl
     ///             - Exits if the beat counter is not 0
     ///             - Sets the parameters for the auction
     ///             - If the auction tracking period has finished and there is a deficit of OHM sold, attempts to create a bond market
+    ///             - If market creation fails (external dependency), emits BondMarketCreationFailed and continues execution
     function execute() external onlyRole(ROLE_HEART) {
         // Don't do anything if disabled
         if (!isEnabled) return;

--- a/src/policies/EmissionManager.sol
+++ b/src/policies/EmissionManager.sol
@@ -40,6 +40,8 @@ contract EmissionManager is IEmissionManager, IPeriodicTask, Policy, PolicyEnabl
     /// @notice The length of the `EnableParams` struct in bytes
     uint256 internal constant ENABLE_PARAMS_LENGTH = 192;
 
+    uint256 internal constant _TICK_SIZE_MINIMUM = 1;
+
     // ========== STATE VARIABLES ========== //
 
     /// @notice active base emissions rate change information
@@ -610,7 +612,7 @@ contract EmissionManager is IEmissionManager, IPeriodicTask, Policy, PolicyEnabl
         // CDAuctioneer will not accept a tick size of 0, so return the minimum accepted amount. This will effectively disable auctions, as the price would go vertical.
         // This also handles the situation where rounding causes the calculated size to be 0
         uint256 size = (target * tickSizeScalar) / ONE_HUNDRED_PERCENT;
-        if (size == 0) return 1;
+        if (size == 0) return _TICK_SIZE_MINIMUM;
 
         return size;
     }

--- a/src/policies/EmissionManager.sol
+++ b/src/policies/EmissionManager.sol
@@ -94,6 +94,9 @@ contract EmissionManager is IEmissionManager, IPeriodicTask, Policy, PolicyEnabl
     /// @notice time in seconds that the manager needs to be restarted after a shutdown, otherwise it must be re-initialized
     uint48 public restartTimeframe;
 
+    /// @notice In situations where a bond market cannot be created, this variable is used to record the OHM capacity for the bond market that needs to be created
+    uint256 public bondMarketPendingCapacity;
+
     // ========== SETUP ========== //
 
     constructor(
@@ -188,6 +191,11 @@ contract EmissionManager is IEmissionManager, IPeriodicTask, Policy, PolicyEnabl
     // ========== PERIODIC TASK ========== //
 
     /// @inheritdoc IPeriodicTask
+    /// @dev        This function performs the following:
+    ///             - Adjusts the beat counter
+    ///             - Exits if the beat counter is not 0
+    ///             - Sets the parameters for the auction
+    ///             - If the auction tracking period has finished and there is a deficit of OHM sold, attempts to create a bond market
     function execute() external onlyRole(ROLE_HEART) {
         // Don't do anything if disabled
         if (!isEnabled) return;
@@ -225,8 +233,27 @@ contract EmissionManager is IEmissionManager, IPeriodicTask, Policy, PolicyEnabl
             // If there was under-selling, create a market to sell the remaining OHM
             if (difference < 0) {
                 uint256 remainder = uint256(-difference);
-                MINTR.increaseMintApproval(address(this), remainder);
-                _createMarket(remainder);
+
+                // Set the pending capacity (used by the createPendingBondMarket() function)
+                bondMarketPendingCapacity = remainder;
+
+                // Attempt to create the bond market
+                try this.createPendingBondMarket() {
+                    // If successful, zero out the pending capacity
+                    bondMarketPendingCapacity = 0;
+                } catch {
+                    // We don't want the periodic task to fail, so catch the error
+                    // But trigger an event that can be monitored
+                    // Upon failure, the createPendingBondMarket() function can be called again to trigger the bond market
+                    emit BondMarketCreationFailed(remainder);
+                }
+            }
+            // Otherwise, make sure we reset the pending capacity
+            // If there is an issue with creating the bond market, this gives the role-holder the auction tracking period to fix the underlying issue and trigger the creation of the market
+            else {
+                if (bondMarketPendingCapacity > 0) {
+                    bondMarketPendingCapacity = 0;
+                }
             }
         }
     }
@@ -606,6 +633,28 @@ contract EmissionManager is IEmissionManager, IPeriodicTask, Policy, PolicyEnabl
 
         // Change the decimal scale to be the reserve asset's
         return currentPrice.mulDiv(10 ** _reserveDecimals, 10 ** _oracleDecimals);
+    }
+
+    // ========== BOND MARKET CREATION ========== //
+
+    /// @notice Creates a bond market
+    /// @dev    Notes:
+    ///         - If there is no pending capacity, no bond market will be created
+    ///
+    ///         This function will revert if:
+    ///         - The caller is not this contract, or an address with the admin/manager role
+    ///         - The bond market cannot be created
+    function createPendingBondMarket() external {
+        // Validate that the caller is this contract or an admin/manager
+        if (msg.sender != address(this) && !_isManager(msg.sender) && !_isAdmin(msg.sender))
+            revert NotAuthorised();
+
+        // If there is no pending capacity, skip
+        if (bondMarketPendingCapacity == 0) return;
+
+        // Create the market
+        MINTR.increaseMintApproval(address(this), bondMarketPendingCapacity);
+        _createMarket(bondMarketPendingCapacity);
     }
 
     // ========== ERC165 ========== //

--- a/src/policies/EmissionManager.sol
+++ b/src/policies/EmissionManager.sol
@@ -199,6 +199,9 @@ contract EmissionManager is IEmissionManager, IPeriodicTask, Policy, PolicyEnabl
     ///             - Sets the parameters for the auction
     ///             - If the auction tracking period has finished and there is a deficit of OHM sold, attempts to create a bond market
     ///             - If market creation fails (external dependency), emits BondMarketCreationFailed and continues execution
+    ///
+    ///             Notes:
+    ///             - If there are delays in the heartbeat (which calls this function), auction result tracking will be affected.
     function execute() external onlyRole(ROLE_HEART) {
         // Don't do anything if disabled
         if (!isEnabled) return;

--- a/src/policies/EmissionManager.sol
+++ b/src/policies/EmissionManager.sol
@@ -239,8 +239,8 @@ contract EmissionManager is IEmissionManager, IPeriodicTask, Policy, PolicyEnabl
 
                 // Attempt to create the bond market
                 try this.createPendingBondMarket() {
-                    // If successful, zero out the pending capacity
-                    bondMarketPendingCapacity = 0;
+                    // Do nothing if successful
+                    // createPendingBondMarket() resets the pending capacity, so it does not need to be done here
                 } catch {
                     // We don't want the periodic task to fail, so catch the error
                     // But trigger an event that can be monitored
@@ -655,6 +655,10 @@ contract EmissionManager is IEmissionManager, IPeriodicTask, Policy, PolicyEnabl
         // Create the market
         MINTR.increaseMintApproval(address(this), bondMarketPendingCapacity);
         _createMarket(bondMarketPendingCapacity);
+
+        // Set the pending capacity to 0
+        // This prevents the bond market from being created again
+        bondMarketPendingCapacity = 0;
     }
 
     // ========== ERC165 ========== //

--- a/src/policies/interfaces/IEmissionManager.sol
+++ b/src/policies/interfaces/IEmissionManager.sol
@@ -14,6 +14,9 @@ interface IEmissionManager {
     // ========== EVENTS ========== //
 
     event SaleCreated(uint256 marketID, uint256 saleAmount);
+
+    event BondMarketCreationFailed(uint256 saleAmount);
+
     event BackingUpdated(uint256 newBacking, uint256 supplyAdded, uint256 reservesAdded);
 
     /// @notice Emitted when the base emission rate is changed


### PR DESCRIPTION
- If the EmissionManager cannot create a bond market (which is possible, given that it is an external contract), the EmissionManager will now gracefully handle it (avoiding a revert of the heartbeat) and allow for the bond market to be created later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a pending-capacity queue for bond-market creation, ensuring unsold capacity is preserved and retried.
  * Introduces an admin-accessible action to manually trigger creation of any pending bond market.
  * Exposes a read-only value to monitor currently pending capacity.
  * Emits a dedicated event when bond-market creation fails, enabling easier monitoring and alerting.
* **Tests**
  * Expanded test coverage for failure scenarios, pending-capacity handling, event emission, and counter behavior to ensure consistent, resilient execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->