### PR TITLE
Price Feed Resilience: support ERC4626 asset underlying decimal differences

### DIFF
--- a/src/modules/PRICE/submodules/feeds/ERC4626Price.sol
+++ b/src/modules/PRICE/submodules/feeds/ERC4626Price.sol
@@ -42,11 +42,11 @@ contract ERC4626Price is PriceSubmodule {
     /// @param maxDecimals_         The maximum decimals allowed
     error ERC4626_AssetDecimalsOutOfBounds(uint8 assetDecimals_, uint8 maxDecimals_);
 
-    /// @notice                     There is a mismatch between the decimals of the ERC4626 asset and underlying
+    /// @notice                     The value for the ERC4626 underlying decimals is more than the maximum decimals allowed
     ///
-    /// @param assetDecimals_       The asset decimals
-    /// @param underlyingAssetDecimals_  The underlying asset decimals
-    error ERC4626_AssetDecimalsMismatch(uint8 assetDecimals_, uint8 underlyingAssetDecimals_);
+    /// @param underlyingDecimals_  The underlying asset decimals
+    /// @param maxDecimals_         The maximum decimals allowed
+    error ERC4626_UnderlyingDecimalsOutOfBounds(uint8 underlyingDecimals_, uint8 maxDecimals_);
 
     /// @notice                     The underlying asset is not set
     ///
@@ -83,7 +83,7 @@ contract ERC4626Price is PriceSubmodule {
     /// @dev                    This function will revert if:
     /// @dev                    - The output decimals are more than the maximum decimals allowed
     /// @dev                    - The asset decimals are more than the maximum decimals allowed
-    /// @dev                    - The asset and underlying decimals do not match
+    /// @dev                    - The underlying decimals are more than the maximum decimals allowed
     /// @dev                    - The underlying asset is not set
     /// @dev                    - The price of the underlying asset cannot be determined using PRICE
     ///
@@ -111,20 +111,24 @@ contract ERC4626Price is PriceSubmodule {
 
         // Check decimals
         uint256 assetScale;
+        uint256 underlyingScale;
         {
             uint8 assetDecimals = asset.decimals();
             uint8 underlyingDecimals = ERC20(underlying).decimals();
-            // This shouldn't be possible, but we check anyway
-            if (assetDecimals != underlyingDecimals) {
-                revert ERC4626_AssetDecimalsMismatch(assetDecimals, underlyingDecimals);
-            }
 
             // Don't allow an unreasonably large number of decimals that would result in an overflow
             if (assetDecimals > BASE_10_MAX_EXPONENT) {
                 revert ERC4626_AssetDecimalsOutOfBounds(assetDecimals, BASE_10_MAX_EXPONENT);
             }
+            if (underlyingDecimals > BASE_10_MAX_EXPONENT) {
+                revert ERC4626_UnderlyingDecimalsOutOfBounds(
+                    underlyingDecimals,
+                    BASE_10_MAX_EXPONENT
+                );
+            }
 
             assetScale = 10 ** assetDecimals;
+            underlyingScale = 10 ** underlyingDecimals;
         }
 
         // Get the price of the underlying asset
@@ -136,11 +140,16 @@ contract ERC4626Price is PriceSubmodule {
             IPRICEv2.Variant.CURRENT
         );
 
-        // Calculate the price of the asset
+        // Calculate the price of one whole share.
+        // underlyingPrice: output decimals
+        // assetScale: one whole share, in share token decimals
+        // convertToAssets(assetScale): underlying asset amount, in underlying token decimals
+        // underlyingScale: underlying token decimals
+        // Result: output decimals, rounded down by mulDiv.
         // Scale: output decimals
         uint256 assetPrice = (underlyingPrice).mulDiv(
             asset.convertToAssets(assetScale),
-            assetScale
+            underlyingScale
         );
 
         return assetPrice;

--- a/src/modules/PRICE/submodules/feeds/ERC4626Price.sol
+++ b/src/modules/PRICE/submodules/feeds/ERC4626Price.sol
@@ -87,6 +87,15 @@ contract ERC4626Price is PriceSubmodule {
     /// @dev                    - The underlying asset is not set
     /// @dev                    - The price of the underlying asset cannot be determined using PRICE
     ///
+    /// @dev                    Limitations:
+    /// @dev                    - This adapter trusts the raw ERC4626 `convertToAssets()` share rate. It does not
+    /// @dev                      smooth, bound, or otherwise sanity-check vault accounting changes, so it should
+    /// @dev                      only be configured for vaults whose share conversion is already trusted on oracle
+    /// @dev                      timescales.
+    /// @dev                    - This adapter reports the ERC4626 idealized average-user conversion. It does not
+    /// @dev                      account for withdrawal fees, redemption gates, slippage, or other execution
+    /// @dev                      conditions that may make actual exits worse than `convertToAssets()`.
+    ///
     /// @param asset_           The address of the ERC4626 asset
     /// @param outputDecimals_  The number of output decimals (assumed to be the same as PRICE decimals)
     /// @return uint256         The price of `asset_` in USD (in the scale of `outputDecimals_`)

--- a/src/test/modules/PRICE.v2/submodules/feeds/ERC4626Price.t.sol
+++ b/src/test/modules/PRICE.v2/submodules/feeds/ERC4626Price.t.sol
@@ -20,6 +20,24 @@ import {FullMath} from "libraries/FullMath.sol";
 import {Kernel} from "src/Kernel.sol";
 import {ERC4626Price} from "modules/PRICE/submodules/feeds/ERC4626Price.sol";
 
+contract MockERC4626WithDecimals {
+    using FullMath for uint256;
+
+    MockERC20 public immutable asset;
+    uint8 public immutable decimals;
+    uint256 internal immutable _assetsPerShare;
+
+    constructor(MockERC20 asset_, uint8 shareDecimals_, uint256 assetsPerShare_) {
+        asset = asset_;
+        decimals = shareDecimals_;
+        _assetsPerShare = assetsPerShare_;
+    }
+
+    function convertToAssets(uint256 shares_) external view returns (uint256) {
+        return shares_.mulDiv(_assetsPerShare, 10 ** decimals);
+    }
+}
+
 contract ERC4626Test is Test {
     using FullMath for uint256;
     using ModuleTestFixtureGenerator for ERC4626Price;
@@ -96,7 +114,7 @@ contract ERC4626Test is Test {
     // [X] getPriceFromUnderlying
     //  [X] output decimals within bounds
     //  [X] output decimals out of bounds
-    //  [X] underlying asset decimals mismatch
+    //  [X] handles underlying asset decimals mismatch
     //  [X] asset decimals within bounds
     //  [X] asset decimals out of bounds
     //  [X] underlying asset not set
@@ -139,23 +157,26 @@ contract ERC4626Test is Test {
         submodule.getPriceFromUnderlying(address(sDai), outputDecimals, "");
     }
 
-    function test_assetDecimalsDifferent_reverts() public {
-        // Mock the asset having a different number of decimals to the underlying
-        vm.mockCall(
-            address(sDai),
-            abi.encodeWithSignature("decimals()"),
-            abi.encode(DAI_DECIMALS + 1)
+    function test_assetDecimalsDifferent_succeeds() public {
+        uint8 underlyingDecimals = 6;
+        uint8 shareDecimals = 18;
+        uint256 assetsPerShare = 1_234_567;
+        MockERC20 usdc = new MockERC20("USD Coin", "USDC", underlyingDecimals);
+        MockERC4626WithDecimals sUsdc = new MockERC4626WithDecimals(
+            usdc,
+            shareDecimals,
+            assetsPerShare
         );
+        uint256 underlyingPrice = 2e18;
+        mockAssetPrice(address(usdc), underlyingPrice);
 
-        // Call the function
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                ERC4626Price.ERC4626_AssetDecimalsMismatch.selector,
-                DAI_DECIMALS + 1,
-                DAI_DECIMALS
-            )
-        );
-        submodule.getPriceFromUnderlying(address(sDai), PRICE_DECIMALS, "");
+        // shares = 1e18 (18 decimals) = 1 whole share
+        // convertToAssets(1e18) = 1,234,567 (6 decimals) = 1.234567 USDC
+        // underlyingPrice = 2e18 (18 decimals) = $2 per USDC
+        // Expected: 2e18 * 1,234,567 / 1e6 = 2.469134e18
+        uint256 assetPrice = submodule.getPriceFromUnderlying(address(sUsdc), PRICE_DECIMALS, "");
+
+        assertEq(assetPrice, 2_469_134e12, "Asset price should normalize by underlying decimals");
     }
 
     function test_assetDecimals_fuzz(uint8 assetDecimals_) public {
@@ -208,6 +229,26 @@ contract ERC4626Test is Test {
             abi.encodeWithSelector(
                 ERC4626Price.ERC4626_AssetDecimalsOutOfBounds.selector,
                 assetDecimals,
+                MAX_DECIMALS
+            )
+        );
+        submodule.getPriceFromUnderlying(address(newAsset), PRICE_DECIMALS, "");
+    }
+
+    function test_underlyingDecimals_maximum_reverts(uint8 underlyingDecimals_) public {
+        uint8 underlyingDecimals = uint8(bound(underlyingDecimals_, MAX_DECIMALS + 1, 60));
+        MockERC20 newUnderlying = new MockERC20("New Token", "NEW", underlyingDecimals);
+        MockERC4626WithDecimals newAsset = new MockERC4626WithDecimals(
+            newUnderlying,
+            PRICE_DECIMALS,
+            10 ** PRICE_DECIMALS
+        );
+
+        // Call the function
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ERC4626Price.ERC4626_UnderlyingDecimalsOutOfBounds.selector,
+                underlyingDecimals,
                 MAX_DECIMALS
             )
         );

--- a/src/test/modules/PRICE.v2/submodules/feeds/ERC4626Price.t.sol
+++ b/src/test/modules/PRICE.v2/submodules/feeds/ERC4626Price.t.sol
@@ -179,6 +179,32 @@ contract ERC4626Test is Test {
         assertEq(assetPrice, 2_469_134e12, "Asset price should normalize by underlying decimals");
     }
 
+    function test_shareDecimalsLessThanUnderlying_succeeds() public {
+        uint8 underlyingDecimals = 18;
+        uint8 shareDecimals = 6;
+        uint256 assetsPerShare = 3_500_000_000_000_000_000;
+        MockERC20 weth = new MockERC20("Wrapped Ether", "WETH", underlyingDecimals);
+        MockERC4626WithDecimals sWeth = new MockERC4626WithDecimals(
+            weth,
+            shareDecimals,
+            assetsPerShare
+        );
+        uint256 underlyingPrice = 2_500e18;
+        mockAssetPrice(address(weth), underlyingPrice);
+
+        // shares = 1e6 (6 decimals) = 1 whole share
+        // convertToAssets(1e6) = 3.5e18 (18 decimals) = 3.5 WETH
+        // underlyingPrice = 2,500e18 (18 decimals) = $2,500 per WETH
+        // Expected: 2,500e18 * 3.5e18 / 1e18 = 8,750e18
+        uint256 assetPrice = submodule.getPriceFromUnderlying(address(sWeth), PRICE_DECIMALS, "");
+
+        assertEq(
+            assetPrice,
+            8_750e18,
+            "Asset price should normalize when share decimals are lower"
+        );
+    }
+
     function test_assetDecimals_fuzz(uint8 assetDecimals_) public {
         uint8 assetDecimals = uint8(bound(assetDecimals_, 0, MAX_DECIMALS));
 


### PR DESCRIPTION
## Summary
- Addresses audit issue L-03 by allowing ERC4626 share tokens and underlying assets to use different decimals.
- Prices one whole share with `convertToAssets(10 ** shareDecimals)`, then normalizes by `10 ** underlyingDecimals`.
- Adds a deterministic regression test with 18-decimal shares over a 6-decimal underlying and an explicit worked price proof.
- Adds a bounds check for underlying decimals before computing its scale.

## Audit Notes
- L-03: Removes the incorrect share/underlying decimal equality requirement and normalizes across both decimal scales.
- I-12: Documents that `ERC4626Price` trusts the raw `convertToAssets()` share rate and should only be configured for vaults whose conversion is already trusted on oracle timescales.
- I-01: Documents that `convertToAssets()` is an idealized ERC4626 conversion and does not account for withdrawal fees, redemption gates, slippage, or worse execution conditions.

## Validation
- `forge test -vvv --match-contract ERC4626Test`
- `forge build --contracts src/modules/PRICE/submodules/feeds/ERC4626Price.sol`
- `pnpm run prettier`
- `pnpm run lint`
- `coderabbit --prompt-only -t uncommitted`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Price feed now supports vaults whose asset decimals differ from the underlying token, producing normalized prices.

* **Bug Fixes**
  * Price feed now rejects underlying tokens with decimals above the allowed maximum to prevent out-of-bounds calculations and trigger a clear revert.

* **Documentation**
  * Clarified that reported prices assume idealized convertToAssets() behavior and do not model fees, gates, slippage, or exit-time execution effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->