### PR TITLE
Price Feed Resilience: add L-20 regression for MA metadata clear on disable

### DIFF
--- a/src/test/modules/PRICE.v2/updateAsset.t.sol
+++ b/src/test/modules/PRICE.v2/updateAsset.t.sol
@@ -2053,6 +2053,63 @@ contract PriceV2UpdateAssetTest is PriceV2BaseTest {
         price.getPrice(asset_SingleFeed_NoStrategy_StoreMA, IPRICEv2.Variant.LAST);
     }
 
+    function test_whenUpdatingMovingAverage_whenStoreMovingAverageFalse_afterObservationStored_clearsMetadata()
+        public
+        givenAsset_SingleFeed_NoStrategy_StoreMA
+    {
+        vm.prank(priceWriter);
+        price.storeObservation(asset_SingleFeed_NoStrategy_StoreMA);
+
+        IPRICEv2.Asset memory oldAssetData = price.getAssetData(
+            asset_SingleFeed_NoStrategy_StoreMA
+        );
+        assertEq(oldAssetData.storeMovingAverage, true, "precondition: MA should be stored");
+        assertEq(
+            oldAssetData.nextObsIndex,
+            uint16(1),
+            "precondition: nextObsIndex should advance after storing an observation"
+        );
+        assertGt(
+            oldAssetData.movingAverageDuration,
+            uint32(0),
+            "precondition: movingAverageDuration should be non-zero"
+        );
+        assertGt(
+            oldAssetData.numObservations,
+            uint16(0),
+            "precondition: numObservations should be non-zero"
+        );
+        assertGt(
+            oldAssetData.lastObservationTime,
+            uint48(0),
+            "precondition: lastObservationTime should be non-zero"
+        );
+
+        IPRICEv2.UpdateAssetParams memory params = IPRICEv2.UpdateAssetParams({
+            updateFeeds: false,
+            updateStrategy: false,
+            updateMovingAverage: true,
+            feeds: new IPRICEv2.Component[](0),
+            strategy: _emptyStrategy(),
+            useMovingAverage: false,
+            storeMovingAverage: false,
+            movingAverageDuration: uint32(0),
+            lastObservationTime: uint48(0),
+            observations: new uint256[](0)
+        });
+
+        vm.expectEmit(true, true, true, true);
+        emit AssetMovingAverageUpdated(asset_SingleFeed_NoStrategy_StoreMA);
+
+        vm.prank(priceWriter);
+        price.updateAsset(asset_SingleFeed_NoStrategy_StoreMA, params);
+
+        IPRICEv2.Asset memory assetData = price.getAssetData(asset_SingleFeed_NoStrategy_StoreMA);
+        _assertFeedsUnchanged(oldAssetData, assetData);
+        _assertStrategyUnchanged(oldAssetData, assetData);
+        _assertMovingAverageNotStored(assetData);
+    }
+
     function test_whenUpdatingMovingAverage_whenStoreMovingAverageFalse_whenDurationIsNonZero_reverts()
         public
         givenAsset_SingleFeed_NoStrategy_StoreMA


### PR DESCRIPTION
## Summary
- add a regression test for disabling moving-average storage after at least one observation has been stored
- verify preconditions show active MA metadata (`nextObsIndex`, `movingAverageDuration`, `numObservations`, `lastObservationTime`)
- verify `updateAsset(... storeMovingAverage=false ...)` clears MA metadata via `_assertMovingAverageNotStored`

## Validation
- `forge test --match-path src/test/modules/PRICE.v2/updateAsset.t.sol --match-test test_whenUpdatingMovingAverage_whenStoreMovingAverageFalse_afterObservationStored_clearsMetadata -vvv`
- `pnpm run lint:check`
- `coderabbit --prompt-only -t uncommitted --base fix/price-cache` (no findings)

## Audit reference
- Adds regression coverage for audit issue `L-20`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved oracle price conversion to use safer casting that prevents integer overflow conditions.

* **Tests**
  * Added test to verify oracle correctly handles price values that exceed safe conversion limits.
  * Added test to verify moving average metadata is properly cleared when storage is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->