### PR TITLE
Price Feed Resilience: Clamp Pyth max confidence

### DIFF
--- a/documentation/price.md
+++ b/documentation/price.md
@@ -84,8 +84,13 @@ The **max confidence interval** is a Pyth-specific parameter that sets the maxim
 
 1. Pyth returns both a `price` and a `conf` (confidence) value
 2. The contract converts `maxConfidence` from 18-decimal scale to Pyth's native scale (based on the feed's exponent)
-3. If `priceData.conf > maxConfidenceInPythScale`, the feed reverts with `Pyth_FeedConfidenceExcessive`
-4. This prevents using prices with high uncertainty
+3. If the converted value exceeds `uint64`, it is clamped to `type(uint64).max`
+4. If `priceData.conf > maxConfidenceInPythScale`, the feed reverts with `Pyth_FeedConfidenceExcessive`
+5. For Pyth two-feed reads, the contract validates each feed independently, derives a conservative confidence interval for the output product or ratio, and compares it against `outputMaxConfidence`
+6. If the derived output confidence exceeds `outputMaxConfidence`, the feed reverts with `Pyth_DerivedFeedConfidenceExcessive`
+7. For division, if the denominator confidence is greater than or equal to the denominator price, the feed reverts with `Pyth_DerivedFeedConfidenceInvalid`
+
+Pyth two-feed parameters include `firstMaxConfidence`, `secondMaxConfidence`, and `outputMaxConfidence`, all in output decimals. The first two thresholds cap each input feed independently. `outputMaxConfidence` caps the uncertainty of the derived price that callers actually consume.
 
 ### wETH Price Resolution
 

--- a/src/modules/PRICE/submodules/feeds/PythPriceFeeds.sol
+++ b/src/modules/PRICE/submodules/feeds/PythPriceFeeds.sol
@@ -445,6 +445,8 @@ contract PythPriceFeeds is PriceSubmodule {
     /// @dev                    - Any parameter is invalid
     /// @dev                    - The exponent calculation would result in an overflow
     /// @dev                    - Any of the price feeds' results are invalid
+    /// @dev                    - The denominator confidence interval is greater than or equal to the denominator price
+    /// @dev                    - The derived output confidence interval exceeds `outputMaxConfidence`
     ///
     /// @param outputDecimals_  The number of output decimals (assumed to be the same as PRICE decimals)
     /// @param params_          Pyth feed parameters of type `TwoFeedParams`
@@ -513,6 +515,7 @@ contract PythPriceFeeds is PriceSubmodule {
     /// @dev                    - Any parameter is invalid
     /// @dev                    - The exponent calculation would result in an overflow
     /// @dev                    - Any of the price feeds' results are invalid
+    /// @dev                    - The derived output confidence interval exceeds `outputMaxConfidence`
     ///
     /// @param outputDecimals_  The number of output decimals (assumed to be the same as PRICE decimals)
     /// @param params_          Pyth feed parameters of type `TwoFeedParams`

--- a/src/modules/PRICE/submodules/feeds/PythPriceFeeds.sol
+++ b/src/modules/PRICE/submodules/feeds/PythPriceFeeds.sol
@@ -7,7 +7,6 @@ import {IPyth} from "src/interfaces/IPyth.sol";
 
 // Libraries
 import {FullMath} from "src/libraries/FullMath.sol";
-import {SafeCast} from "src/libraries/SafeCast.sol";
 
 // Bophades
 import {Module} from "src/Kernel.sol";
@@ -280,15 +279,21 @@ contract PythPriceFeeds is PriceSubmodule {
         }
 
         // Convert maxConfidence from output decimals scale to Pyth feed scale (10^expo)
-        // Formula: maxConfidenceInPythScale = maxConfidence * 10^expo / 10^outputDecimals
-        //         = maxConfidence * 10^(expo - outputDecimals)
-        // Note: Result is cast to uint64 since it's compared against priceData.conf (uint64)
-        uint64 maxConfidenceInPythScale = SafeCast.encodeUInt64(
-            maxConfidence_.mulDiv(
-                10 ** uint256(uint32(-priceData.expo)),
-                10 ** uint256(outputDecimals_)
-            )
+        // Formula: maxConfidenceInPythScale = maxConfidence * 10^|expo| / 10^outputDecimals
+        // Note: The result is clamped to uint64 max because priceData.conf is uint64, so any
+        // threshold above uint64 max permits all possible feed confidence values.
+        uint256 maxConfidenceInPythScaleUint = maxConfidence_.mulDiv(
+            10 ** uint256(uint32(-priceData.expo)),
+            10 ** uint256(outputDecimals_)
         );
+        uint64 maxConfidenceInPythScale;
+        if (maxConfidenceInPythScaleUint > type(uint64).max) {
+            maxConfidenceInPythScale = type(uint64).max;
+        } else {
+            // Casting to uint64 is safe because the branch above handles values above uint64 max.
+            // forge-lint: disable-next-line(unsafe-typecast)
+            maxConfidenceInPythScale = uint64(maxConfidenceInPythScaleUint);
+        }
 
         // Validate raw values from the price feed
         _validatePriceFeedResult(

--- a/src/modules/PRICE/submodules/feeds/PythPriceFeeds.sol
+++ b/src/modules/PRICE/submodules/feeds/PythPriceFeeds.sol
@@ -24,8 +24,8 @@ contract PythPriceFeeds is PriceSubmodule {
     /// @notice     The expected length of the encoded one feed parameters (address + bytes32 + uint48 + uint256 = 128 bytes)
     uint256 internal constant ONE_FEED_PARAMS_LENGTH = 128;
 
-    /// @notice     The expected length of the encoded two feed parameters (2x address + 2x bytes32 + 2x uint48 + 2x uint256 = 256 bytes)
-    uint256 internal constant TWO_FEED_PARAMS_LENGTH = 256;
+    /// @notice     The expected length of the encoded two feed parameters (2x address + 2x bytes32 + 2x uint48 + 3x uint256 = 288 bytes)
+    uint256 internal constant TWO_FEED_PARAMS_LENGTH = 288;
 
     /// @notice                 Parameters for a single Pyth price feed
     ///
@@ -50,6 +50,7 @@ contract PythPriceFeeds is PriceSubmodule {
     /// @param secondPriceFeedId        Second: The Pyth price feed ID
     /// @param secondUpdateThreshold    Second: The maximum number of seconds elapsed since the last price feed update
     /// @param secondMaxConfidence      Second: The maximum confidence interval allowed (in output decimals scale)
+    /// @param outputMaxConfidence      The maximum confidence interval allowed for the derived output (in output decimals scale)
     struct TwoFeedParams {
         address firstPyth;
         bytes32 firstPriceFeedId;
@@ -59,6 +60,16 @@ contract PythPriceFeeds is PriceSubmodule {
         bytes32 secondPriceFeedId;
         uint48 secondUpdateThreshold;
         uint256 secondMaxConfidence;
+        uint256 outputMaxConfidence;
+    }
+
+    /// @notice                         Price feed result in output decimals scale
+    ///
+    /// @param price                    The price returned by the feed
+    /// @param confidence               The confidence interval returned by the feed
+    struct FeedResult {
+        uint256 price;
+        uint256 confidence;
     }
 
     // ========== ERRORS ========== //
@@ -137,6 +148,22 @@ contract PythPriceFeeds is PriceSubmodule {
         bytes32 priceFeedId_,
         uint64 confidence_,
         uint64 maxConfidence_
+    );
+
+    /// @notice                     The derived confidence interval exceeds the maximum allowed
+    ///
+    /// @param confidence_          The derived confidence interval (in output decimals scale)
+    /// @param maxConfidence_       The maximum derived confidence interval allowed (in output decimals scale)
+    error Pyth_DerivedFeedConfidenceExcessive(uint256 confidence_, uint256 maxConfidence_);
+
+    /// @notice                     The derived confidence interval is invalid
+    /// @dev                        This occurs if the denominator confidence interval reaches or exceeds the denominator price.
+    ///
+    /// @param denominatorPrice_     The denominator price (in output decimals scale)
+    /// @param denominatorConfidence_ The denominator confidence interval (in output decimals scale)
+    error Pyth_DerivedFeedConfidenceInvalid(
+        uint256 denominatorPrice_,
+        uint256 denominatorConfidence_
     );
 
     /// @notice                 The exponent from the price feed is positive, which results in loss of precision
@@ -227,14 +254,14 @@ contract PythPriceFeeds is PriceSubmodule {
     /// @param updateThreshold_         The maximum number of seconds elapsed since the last price feed update
     /// @param maxConfidence_           The maximum confidence interval allowed (in output decimals scale)
     /// @param outputDecimals_          The number of decimals to return the price in
-    /// @return uint256                 The validated price in the scale of `outputDecimals_`
+    /// @return FeedResult             The validated price and confidence in the scale of `outputDecimals_`
     function _getFeedPrice(
         address pyth_,
         bytes32 priceFeedId_,
         uint48 updateThreshold_,
         uint256 maxConfidence_,
         uint8 outputDecimals_
-    ) internal view returns (uint256) {
+    ) internal view returns (FeedResult memory) {
         IPyth.Price memory priceData;
         {
             // Encode function call: getPriceNoOlderThan(bytes32,uint256)
@@ -306,10 +333,71 @@ contract PythPriceFeeds is PriceSubmodule {
         );
 
         uint256 price = uint256(int256(priceData.price));
+        uint256 scale = 10 ** uint256(outputDecimals_);
+        uint256 feedScale = 10 ** uint256(uint32(-priceData.expo));
 
         // Convert price to output decimals
         // The PRICE module will handle the zero value
-        return price.mulDiv(10 ** uint256(outputDecimals_), 10 ** uint256(uint32(-priceData.expo)));
+        return
+            FeedResult({
+                price: price.mulDiv(scale, feedScale),
+                confidence: uint256(priceData.conf).mulDivUp(scale, feedScale)
+            });
+    }
+
+    /// @notice                 Validates a derived confidence interval
+    ///
+    /// @param confidence_      The derived confidence interval (in output decimals scale)
+    /// @param maxConfidence_   The maximum confidence interval allowed (in output decimals scale)
+    function _validateDerivedConfidence(uint256 confidence_, uint256 maxConfidence_) internal pure {
+        if (confidence_ > maxConfidence_)
+            revert Pyth_DerivedFeedConfidenceExcessive(confidence_, maxConfidence_);
+    }
+
+    /// @notice                         Derives the confidence interval for a multiplication result
+    ///
+    /// @param first                    First feed result in output decimals scale
+    /// @param second                   Second feed result in output decimals scale
+    /// @param outputDecimals_          The number of output decimals
+    /// @return uint256                 The derived confidence interval in output decimals scale
+    function _deriveMulConfidence(
+        FeedResult memory first,
+        FeedResult memory second,
+        uint8 outputDecimals_
+    ) internal pure returns (uint256) {
+        uint256 scale = 10 ** uint256(outputDecimals_);
+
+        // Product confidence: (A + cA)(B + cB) - AB = A*cB + B*cA + cA*cB
+        // A, B, cA, cB all have outputDecimals_ decimals, so each product is divided by scale.
+        return
+            first.price.mulDivUp(second.confidence, scale) +
+            second.price.mulDivUp(first.confidence, scale) +
+            first.confidence.mulDivUp(second.confidence, scale);
+    }
+
+    /// @notice                         Derives the confidence interval for a division result
+    ///
+    /// @param numerator                Numerator feed result in output decimals scale
+    /// @param denominator              Denominator feed result in output decimals scale
+    /// @param outputDecimals_          The number of output decimals
+    /// @param priceResult_             The derived division price in output decimals scale
+    /// @return uint256                 The derived confidence interval in output decimals scale
+    function _deriveDivConfidence(
+        FeedResult memory numerator,
+        FeedResult memory denominator,
+        uint8 outputDecimals_,
+        uint256 priceResult_
+    ) internal pure returns (uint256) {
+        if (denominator.confidence >= denominator.price)
+            revert Pyth_DerivedFeedConfidenceInvalid(denominator.price, denominator.confidence);
+
+        uint256 scale = 10 ** uint256(outputDecimals_);
+        uint256 upperPrice = (numerator.price + numerator.confidence).mulDivUp(
+            scale,
+            denominator.price - denominator.confidence
+        );
+
+        return upperPrice - priceResult_;
     }
 
     /// @notice                 Returns the price from a single Pyth feed, as specified in `params_`.
@@ -339,7 +427,7 @@ contract PythPriceFeeds is PriceSubmodule {
         if (params.maxConfidence == 0)
             revert Pyth_ParamsMaxConfidenceInvalid(3, params.maxConfidence);
 
-        uint256 feedPrice = _getFeedPrice(
+        FeedResult memory feedResult = _getFeedPrice(
             params.pyth,
             params.priceFeedId,
             params.updateThreshold,
@@ -347,7 +435,7 @@ contract PythPriceFeeds is PriceSubmodule {
             outputDecimals_
         );
 
-        return feedPrice;
+        return feedResult.price;
     }
 
     /// @notice                 Returns the result of dividing the price from the first Pyth feed by the price from the second.
@@ -385,16 +473,18 @@ contract PythPriceFeeds is PriceSubmodule {
             revert Pyth_ParamsUpdateThresholdInvalid(6, params.secondUpdateThreshold);
         if (params.secondMaxConfidence == 0)
             revert Pyth_ParamsMaxConfidenceInvalid(7, params.secondMaxConfidence);
+        if (params.outputMaxConfidence == 0)
+            revert Pyth_ParamsMaxConfidenceInvalid(8, params.outputMaxConfidence);
 
-        // Get prices from feeds (both already converted to outputDecimals scale)
-        uint256 numeratorPrice = _getFeedPrice(
+        // Get prices and confidence intervals from feeds (already converted to outputDecimals scale)
+        FeedResult memory numerator = _getFeedPrice(
             params.firstPyth,
             params.firstPriceFeedId,
             params.firstUpdateThreshold,
             params.firstMaxConfidence,
             outputDecimals_
         );
-        uint256 denominatorPrice = _getFeedPrice(
+        FeedResult memory denominator = _getFeedPrice(
             params.secondPyth,
             params.secondPriceFeedId,
             params.secondUpdateThreshold,
@@ -404,10 +494,14 @@ contract PythPriceFeeds is PriceSubmodule {
 
         // If denominatorPrice is zero, do an early exit
         // The PRICE module will handle the zero value
-        if (denominatorPrice == 0) return 0;
+        if (denominator.price == 0) return 0;
 
         // Convert to numerator/denominator price and return
-        uint256 priceResult = numeratorPrice.mulDiv(10 ** outputDecimals_, denominatorPrice);
+        uint256 priceResult = numerator.price.mulDiv(10 ** outputDecimals_, denominator.price);
+        _validateDerivedConfidence(
+            _deriveDivConfidence(numerator, denominator, outputDecimals_, priceResult),
+            params.outputMaxConfidence
+        );
 
         return priceResult;
     }
@@ -447,16 +541,18 @@ contract PythPriceFeeds is PriceSubmodule {
             revert Pyth_ParamsUpdateThresholdInvalid(6, params.secondUpdateThreshold);
         if (params.secondMaxConfidence == 0)
             revert Pyth_ParamsMaxConfidenceInvalid(7, params.secondMaxConfidence);
+        if (params.outputMaxConfidence == 0)
+            revert Pyth_ParamsMaxConfidenceInvalid(8, params.outputMaxConfidence);
 
-        // Get prices from feeds (both already converted to outputDecimals scale)
-        uint256 firstPrice = _getFeedPrice(
+        // Get prices and confidence intervals from feeds (already converted to outputDecimals scale)
+        FeedResult memory first = _getFeedPrice(
             params.firstPyth,
             params.firstPriceFeedId,
             params.firstUpdateThreshold,
             params.firstMaxConfidence,
             outputDecimals_
         );
-        uint256 secondPrice = _getFeedPrice(
+        FeedResult memory second = _getFeedPrice(
             params.secondPyth,
             params.secondPriceFeedId,
             params.secondUpdateThreshold,
@@ -465,7 +561,11 @@ contract PythPriceFeeds is PriceSubmodule {
         );
 
         // Convert to first * second price and return
-        uint256 priceResult = firstPrice.mulDiv(secondPrice, 10 ** outputDecimals_);
+        uint256 priceResult = first.price.mulDiv(second.price, 10 ** outputDecimals_);
+        _validateDerivedConfidence(
+            _deriveMulConfidence(first, second, outputDecimals_),
+            params.outputMaxConfidence
+        );
 
         return priceResult;
     }

--- a/src/test/modules/PRICE.v2/submodules/feeds/PythPriceFeeds/PythPriceFeedsTest.sol
+++ b/src/test/modules/PRICE.v2/submodules/feeds/PythPriceFeeds/PythPriceFeedsTest.sol
@@ -114,6 +114,31 @@ contract PythPriceFeedsTest is Test {
         uint256 secondMaxConfidence_
     ) internal pure returns (bytes memory params) {
         return
+            encodeTwoFeedParams(
+                firstPyth_,
+                firstPriceFeedId_,
+                firstUpdateThreshold_,
+                firstMaxConfidence_,
+                secondPyth_,
+                secondPriceFeedId_,
+                secondUpdateThreshold_,
+                secondMaxConfidence_,
+                type(uint256).max
+            );
+    }
+
+    function encodeTwoFeedParams(
+        address firstPyth_,
+        bytes32 firstPriceFeedId_,
+        uint48 firstUpdateThreshold_,
+        uint256 firstMaxConfidence_,
+        address secondPyth_,
+        bytes32 secondPriceFeedId_,
+        uint48 secondUpdateThreshold_,
+        uint256 secondMaxConfidence_,
+        uint256 outputMaxConfidence_
+    ) internal pure returns (bytes memory params) {
+        return
             abi.encode(
                 firstPyth_,
                 firstPriceFeedId_,
@@ -122,7 +147,8 @@ contract PythPriceFeedsTest is Test {
                 secondPyth_,
                 secondPriceFeedId_,
                 secondUpdateThreshold_,
-                secondMaxConfidence_
+                secondMaxConfidence_,
+                outputMaxConfidence_
             );
     }
 }

--- a/src/test/modules/PRICE.v2/submodules/feeds/PythPriceFeeds/getOneFeedPrice.t.sol
+++ b/src/test/modules/PRICE.v2/submodules/feeds/PythPriceFeeds/getOneFeedPrice.t.sol
@@ -543,6 +543,52 @@ contract PythPriceFeedsGetOneFeedPriceTest is PythPriceFeedsTest {
         assertEq(priceInt, 1000000, "Price should match expected value for very negative expo");
     }
 
+    // given expo is -21 and the converted max confidence fits in uint64
+    //  [X] it correctly converts the price
+    function test_expoNegativeTwentyOne_maxConfidenceFits() public {
+        // maxConfidence = 1e16 (18 decimals)
+        // expo = -21
+        // maxConfidenceInPythScale = 1e16 * 1e21 / 1e18 = 1e19, which fits in uint64
+        int64 price = 100000000;
+        int32 expo = -21;
+        pyth.setPrice(PRICE_ID_1, price, CONF_1, expo, block.timestamp);
+
+        bytes memory params = encodeOneFeedParams(
+            address(pyth),
+            PRICE_ID_1,
+            UPDATE_THRESHOLD,
+            1e16
+        );
+        uint256 priceInt = pythSubmodule.getOneFeedPrice(address(0), PRICE_DECIMALS, params);
+
+        // price = 100000000 (21 decimals)
+        // Expected: 100000000 * 1e18 / 1e21 = 100000
+        assertEq(priceInt, 100000, "Price should match expected value for expo -21");
+    }
+
+    // given expo is -22 and the converted max confidence exceeds uint64
+    //  [X] it clamps the maximum confidence and correctly converts the price
+    function test_expoNegativeTwentyTwo_maxConfidenceClamps() public {
+        // maxConfidence = 1e16 (18 decimals)
+        // expo = -22
+        // maxConfidenceInPythScale = 1e16 * 1e22 / 1e18 = 1e20, which exceeds uint64
+        int64 price = 100000000;
+        int32 expo = -22;
+        pyth.setPrice(PRICE_ID_1, price, type(uint64).max, expo, block.timestamp);
+
+        bytes memory params = encodeOneFeedParams(
+            address(pyth),
+            PRICE_ID_1,
+            UPDATE_THRESHOLD,
+            1e16
+        );
+        uint256 priceInt = pythSubmodule.getOneFeedPrice(address(0), PRICE_DECIMALS, params);
+
+        // price = 100000000 (22 decimals)
+        // Expected: 100000000 * 1e18 / 1e22 = 10000
+        assertEq(priceInt, 10000, "Price should match expected value for expo -22");
+    }
+
     // given the confidence interval is at the maximum (boundary case)
     //  [X] it correctly converts the price
     function test_confidenceEqualsMaximum() public {

--- a/src/test/modules/PRICE.v2/submodules/feeds/PythPriceFeeds/getOneFeedPrice.t.sol
+++ b/src/test/modules/PRICE.v2/submodules/feeds/PythPriceFeeds/getOneFeedPrice.t.sol
@@ -566,6 +566,35 @@ contract PythPriceFeedsGetOneFeedPriceTest is PythPriceFeedsTest {
         assertEq(priceInt, 100000, "Price should match expected value for expo -21");
     }
 
+    // given expo is -21 and the feed confidence exceeds the converted max confidence
+    //  [X] it reverts with Pyth_FeedConfidenceExcessive
+    function test_expoNegativeTwentyOne_maxConfidenceExceeded_reverts() public {
+        // maxConfidence = 1e16 (18 decimals)
+        // expo = -21
+        // maxConfidenceInPythScale = 1e16 * 1e21 / 1e18 = 1e19, which fits in uint64
+        int64 price = 100000000;
+        int32 expo = -21;
+        uint64 priceConfidence = uint64(1e19 + 1);
+        pyth.setPrice(PRICE_ID_1, price, priceConfidence, expo, block.timestamp);
+
+        bytes memory err = abi.encodeWithSelector(
+            PythPriceFeeds.Pyth_FeedConfidenceExcessive.selector,
+            address(pyth),
+            PRICE_ID_1,
+            priceConfidence,
+            uint64(1e19)
+        );
+        vm.expectRevert(err);
+
+        bytes memory params = encodeOneFeedParams(
+            address(pyth),
+            PRICE_ID_1,
+            UPDATE_THRESHOLD,
+            1e16
+        );
+        pythSubmodule.getOneFeedPrice(address(0), PRICE_DECIMALS, params);
+    }
+
     // given expo is -22 and the converted max confidence exceeds uint64
     //  [X] it clamps the maximum confidence and correctly converts the price
     function test_expoNegativeTwentyTwo_maxConfidenceClamps() public {

--- a/src/test/modules/PRICE.v2/submodules/feeds/PythPriceFeeds/getTwoFeedPriceDiv.t.sol
+++ b/src/test/modules/PRICE.v2/submodules/feeds/PythPriceFeeds/getTwoFeedPriceDiv.t.sol
@@ -27,7 +27,7 @@ contract PythPriceFeedsGetTwoFeedPriceDivTest is PythPriceFeedsTest {
     }
 
     function test_revertsOnParamsTooShort() public {
-        bytes memory shortParams = new bytes(255); // 1 byte short of 256
+        bytes memory shortParams = new bytes(287); // 1 byte short of 288
         bytes memory params = encodeTwoFeedParams(
             address(pyth),
             PRICE_ID_1,
@@ -38,7 +38,7 @@ contract PythPriceFeedsGetTwoFeedPriceDivTest is PythPriceFeedsTest {
             UPDATE_THRESHOLD,
             MAX_CONFIDENCE
         );
-        for (uint256 i = 0; i < 255; i++) {
+        for (uint256 i = 0; i < 287; i++) {
             shortParams[i] = params[i];
         }
 
@@ -52,7 +52,7 @@ contract PythPriceFeedsGetTwoFeedPriceDivTest is PythPriceFeedsTest {
     }
 
     function test_revertsOnParamsTooLong() public {
-        bytes memory longParams = new bytes(512); // Double the expected size
+        bytes memory longParams = new bytes(576); // Double the expected size
         bytes memory params = encodeTwoFeedParams(
             address(pyth),
             PRICE_ID_1,
@@ -63,7 +63,7 @@ contract PythPriceFeedsGetTwoFeedPriceDivTest is PythPriceFeedsTest {
             UPDATE_THRESHOLD,
             MAX_CONFIDENCE
         );
-        for (uint256 i = 0; i < 256; i++) {
+        for (uint256 i = 0; i < 288; i++) {
             longParams[i] = params[i];
         }
 
@@ -303,6 +303,71 @@ contract PythPriceFeedsGetTwoFeedPriceDivTest is PythPriceFeedsTest {
             PRICE_ID_3,
             UPDATE_THRESHOLD,
             0
+        );
+        pythSubmodule.getTwoFeedPriceDiv(address(0), PRICE_DECIMALS, params);
+    }
+
+    // given the output max confidence is zero
+    //  [X] it reverts with Pyth_ParamsMaxConfidenceInvalid
+    function test_outputMaxConfidenceZero_reverts() public {
+        bytes memory err = abi.encodeWithSelector(
+            PythPriceFeeds.Pyth_ParamsMaxConfidenceInvalid.selector,
+            8,
+            0
+        );
+        vm.expectRevert(err);
+
+        bytes memory params = encodeTwoFeedParams(
+            address(pyth),
+            PRICE_ID_1,
+            UPDATE_THRESHOLD,
+            MAX_CONFIDENCE,
+            address(pyth),
+            PRICE_ID_3,
+            UPDATE_THRESHOLD,
+            MAX_CONFIDENCE,
+            0
+        );
+        pythSubmodule.getTwoFeedPriceDiv(address(0), PRICE_DECIMALS, params);
+    }
+
+    // given each leg confidence is below the per-feed maximum
+    //  given the derived division confidence exceeds the output maximum
+    //   [X] it reverts with Pyth_DerivedFeedConfidenceExcessive
+    function test_outputMaxConfidenceExceeded_reverts() public {
+        // numeratorPrice = 1.23456789e18, numeratorConfidence = 0.01e18
+        // denominatorPrice = 500000000, denominatorConfidence = 500000
+        uint256 numeratorPrice = EXPECTED_PRICE_1_18_DEC;
+        uint256 numeratorConfidence = 1e16;
+        uint256 denominatorPrice = 500000000;
+        uint256 denominatorConfidence = 500000;
+        uint256 scale = 10 ** uint256(PRICE_DECIMALS);
+
+        uint256 priceResult = numeratorPrice.mulDiv(scale, denominatorPrice);
+        uint256 upperPrice = (numeratorPrice + numeratorConfidence).mulDivUp(
+            scale,
+            denominatorPrice - denominatorConfidence
+        );
+        uint256 derivedConfidence = upperPrice - priceResult;
+        uint256 outputMaxConfidence = derivedConfidence - 1;
+
+        bytes memory err = abi.encodeWithSelector(
+            PythPriceFeeds.Pyth_DerivedFeedConfidenceExcessive.selector,
+            derivedConfidence,
+            outputMaxConfidence
+        );
+        vm.expectRevert(err);
+
+        bytes memory params = encodeTwoFeedParams(
+            address(pyth),
+            PRICE_ID_1,
+            UPDATE_THRESHOLD,
+            MAX_CONFIDENCE,
+            address(pyth),
+            PRICE_ID_3,
+            UPDATE_THRESHOLD,
+            MAX_CONFIDENCE,
+            outputMaxConfidence
         );
         pythSubmodule.getTwoFeedPriceDiv(address(0), PRICE_DECIMALS, params);
     }

--- a/src/test/modules/PRICE.v2/submodules/feeds/PythPriceFeeds/getTwoFeedPriceMul.t.sol
+++ b/src/test/modules/PRICE.v2/submodules/feeds/PythPriceFeeds/getTwoFeedPriceMul.t.sol
@@ -27,7 +27,7 @@ contract PythPriceFeedsGetTwoFeedPriceMulTest is PythPriceFeedsTest {
     }
 
     function test_revertsOnParamsTooShort() public {
-        bytes memory shortParams = new bytes(255); // 1 byte short of 256
+        bytes memory shortParams = new bytes(287); // 1 byte short of 288
         bytes memory params = encodeTwoFeedParams(
             address(pyth),
             PRICE_ID_1,
@@ -38,7 +38,7 @@ contract PythPriceFeedsGetTwoFeedPriceMulTest is PythPriceFeedsTest {
             UPDATE_THRESHOLD,
             MAX_CONFIDENCE
         );
-        for (uint256 i = 0; i < 255; i++) {
+        for (uint256 i = 0; i < 287; i++) {
             shortParams[i] = params[i];
         }
 
@@ -52,7 +52,7 @@ contract PythPriceFeedsGetTwoFeedPriceMulTest is PythPriceFeedsTest {
     }
 
     function test_revertsOnParamsTooLong() public {
-        bytes memory longParams = new bytes(512); // Double the expected size
+        bytes memory longParams = new bytes(576); // Double the expected size
         bytes memory params = encodeTwoFeedParams(
             address(pyth),
             PRICE_ID_1,
@@ -63,7 +63,7 @@ contract PythPriceFeedsGetTwoFeedPriceMulTest is PythPriceFeedsTest {
             UPDATE_THRESHOLD,
             MAX_CONFIDENCE
         );
-        for (uint256 i = 0; i < 256; i++) {
+        for (uint256 i = 0; i < 288; i++) {
             longParams[i] = params[i];
         }
 
@@ -282,6 +282,70 @@ contract PythPriceFeedsGetTwoFeedPriceMulTest is PythPriceFeedsTest {
             PRICE_ID_3,
             UPDATE_THRESHOLD,
             0
+        );
+        pythSubmodule.getTwoFeedPriceMul(address(0), PRICE_DECIMALS, params);
+    }
+
+    // given the output max confidence is zero
+    //  [X] it reverts with Pyth_ParamsMaxConfidenceInvalid
+    function test_outputMaxConfidenceZero_reverts() public {
+        bytes memory err = abi.encodeWithSelector(
+            PythPriceFeeds.Pyth_ParamsMaxConfidenceInvalid.selector,
+            8,
+            0
+        );
+        vm.expectRevert(err);
+
+        bytes memory params = encodeTwoFeedParams(
+            address(pyth),
+            PRICE_ID_1,
+            UPDATE_THRESHOLD,
+            MAX_CONFIDENCE,
+            address(pyth),
+            PRICE_ID_3,
+            UPDATE_THRESHOLD,
+            MAX_CONFIDENCE,
+            0
+        );
+        pythSubmodule.getTwoFeedPriceMul(address(0), PRICE_DECIMALS, params);
+    }
+
+    // given each leg confidence is below the per-feed maximum
+    //  given the derived multiplication confidence exceeds the output maximum
+    //   [X] it reverts with Pyth_DerivedFeedConfidenceExcessive
+    function test_outputMaxConfidenceExceeded_reverts() public {
+        // firstPrice = 1.23456789e18, firstConfidence = 0.01e18
+        // secondPrice = 500000000, secondConfidence = 500000
+        uint256 firstPrice = EXPECTED_PRICE_1_18_DEC;
+        uint256 firstConfidence = 1e16;
+        uint256 secondPrice = 500000000;
+        uint256 secondConfidence = 500000;
+        uint256 scale = 10 ** uint256(PRICE_DECIMALS);
+
+        // Product confidence: (A + cA)(B + cB) - AB = A*cB + B*cA + cA*cB
+        // Each product has 36 decimals and is divided by scale to return 18 decimals.
+        uint256 derivedConfidence = firstPrice.mulDivUp(secondConfidence, scale) +
+            secondPrice.mulDivUp(firstConfidence, scale) +
+            firstConfidence.mulDivUp(secondConfidence, scale);
+        uint256 outputMaxConfidence = derivedConfidence - 1;
+
+        bytes memory err = abi.encodeWithSelector(
+            PythPriceFeeds.Pyth_DerivedFeedConfidenceExcessive.selector,
+            derivedConfidence,
+            outputMaxConfidence
+        );
+        vm.expectRevert(err);
+
+        bytes memory params = encodeTwoFeedParams(
+            address(pyth),
+            PRICE_ID_1,
+            UPDATE_THRESHOLD,
+            MAX_CONFIDENCE,
+            address(pyth),
+            PRICE_ID_3,
+            UPDATE_THRESHOLD,
+            MAX_CONFIDENCE,
+            outputMaxConfidence
         );
         pythSubmodule.getTwoFeedPriceMul(address(0), PRICE_DECIMALS, params);
     }


### PR DESCRIPTION
## Summary
- Fixes audit issue L-08 by clamping converted Pyth max-confidence thresholds to uint64 max when the output-decimal conversion exceeds the Pyth confidence type.
- Fixes audit issue L-06 by deriving and validating synthetic output confidence for Pyth two-feed product and ratio helpers.
- Adds regression coverage for the L-08 exponent boundary and the L-06 derived-confidence failure path.
- Documents the Pyth two-feed derived confidence behavior in the price configuration docs and Pyth submodule NatSpec.

## Root Cause
L-08: `PythPriceFeeds._getFeedPrice()` converted admin-supplied `maxConfidence` from output decimals into Pyth feed scale, then `SafeCast.encodeUInt64()` reverted when the converted value exceeded uint64 max. For exponents such as -22 and `maxConfidence = 1e16` at 18 output decimals, the conversion produces 1e20, causing every `getOneFeedPrice` call to revert before comparing against actual feed confidence.

L-06: `getTwoFeedPriceDiv()` and `getTwoFeedPriceMul()` validated each input feed independently, then returned a composed price without deriving or validating the composed confidence interval. A product or ratio can therefore be materially wider than either individual leg.

## Validation
- `pnpm run lint`
- `forge build --contracts src/modules/PRICE/submodules/feeds/PythPriceFeeds.sol`
- `forge test -vvv --match-contract PythPriceFeedsGetOneFeedPriceTest`
- `forge test -vvv --match-path 'src/test/modules/PRICE.v2/submodules/feeds/PythPriceFeeds/*.sol'`
- Red check for L-06: temporarily disabled derived-confidence validation and confirmed the new `test_outputMaxConfidenceExceeded_reverts` cases failed, then restored validation and confirmed they passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Price feed handling now returns and validates a derived output confidence, clamps oversized confidence conversions, and adds stricter validation including a new invalid-condition for unsafe division confidence.

* **Tests**
  * Added tests for negative-exponent confidence conversion, clamped-overflow cases, two-feed output-confidence validation (zero/exceeded), and adjusted parameter-length boundary checks.

* **Documentation**
  * Expanded docs on confidence conversion, clamping behavior, two-feed derived-confidence rules, and new invalid/excessive confidence conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->