### PR TITLE
Price Feed Resilience: enforce earliest allowed observation time

### DIFF
--- a/snapshots/PriceV2GasTest.json
+++ b/snapshots/PriceV2GasTest.json
@@ -1,6 +1,6 @@
 {
     "OlympusPricev2.getPrice.current": "58227",
     "OlympusPricev2.getPrice.last": "2688",
-    "OlympusPricev2.getPriceIn.last": "5233",
-    "OlympusPricev2.storeObservation": "84587"
+    "OlympusPricev2.getPriceIn.last": "5173",
+    "OlympusPricev2.storeObservation": "84894"
 }

--- a/src/modules/PRICE/IPRICE.v2.sol
+++ b/src/modules/PRICE/IPRICE.v2.sol
@@ -85,6 +85,17 @@ interface IPRICEv2 {
     /// @param lastObservationTime_     The timestamp of the last observation
     error PRICE_MovingAverageStale(address asset_, uint48 lastObservationTime_);
 
+    /// @notice                         An observation was attempted before the earliest permitted timestamp
+    ///
+    /// @param asset_                   The address of the asset
+    /// @param observationTime_         The timestamp used by the attempted observation
+    /// @param earliestAllowedTime_     The earliest permissible timestamp for the next observation
+    error PRICE_ObservationTooEarly(
+        address asset_,
+        uint48 observationTime_,
+        uint48 earliestAllowedTime_
+    );
+
     /// @notice                     The last observation time is invalid
     /// @dev                        The last observation time must be less than the latest timestamp
     ///

--- a/src/modules/PRICE/OlympusPrice.v2.sol
+++ b/src/modules/PRICE/OlympusPrice.v2.sol
@@ -363,8 +363,11 @@ contract OlympusPricev2 is PRICEv2, IVersioned {
     /// @dev        Reentrancy note: feed/strategy resolution is done via `staticcall`, so callbacks
     /// @dev        cannot perform state-changing reentry.
     ///
-    /// @dev        This function does not enforce a minimum frequency between observations,
-    /// @dev        leaving the onus on the caller to perform validation.
+    /// @dev        This function enforces an implementation-defined earliest allowed timestamp for each
+    /// @dev        asset observation write. The current implementation uses `lastObservationTime + 1`,
+    /// @dev        which prevents same-block double writes.
+    /// @dev        It does not enforce a larger minimum frequency between observations.
+    /// @dev        Calling policies are responsible for cadence/epoch scheduling.
     ///
     /// @param asset_   The address of the asset
     function storeObservation(address asset_) public override permissioned {
@@ -377,6 +380,8 @@ contract OlympusPricev2 is PRICEv2, IVersioned {
     /// @dev    - The moving average is not stored for the asset
     /// @dev    - Getting the prices fails
     /// @dev    - Aggregating the prices fails
+    /// @dev    - The observation timestamp is before the implementation-defined earliest allowed time
+    /// @dev    - Cadence beyond same-block writes is not enforced in this module
     ///
     /// @param asset_   The address of the asset
     function _storeObservation(address asset_) internal {
@@ -386,6 +391,12 @@ contract OlympusPricev2 is PRICEv2, IVersioned {
         if (!asset.approved) revert PRICE_AssetNotApproved(asset_);
         // Check if asset stores moving average
         if (!asset.storeMovingAverage) revert PRICE_MovingAverageNotStored(asset_);
+        uint48 observationTime = uint48(block.timestamp);
+        uint48 earliestAllowedTime = asset.lastObservationTime;
+        // Earliest allowed is implementation-defined; currently last observation + 1 second.
+        if (earliestAllowedTime < type(uint48).max) earliestAllowedTime += 1;
+        if (observationTime < earliestAllowedTime)
+            revert PRICE_ObservationTooEarly(asset_, observationTime, earliestAllowedTime);
 
         // Get the current observation value (excludes MA contribution by design).
         (uint256 obsPrice, uint48 currentTime, ) = _getCurrentPrice(asset_, false);
@@ -418,8 +429,11 @@ contract OlympusPricev2 is PRICEv2, IVersioned {
     /// @dev        Reentrancy note: delegates to `storeObservation()`, which only reaches external
     /// @dev        price providers via `staticcall`.
     ///
-    /// @dev        This function does not enforce a minimum frequency between observations,
-    /// @dev        leaving the onus on the caller to perform validation.
+    /// @dev        This function enforces an implementation-defined earliest allowed timestamp for each
+    /// @dev        asset observation write. The current implementation uses `lastObservationTime + 1`,
+    /// @dev        which prevents same-block double writes.
+    /// @dev        It does not enforce a larger minimum frequency between observations.
+    /// @dev        Calling policies are responsible for cadence/epoch scheduling.
     function storeObservations() public override permissioned {
         uint256 len = assets.length;
         for (uint256 i; i < len; ) {

--- a/src/test/modules/PRICE.v2/PRICE.v2.t.sol
+++ b/src/test/modules/PRICE.v2/PRICE.v2.t.sol
@@ -74,6 +74,7 @@ import {UniswapV3Price} from "modules/PRICE/submodules/feeds/UniswapV3Price.sol"
 //      [X] reverts if asset not configured on PRICE module (not approved)
 //      [X] reverts if price is zero
 //      [X] reverts if caller is not permissioned
+//      [X] reverts if called twice in the same block
 //      [X] reverts if observationFrequency has not elapsed since last observation
 //      [X] updates stored observations
 //           [X] single observation stored (no moving average)
@@ -1774,6 +1775,28 @@ contract PriceV2Test is PriceV2BaseTest {
 
         // Call the function
         // Should not revert
+        vm.prank(priceWriter);
+        price.storeObservation(address(onema));
+    }
+
+    function testRevert_storeObservation_sameBlock(uint256 nonce_) public {
+        // Add base assets to price module
+        _addBaseAssets(nonce_);
+        vm.warp(block.timestamp + OBSERVATION_FREQUENCY);
+
+        // Store first observation
+        vm.prank(priceWriter);
+        price.storeObservation(address(onema));
+
+        // Storing a second observation in the same block should revert
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPRICEv2.PRICE_ObservationTooEarly.selector,
+                address(onema),
+                uint48(block.timestamp),
+                uint48(block.timestamp + 1)
+            )
+        );
         vm.prank(priceWriter);
         price.storeObservation(address(onema));
     }

--- a/src/test/modules/PRICE.v2/PRICE.v2.t.sol
+++ b/src/test/modules/PRICE.v2/PRICE.v2.t.sol
@@ -549,6 +549,7 @@ contract PriceV2Test is PriceV2BaseTest {
             rawObservation) / twomaData.numObservations;
         uint256 expectedCurrent = (uint256(30e18) + uint256(40e18) + updatedMovingAverage) / 3;
 
+        vm.warp(block.timestamp + 1);
         vm.prank(priceWriter);
         price.storeObservation(address(twoma));
 
@@ -976,6 +977,7 @@ contract PriceV2Test is PriceV2BaseTest {
             rawObservation) / twomaData.numObservations;
         uint256 expectedCurrent = (uint256(30e18) + uint256(40e18) + updatedMovingAverage) / 3;
 
+        vm.warp(block.timestamp + 1);
         vm.prank(priceWriter);
         price.storeObservation(address(twoma));
 
@@ -1044,6 +1046,7 @@ contract PriceV2Test is PriceV2BaseTest {
             rawObservation) / twomaData.numObservations;
         uint256 expectedTwomaCurrent = (uint256(30e18) + uint256(40e18) + updatedMovingAverage) / 3;
 
+        vm.warp(block.timestamp + 1);
         vm.prank(priceWriter);
         price.storeObservation(address(twoma));
 

--- a/src/test/modules/PRICE.v2/gas.t.sol
+++ b/src/test/modules/PRICE.v2/gas.t.sol
@@ -11,6 +11,7 @@ contract PriceV2GasTest is PriceV2BaseTest {
     }
 
     function test_gasSnapshot_getPrice_last() public {
+        vm.warp(block.timestamp + 1);
         vm.prank(priceWriter);
         price.storeObservation(address(onema));
 
@@ -33,6 +34,7 @@ contract PriceV2GasTest is PriceV2BaseTest {
     }
 
     function test_gasSnapshot_getPriceIn_last() public {
+        vm.warp(block.timestamp + 1);
         vm.startPrank(priceWriter);
         price.storeObservation(address(onema));
         price.storeObservation(address(twoma));

--- a/src/test/modules/PRICE/OlympusPricev1_2.t.sol
+++ b/src/test/modules/PRICE/OlympusPricev1_2.t.sol
@@ -764,6 +764,7 @@ contract OlympusPricev1_2Test is Test {
     {
         IPRICEv2.Asset memory reserveADataBefore = price.getAssetData(address(reserveA));
 
+        vm.warp(block.timestamp + 1);
         vm.prank(priceWriterV1_2);
         price.updateMovingAverage();
 

--- a/src/test/policies/price/PriceConfig.v2.t.sol
+++ b/src/test/policies/price/PriceConfig.v2.t.sol
@@ -977,6 +977,7 @@ contract PriceConfigv2Test is Test {
         priceConfig.storeObservation(address(ohm));
 
         // Try with priceManager account, expect success
+        vm.warp(block.timestamp + 1);
         vm.prank(priceManager);
         priceConfig.storeObservation(address(ohm));
 
@@ -994,6 +995,7 @@ contract PriceConfigv2Test is Test {
         _addBaseAssets();
 
         // Store price using authorized caller
+        vm.warp(block.timestamp + 1);
         vm.prank(caller);
         priceConfig.storeObservation(address(ohm));
 
@@ -1025,6 +1027,7 @@ contract PriceConfigv2Test is Test {
         priceConfig.storeObservations();
 
         // Try with priceManager account, expect success
+        vm.warp(block.timestamp + 1);
         vm.prank(priceManager);
         priceConfig.storeObservations();
 
@@ -1042,6 +1045,7 @@ contract PriceConfigv2Test is Test {
         _addBaseAssets();
 
         // Store observations using authorized caller
+        vm.warp(block.timestamp + 1);
         vm.prank(caller);
         priceConfig.storeObservations();
 


### PR DESCRIPTION
## Summary
- add `PRICE_ObservationTooEarly` and enforce an implementation-level earliest allowed observation time in `OlympusPrice.v2` (currently `lastObservationTime + 1`)
- document that same-block protection is enforced in implementation, while broader observation cadence remains the responsibility of calling policies
- update PRICE tests to advance time where a second observation is intentionally performed
- add a same-block revert test for `storeObservation()`
- update gas snapshot values affected by the timing change

## Audit
- addresses audit issue **I-05**

## Validation
- `pnpm run lint`
- `pnpm run test:unit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added runtime validation to the price module to prevent duplicate observations from being stored within the same blockchain block.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->