### PR TITLE
Price Feed Resilience: Fix average strategy no-deviation feed selection

### DIFF
--- a/src/modules/PRICE/submodules/strategies/SimplePriceFeedStrategy.sol
+++ b/src/modules/PRICE/submodules/strategies/SimplePriceFeedStrategy.sol
@@ -182,10 +182,13 @@ contract SimplePriceFeedStrategy is PriceSubmodule, ISimplePriceFeedStrategy {
         // 0 prices = no data, always revert
         if (nonZeroPricesLen == 0) revert SimpleStrategy_PriceCountInvalid(0, 2);
 
+        // Cache first non-zero price before sorting
+        uint256 firstNonZeroPrice = nonZeroPrices[0];
+
         // 1 price = check flag
         if (nonZeroPricesLen == 1) {
             if (params.revertOnInsufficientCount) revert SimpleStrategy_PriceCountInvalid(1, 2);
-            return nonZeroPrices[0]; // flag=false: accept single source
+            return firstNonZeroPrice; // flag=false: accept single source
         }
 
         // ========== 2+ PRICES: CHECK DEVIATION ==========
@@ -203,7 +206,7 @@ contract SimplePriceFeedStrategy is PriceSubmodule, ISimplePriceFeedStrategy {
             return averagePrice;
 
         // No deviation detected, return the first non-zero price
-        return nonZeroPrices[0];
+        return firstNonZeroPrice;
     }
 
     /// @inheritdoc ISimplePriceFeedStrategy

--- a/src/test/modules/PRICE.v2/submodules/strategies/SimplePriceFeedStrategy/getAveragePriceIfDeviation.t.sol
+++ b/src/test/modules/PRICE.v2/submodules/strategies/SimplePriceFeedStrategy/getAveragePriceIfDeviation.t.sol
@@ -193,6 +193,24 @@ contract SimplePriceFeedStrategyGetAveragePriceIfDeviationTest is SimplePriceFee
         assertEq(price, 1e18, "should return first price when no deviation");
     }
 
+    function test_whenNoDeviation_returnsFirstConfiguredNonZeroPrice() public view {
+        uint256[] memory prices = new uint256[](4);
+        prices[0] = 0;
+        prices[1] = 1.002e18; // first configured non-zero price
+        prices[2] = 1e18; // lower than first non-zero
+        prices[3] = 1.001e18;
+
+        uint256 price = strategy.getAveragePriceIfDeviation(
+            prices,
+            _encodeDeviationParams(uint16(100), false) // 1% threshold
+        );
+        assertEq(
+            price,
+            1.002e18,
+            "should return first configured non-zero price when no deviation"
+        );
+    }
+
     // ========== FUZZ TESTS ========== //
 
     function test_whenThreePrices_whenDeviating_fuzz(


### PR DESCRIPTION
## Summary
- preserve feed-order semantics in `getAveragePriceIfDeviation` by caching the first non-zero price before sorting
- return the cached first non-zero price on the no-deviation path (and the single-source best-effort path)
- add a regression test proving no-deviation results use the first configured non-zero feed, not the minimum sorted feed

## Audit
- fixes L-02: `getAveragePriceIfDeviation` returned the minimum surviving price after in-place sort instead of the first configured non-zero feed when no deviation was detected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal caching logic in price strategy calculations.

* **Tests**
  * Added test coverage for price deviation edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->