### PR TITLE
Price Feed Resilience: honor final useMovingAverage state in updateAsset cache selection

### DIFF
--- a/src/modules/PRICE/OlympusPrice.v2.sol
+++ b/src/modules/PRICE/OlympusPrice.v2.sol
@@ -830,7 +830,7 @@ contract OlympusPricev2 is PRICEv2, IVersioned {
         }
 
         if (params_.updateStrategy) {
-            _updateAssetPriceStrategy(asset_, params_.strategy, params_.useMovingAverage);
+            _updateAssetPriceStrategy(asset_, params_.strategy, finalUseMA);
         }
 
         if (params_.updateMovingAverage) {

--- a/src/test/modules/PRICE.v2/updateAsset.t.sol
+++ b/src/test/modules/PRICE.v2/updateAsset.t.sol
@@ -1734,6 +1734,66 @@ contract PriceV2UpdateAssetTest is PriceV2BaseTest {
         assertEq(lastPrice, 5e18, "LAST should remain the most recent stored observation");
     }
 
+    // when the moving average configuration is being updated, when the strategy configuration is not being updated, when params.useMovingAverage is false but existing strategy uses MA: LAST remains observation-based
+
+    function test_whenUpdatingMovingAverage_whenNotUpdatingStrategy_whenParamsUseMovingAverageFalse_lastRemainsObservationBased()
+        public
+    {
+        uint256[] memory observations = new uint256[](2);
+        observations[0] = 5e18;
+        observations[1] = 5e18;
+
+        vm.startPrank(priceWriter);
+        ChainlinkPriceFeeds.OneFeedParams memory onemaFeedParams = ChainlinkPriceFeeds
+            .OneFeedParams(onemaUsdPriceFeed, uint48(24 hours));
+
+        IPRICEv2.Component[] memory feeds = new IPRICEv2.Component[](1);
+        feeds[0] = IPRICEv2.Component(
+            toSubKeycode("PRICE.CHAINLINK"),
+            ChainlinkPriceFeeds.getOneFeedPrice.selector,
+            abi.encode(onemaFeedParams)
+        );
+
+        // Initial add with strategy using MA and observation price 5e18.
+        onemaUsdPriceFeed.setLatestAnswer(int256(5e8));
+        price.addAsset(
+            address(onema),
+            true, // storeMovingAverage
+            true, // useMovingAverage
+            uint32(observations.length) * OBSERVATION_FREQUENCY,
+            uint48(block.timestamp),
+            observations,
+            IPRICEv2.Component(
+                toSubKeycode("PRICE.SIMPLESTRATEGY"),
+                ISimplePriceFeedStrategy.getAveragePrice.selector,
+                abi.encode(0)
+            ),
+            feeds
+        );
+
+        // Update moving average only. `useMovingAverage` in params should be ignored.
+        onemaUsdPriceFeed.setLatestAnswer(int256(10e8)); // Feed returns 10e18.
+
+        IPRICEv2.UpdateAssetParams memory params = IPRICEv2.UpdateAssetParams({
+            updateFeeds: false,
+            updateStrategy: false,
+            updateMovingAverage: true,
+            feeds: new IPRICEv2.Component[](0),
+            strategy: _emptyStrategy(),
+            useMovingAverage: false, // Should be ignored because updateStrategy = false.
+            storeMovingAverage: true,
+            movingAverageDuration: uint32(observations.length) * OBSERVATION_FREQUENCY,
+            lastObservationTime: uint48(block.timestamp),
+            observations: observations
+        });
+
+        price.updateAsset(address(onema), params);
+        vm.stopPrank();
+
+        (uint256 lastPrice, ) = price.getPrice(address(onema), IPRICEv2.Variant.LAST);
+        assertEq(lastPrice, 5e18, "LAST should remain the most recent stored observation");
+    }
+
     // when the moving average configured is being updated, when store moving average is true: LAST remains observation-based
 
     function test_whenUpdatingMovingAverage_whenUseMovingAverageTrue_lastRemainsObservationBased()


### PR DESCRIPTION
## Summary
- add a regression test covering `updateStrategy = false` while `useMovingAverage` is set in params
- fix `OlympusPrice.v2.updateAsset()` to use resolved final state (`finalUseMA`) when selecting cache behavior
- align implementation with the documented `IPricev2.UpdateAssetParams` contract

## Audit Reference
- Addresses **L-09** audit issue: `updateAsset()` cache-selection path read `params_.useMovingAverage` even when `updateStrategy=false`.

## Why this matters
When `updateStrategy=false`, strategy fields are documented as ignored. Before this fix, `params_.useMovingAverage` could still change whether a single supplied observation updated `Variant.LAST`, causing state differences from an ignored field.

## Validation
- `pnpm install`
- `pnpm build`
- `forge test --match-path src/test/modules/PRICE.v2/updateAsset.t.sol`
- `pnpm run lint:check`

## Notes
- Regression reproduces on audited `price-feed-improvements` branch and passes with this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added overflow protection to price oracle calculations to prevent unsafe type conversions

* **Tests**
  * Added test coverage for price update edge cases, including moving average configurations and cached pricing scenarios with overflow validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->