### PR TITLE
Price Feed Resilience: iterative deviation filtering and strict survivor handling

### DIFF
--- a/src/modules/PRICE/submodules/strategies/SimplePriceFeedStrategy.sol
+++ b/src/modules/PRICE/submodules/strategies/SimplePriceFeedStrategy.sol
@@ -506,15 +506,12 @@ contract SimplePriceFeedStrategy is PriceSubmodule, ISimplePriceFeedStrategy {
 
         // ========== 3+ PRICES: USE MEDIAN AS BENCHMARK ==========
         uint256[] memory sortedPrices = nonZeroPrices.sort();
-        uint256 medianPrice = _getMedianPrice(sortedPrices);
-
-        // Filter by deviation from median
-        (uint256[] memory validPrices, uint256 validCount) = _filterByDeviation(
+        uint256[] memory validPrices = _filterByMedianDeviationUntilStable(
             sortedPrices,
-            medianPrice,
             params.deviationBps,
             2
         );
+        uint256 validCount = validPrices.length;
 
         // 1 price = check flag
         if (validCount == 1 && params.revertOnInsufficientCount)
@@ -619,18 +616,15 @@ contract SimplePriceFeedStrategy is PriceSubmodule, ISimplePriceFeedStrategy {
 
         // ========== 3+ PRICES: USE MEDIAN AS BENCHMARK ==========
         // Note: Using median (not average) as benchmark for the deviation check
-        // This is the same approach as getAveragePriceExcludingDeviations
+        // This is the same iterative approach as getAveragePriceExcludingDeviations
         // Using median as benchmark prevents the case where all values deviate from their own average
         uint256[] memory sortedPrices = nonZeroPrices.sort();
-        uint256 medianPrice = _getMedianPrice(sortedPrices);
-
-        // Filter by deviation from median
-        (uint256[] memory validPrices, uint256 validCount) = _filterByDeviation(
+        uint256[] memory validPrices = _filterByMedianDeviationUntilStable(
             sortedPrices,
-            medianPrice,
             params.deviationBps,
             3
         );
+        uint256 validCount = validPrices.length;
 
         // 1 price = check flag (median requires 3+ sources)
         if (validCount == 1 && params.revertOnInsufficientCount)
@@ -672,6 +666,36 @@ contract SimplePriceFeedStrategy is PriceSubmodule, ISimplePriceFeedStrategy {
             revert SimpleStrategy_ParamsInvalid(params_);
 
         return params;
+    }
+
+    /// @notice         Filters prices iteratively using a median benchmark until the set is stable
+    /// @dev            Stops when no additional prices are removed or when fewer than 3 prices remain
+    ///
+    /// @param  prices_            Sorted array of prices to filter
+    /// @param  deviationBps_      The accepted deviation in basis points
+    /// @param  minExpectedCount_  Minimum number of prices required (for error reporting)
+    /// @return validPrices_       Sorted array of prices after iterative filtering
+    function _filterByMedianDeviationUntilStable(
+        uint256[] memory prices_,
+        uint16 deviationBps_,
+        uint256 minExpectedCount_
+    ) internal pure returns (uint256[] memory validPrices_) {
+        validPrices_ = prices_;
+
+        while (validPrices_.length >= 3) {
+            uint256 medianPrice = _getMedianPrice(validPrices_);
+            (uint256[] memory nextValidPrices, uint256 nextValidCount) = _filterByDeviation(
+                validPrices_,
+                medianPrice,
+                deviationBps_,
+                minExpectedCount_
+            );
+
+            // No prices were excluded in this round, so the set is stable
+            if (nextValidCount == validPrices_.length) break;
+
+            validPrices_ = nextValidPrices;
+        }
     }
 
     /// @notice         Filters prices by deviation from a benchmark value

--- a/src/test/modules/PRICE.v2/submodules/strategies/SimplePriceFeedStrategy/getAveragePriceExcludingDeviations.t.sol
+++ b/src/test/modules/PRICE.v2/submodules/strategies/SimplePriceFeedStrategy/getAveragePriceExcludingDeviations.t.sol
@@ -509,6 +509,24 @@ contract SimplePriceFeedStrategyGetAveragePriceExcludingDeviationsTest is
         strategy.getAveragePriceExcludingDeviations(prices, params);
     }
 
+    function test_whenFilteringLeavesOnePrice_strictMode_reverts() public {
+        uint256[] memory prices = new uint256[](3);
+        prices[0] = 10000e18;
+        prices[1] = 10400e18;
+        prices[2] = 11000e18;
+        bytes memory params = _encodeDeviationParams(200, true); // 2% deviation, strict mode
+
+        // Sorted prices: [10000e18, 10400e18, 11000e18]
+        // Median benchmark: 10400e18
+        // 10000e18: |10400 - 10000| / 10400 = 3.84% > 2% -> Exclude
+        // 10400e18: 0% -> Include
+        // 11000e18: |11000 - 10400| / 10400 = 5.77% > 2% -> Exclude
+        // Final survivors: [10400e18] (count = 1)
+        // strict mode for average requires >= 2 prices, so this must revert.
+        _expectRevertPriceCount(1, 2);
+        strategy.getAveragePriceExcludingDeviations(prices, params);
+    }
+
     function test_whenFourPrices_zeroDeviating(uint8 seed) public view {
         seed = uint8(bound(seed, 0, 4));
 
@@ -666,6 +684,61 @@ contract SimplePriceFeedStrategyGetAveragePriceExcludingDeviationsTest is
         // Expected: (1075e18 + 1100e18) / 2 = 2175e18 / 2 = 1087.5e18
         uint256 expected = 1087.5e18;
         assertEq(result, expected, "should return average of 2 remaining prices");
+    }
+
+    function test_whenFourPrices_whenExtremeOutlierMasksWeakerOutlier_iteratesUntilStable()
+        public
+        view
+    {
+        uint256[] memory prices = new uint256[](4);
+        prices[0] = 11000e18;
+        prices[1] = 10000e18;
+        prices[2] = 10400e18;
+        prices[3] = 10000e18;
+
+        uint256 result = strategy.getAveragePriceExcludingDeviations(
+            prices,
+            _encodeDeviationParams(200, false)
+        );
+
+        // Sorted prices: [10000e18, 10000e18, 10400e18, 11000e18]
+        // First benchmark median: (10000e18 + 10400e18) / 2 = 10200e18
+        // First pass removes only 11000e18, leaving [10000e18, 10000e18, 10400e18]
+        // Recomputed benchmark median: 10000e18
+        // Second pass removes 10400e18 (4% deviation > 2% threshold)
+        // Final survivors: [10000e18, 10000e18], average = 10000e18
+        assertEq(
+            result,
+            10000e18,
+            "should iterate filtering until benchmark and survivor set are stable"
+        );
+    }
+
+    function test_whenOutliersAreExcluded_strictMode_returnsAverageOfInBandSurvivors() public view {
+        uint256[] memory prices = new uint256[](6);
+        prices[0] = 20000e18;
+        prices[1] = 11000e18;
+        prices[2] = 10100e18;
+        prices[3] = 10000e18;
+        prices[4] = 10000e18;
+        prices[5] = 10000e18;
+
+        uint256 result = strategy.getAveragePriceExcludingDeviations(
+            prices,
+            _encodeDeviationParams(200, true)
+        );
+
+        // Sorted prices: [10000e18, 10000e18, 10000e18, 10100e18, 11000e18, 20000e18]
+        // First benchmark median: (10000e18 + 10100e18) / 2 = 10050e18
+        // First pass excludes 11000e18 and 20000e18, survivors:
+        //   [10000e18, 10000e18, 10000e18, 10100e18]
+        // Recomputed benchmark median: (10000e18 + 10000e18) / 2 = 10000e18
+        // All survivors remain in-band at 2%:
+        //   10000e18: 0%
+        //   10100e18: 1%
+        // Final average:
+        //   (10000e18 + 10000e18 + 10000e18 + 10100e18) / 4 = 10025e18
+        assertEq(result, 10025e18, "should return the average of the final in-band survivor set");
     }
 
     // Note: For even count (4 prices), the median is the average of the two middle

--- a/src/test/modules/PRICE.v2/submodules/strategies/SimplePriceFeedStrategy/getMedianPriceExcludingDeviations.t.sol
+++ b/src/test/modules/PRICE.v2/submodules/strategies/SimplePriceFeedStrategy/getMedianPriceExcludingDeviations.t.sol
@@ -366,6 +366,56 @@ contract SimplePriceFeedStrategyGetMedianPriceExcludingDeviationsTest is
         );
     }
 
+    function test_whenFourPrices_whenExtremeOutlierMasksWeakerOutlier_strictMode_reverts() public {
+        uint256[] memory prices = new uint256[](4);
+        prices[0] = 11000e18;
+        prices[1] = 10000e18;
+        prices[2] = 10400e18;
+        prices[3] = 10000e18;
+
+        // Sorted prices: [10000e18, 10000e18, 10400e18, 11000e18]
+        // First benchmark median: (10000e18 + 10400e18) / 2 = 10200e18
+        // First pass excludes 11000e18, survivors:
+        //   [10000e18, 10000e18, 10400e18]
+        // Recomputed benchmark median: 10000e18
+        // Second pass excludes 10400e18 (4% deviation > 2%), survivors:
+        //   [10000e18, 10000e18]
+        // Final survivor count is 2.
+        // Strict mode requires 3+ valid prices for median resolution, so this must revert.
+        _expectRevertPriceCount(2, 3);
+        strategy.getMedianPriceExcludingDeviations(
+            prices,
+            _encodeDeviationParams(uint16(200), true)
+        );
+    }
+
+    function test_whenOutliersAreExcluded_strictMode_returnsMedianOfInBandSurvivors() public view {
+        uint256[] memory prices = new uint256[](6);
+        prices[0] = 20000e18;
+        prices[1] = 11000e18;
+        prices[2] = 10100e18;
+        prices[3] = 10000e18;
+        prices[4] = 10000e18;
+        prices[5] = 10000e18;
+
+        uint256 price = strategy.getMedianPriceExcludingDeviations(
+            prices,
+            _encodeDeviationParams(uint16(200), true)
+        );
+
+        // Sorted prices: [10000e18, 10000e18, 10000e18, 10100e18, 11000e18, 20000e18]
+        // First benchmark median: (10000e18 + 10100e18) / 2 = 10050e18
+        // First pass excludes 11000e18 and 20000e18, survivors:
+        //   [10000e18, 10000e18, 10000e18, 10100e18]
+        // Recomputed benchmark median: (10000e18 + 10000e18) / 2 = 10000e18
+        // All survivors remain in-band at 2%:
+        //   10000e18: 0%
+        //   10100e18: 1%
+        // Final median of [10000e18, 10000e18, 10000e18, 10100e18]:
+        //   (10000e18 + 10000e18) / 2 = 10000e18
+        assertEq(price, 10000e18, "should return median of the final in-band survivor set");
+    }
+
     // ========== FUZZ TESTS ========== //
 
     function test_whenThreePrices_noDeviation_fuzz(


### PR DESCRIPTION
## Summary
- apply iterative median-based deviation filtering until survivor set stabilizes in exclusion strategies
- add regression coverage for cascading-outlier behavior in average/median exclusion strategies
- add strict-mode insufficient-survivor and in-band survivor aggregation tests

## Audit
- Addresses audit issue: M-06


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced price deviation filtering logic to use iterative refinement, improving robustness when handling extreme outliers in price data.

* **Tests**
  * Added comprehensive test coverage for edge cases in price exclusion scenarios, including extreme outliers, minimal survivor sets, and multi-pass filtering iterations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->