### PR TITLE
Price Feed Resilience: Validate canonical Uniswap V3 pools

### DIFF
--- a/src/modules/PRICE/submodules/feeds/UniswapV3Price.sol
+++ b/src/modules/PRICE/submodules/feeds/UniswapV3Price.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.15;
 
 // Interfaces
 import {IPRICEv2} from "src/modules/PRICE/IPRICE.v2.sol";
+import {IUniswapV3Factory} from "@uniswap-v3-core-1.0.1/interfaces/IUniswapV3Factory.sol";
 import {IUniswapV3Pool} from "@uniswap-v3-core-1.0.1/interfaces/IUniswapV3Pool.sol";
 
 // Libraries
@@ -96,15 +97,12 @@ contract UniswapV3Price is PriceSubmodule {
     /// @param factory_         The configured factory address
     error UniswapV3_FactoryInvalid(address factory_);
 
-    /// @notice                     The pool factory does not match the configured canonical Uniswap V3 factory
-    /// @param pool_                The address of the pool
-    /// @param poolFactory_         The factory returned by the pool
-    /// @param expectedFactory_     The expected canonical Uniswap V3 factory
-    error UniswapV3_PoolFactoryInvalid(
-        address pool_,
-        address poolFactory_,
-        address expectedFactory_
-    );
+    /// @notice                     The pool does not match the canonical Uniswap V3 factory's registered pool
+    ///
+    /// @param pool_                The provided pool address
+    /// @param expectedPool_        The pool returned by the canonical Uniswap V3 factory
+    /// @param factory_             The canonical Uniswap V3 factory
+    error UniswapV3_PoolFactoryInvalid(address pool_, address expectedPool_, address factory_);
 
     /// @notice                         The pool has insufficient observation cardinality for the TWAP window
     ///
@@ -307,25 +305,17 @@ contract UniswapV3Price is PriceSubmodule {
             revert UniswapV3_PoolTypeInvalid(address(pool_));
         }
 
-        try pool_.factory() returns (address poolFactory) {
-            if (poolFactory != UNISWAP_V3_FACTORY) {
-                revert UniswapV3_PoolFactoryInvalid(
-                    address(pool_),
-                    poolFactory,
-                    UNISWAP_V3_FACTORY
-                );
-            }
-        } catch (bytes memory) {
-            revert UniswapV3_PoolTypeInvalid(address(pool_));
-        }
-
         address quoteToken;
+        address token0;
+        address token1;
         {
             bool lookupTokenFound;
             try pool_.token0() returns (address token) {
                 // Check if token is zero address, revert if so
                 if (token == address(0))
                     revert UniswapV3_PoolTokensInvalid(address(pool_), 0, token);
+
+                token0 = token;
 
                 // If token is the lookup token, set lookupTokenFound to true
                 // Otherwise, it should be the quote token
@@ -345,6 +335,8 @@ contract UniswapV3Price is PriceSubmodule {
                 if (token == address(0))
                     revert UniswapV3_PoolTokensInvalid(address(pool_), 1, token);
 
+                token1 = token;
+
                 // If token is the lookup token, set lookupTokenFound to true
                 // Otherwise, it should be the quote token
                 // If lookup token isn't found, quote token will be set twice,
@@ -362,6 +354,27 @@ contract UniswapV3Price is PriceSubmodule {
             // If lookup token wasn't found, revert
             if (!lookupTokenFound)
                 revert UniswapV3_LookupTokenNotFound(address(pool_), lookupToken_);
+        }
+
+        uint24 fee;
+        try pool_.fee() returns (uint24 poolFee) {
+            fee = poolFee;
+        } catch (bytes memory) {
+            revert UniswapV3_PoolTypeInvalid(address(pool_));
+        }
+
+        try IUniswapV3Factory(UNISWAP_V3_FACTORY).getPool(token0, token1, fee) returns (
+            address expectedPool
+        ) {
+            if (expectedPool != address(pool_)) {
+                revert UniswapV3_PoolFactoryInvalid(
+                    address(pool_),
+                    expectedPool,
+                    UNISWAP_V3_FACTORY
+                );
+            }
+        } catch (bytes memory) {
+            revert UniswapV3_FactoryInvalid(UNISWAP_V3_FACTORY);
         }
 
         // Validate output decimals are not too high

--- a/src/test/mocks/MockUniV3Pair.sol
+++ b/src/test/mocks/MockUniV3Pair.sol
@@ -24,6 +24,7 @@ contract MockUniV3Pair is IUniswapV3Pool {
     address internal _token1;
     address internal _factory;
 
+    uint24 internal _fee = 500;
     bool internal _observeReverts;
     bool internal _unlocked = true;
 
@@ -61,6 +62,10 @@ contract MockUniV3Pair is IUniswapV3Pool {
 
     function setFactory(address factory_) public {
         _factory = factory_;
+    }
+
+    function setFee(uint24 fee_) public {
+        _fee = fee_;
     }
 
     function setTickCumulatives(int56[] memory observations_) public {
@@ -238,7 +243,9 @@ contract MockUniV3Pair is IUniswapV3Pool {
 
     // Not implemented
 
-    function fee() external view returns (uint24) {}
+    function fee() external view returns (uint24) {
+        return _fee;
+    }
 
     function tickSpacing() external view returns (int24) {}
 

--- a/src/test/modules/PRICE.v2/PriceV2BaseTest.sol
+++ b/src/test/modules/PRICE.v2/PriceV2BaseTest.sol
@@ -16,6 +16,7 @@ import {MockBalancerVault} from "test/mocks/MockBalancerVault.sol";
 import {MockUniV3Pair} from "test/mocks/MockUniV3Pair.sol";
 
 // Interfaces
+import {IUniswapV3Factory} from "@uniswap-v3-core-1.0.1/interfaces/IUniswapV3Factory.sol";
 import {AggregatorV2V3Interface} from "src/interfaces/AggregatorV2V3Interface.sol";
 import {IPRICEv2} from "src/modules/PRICE/IPRICE.v2.sol";
 
@@ -74,6 +75,7 @@ abstract contract PriceV2BaseTest is Test {
     uint32 internal constant TWAP_PERIOD = 24 hours;
     uint32 internal constant _UNISWAP_V3_AVERAGE_BLOCK_TIME_SECONDS = 12;
     address internal constant _UNISWAP_V3_FACTORY = 0x1F98431c8aD98523631AE4a59f267346ea31F984;
+    uint24 internal constant _UNISWAP_V3_FEE = 500;
 
     // Re-declare events from PRICE.v2.sol
     event PriceStored(address indexed asset_, uint256 price_, uint48 timestamp_);
@@ -188,6 +190,13 @@ abstract contract PriceV2BaseTest is Test {
             ohmEthUniV3Pool.setToken0(ohmFirst ? address(ohm) : address(weth));
             ohmEthUniV3Pool.setToken1(ohmFirst ? address(weth) : address(ohm));
             ohmEthUniV3Pool.setFactory(_UNISWAP_V3_FACTORY);
+            ohmEthUniV3Pool.setFee(_UNISWAP_V3_FEE);
+            mockCanonicalPool(
+                ohmEthUniV3Pool.token0(),
+                ohmEthUniV3Pool.token1(),
+                _UNISWAP_V3_FEE,
+                address(ohmEthUniV3Pool)
+            );
             // Create ticks for a 24 hour second observation period
             // Set to a price of 1 OHM = 0.005 ETH
             // Weighted tick needs to be 154257 (if OHM is token0) or -154257 (if OHM is token1) (as if 5,000,000 ETH per OHM because of the decimal difference)
@@ -240,6 +249,19 @@ abstract contract PriceV2BaseTest is Test {
     }
 
     // =========  HELPER FUNCTIONS ========= //
+    function mockCanonicalPool(
+        address token0_,
+        address token1_,
+        uint24 fee_,
+        address pool_
+    ) internal {
+        vm.mockCall(
+            _UNISWAP_V3_FACTORY,
+            abi.encodeWithSelector(IUniswapV3Factory.getPool.selector, token0_, token1_, fee_),
+            abi.encode(pool_)
+        );
+    }
+
     function _makeRandomObservations(
         MockERC20 asset,
         IPRICEv2.Component memory feed,

--- a/src/test/modules/PRICE.v2/submodules/feeds/UniswapV3Price.t.sol
+++ b/src/test/modules/PRICE.v2/submodules/feeds/UniswapV3Price.t.sol
@@ -13,6 +13,7 @@ import {MockPrice} from "test/mocks/MockPrice.v2.sol";
 import {MockUniV3Pair} from "test/mocks/MockUniV3Pair.sol";
 
 // Interfaces
+import {IUniswapV3Factory} from "@uniswap-v3-core-1.0.1/interfaces/IUniswapV3Factory.sol";
 import {IUniswapV3Pool} from "@uniswap-v3-core-1.0.1/interfaces/IUniswapV3Pool.sol";
 import {IPRICEv2} from "src/modules/PRICE/IPRICE.v2.sol";
 
@@ -39,6 +40,7 @@ contract UniswapV3PriceTest is Test {
     address internal USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
     address internal WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
     address internal constant UNISWAP_V3_FACTORY = 0x1F98431c8aD98523631AE4a59f267346ea31F984;
+    uint24 internal constant UNISWAP_V3_FEE = 500;
 
     uint8 internal PRICE_DECIMALS = 18;
 
@@ -83,8 +85,10 @@ contract UniswapV3PriceTest is Test {
             mockUniPair.setToken0(LUSD);
             mockUniPair.setToken1(USDC);
             mockUniPair.setFactory(UNISWAP_V3_FACTORY);
+            mockUniPair.setFee(UNISWAP_V3_FEE);
             mockUniPair.setSqrtPrice(uniSqrtPrice);
             mockUniPair.setTickCumulatives(uniTickCumulatives);
+            mockCanonicalPool(LUSD, USDC, UNISWAP_V3_FEE, address(mockUniPair));
         }
 
         // Mock prices from PRICE
@@ -121,6 +125,19 @@ contract UniswapV3PriceTest is Test {
 
     function mockERC20Decimals(address asset_, uint8 decimals_) internal {
         vm.mockCall(asset_, abi.encodeWithSignature("decimals()"), abi.encode(decimals_));
+    }
+
+    function mockCanonicalPool(
+        address token0_,
+        address token1_,
+        uint24 fee_,
+        address pool_
+    ) internal {
+        vm.mockCall(
+            UNISWAP_V3_FACTORY,
+            abi.encodeWithSelector(IUniswapV3Factory.getPool.selector, token0_, token1_, fee_),
+            abi.encode(pool_)
+        );
     }
 
     function expectRevert_PriceZero(address asset_) internal {
@@ -339,14 +356,14 @@ contract UniswapV3PriceTest is Test {
         uniSubmodule.getTokenTWAP(WETH, PRICE_DECIMALS, params);
     }
 
-    function testRevert_getTokenTWAPOnInvalidFactory() public {
-        address invalidFactory = address(0xBEEF);
-        mockUniPair.setFactory(invalidFactory);
+    function test_getTokenTWAP_givenPoolNotReturnedByCanonicalFactory_reverts() public {
+        address canonicalPool = address(0xBEEF);
+        mockCanonicalPool(LUSD, USDC, UNISWAP_V3_FEE, canonicalPool);
 
         bytes memory err = abi.encodeWithSelector(
             UniswapV3Price.UniswapV3_PoolFactoryInvalid.selector,
             address(mockUniPair),
-            invalidFactory,
+            canonicalPool,
             UNISWAP_V3_FACTORY
         );
         vm.expectRevert(err);
@@ -404,6 +421,7 @@ contract UniswapV3PriceTest is Test {
         // Mock the UNI-wETH pool
         mockUniPair.setToken0(UNI);
         mockUniPair.setToken1(WETH);
+        mockCanonicalPool(UNI, WETH, UNISWAP_V3_FEE, address(mockUniPair));
         int56[] memory tickCumulatives = new int56[](2);
         tickCumulatives[0] = -30809700251260;
         tickCumulatives[1] = -30809733307660;
@@ -774,14 +792,14 @@ contract UniswapV3PriceTest is Test {
         uniSubmodule.getTokenPrice(WETH, PRICE_DECIMALS, params);
     }
 
-    function test_getTokenPrice_invalidFactory_reverts() public {
-        address invalidFactory = address(0xBEEF);
-        mockUniPair.setFactory(invalidFactory);
+    function test_getTokenPrice_givenPoolNotReturnedByCanonicalFactory_reverts() public {
+        address canonicalPool = address(0xBEEF);
+        mockCanonicalPool(LUSD, USDC, UNISWAP_V3_FEE, canonicalPool);
 
         bytes memory err = abi.encodeWithSelector(
             UniswapV3Price.UniswapV3_PoolFactoryInvalid.selector,
             address(mockUniPair),
-            invalidFactory,
+            canonicalPool,
             UNISWAP_V3_FACTORY
         );
         vm.expectRevert(err);
@@ -953,6 +971,7 @@ contract UniswapV3PriceTest is Test {
         // Mock the UNI-wETH pool
         mockUniPair.setToken0(UNI);
         mockUniPair.setToken1(WETH);
+        mockCanonicalPool(UNI, WETH, UNISWAP_V3_FEE, address(mockUniPair));
         int56[] memory tickCumulatives = new int56[](2);
         tickCumulatives[0] = -30809700251260;
         tickCumulatives[1] = -30809733307660;


### PR DESCRIPTION
## Summary

- Validate Uniswap V3 pools by deriving the canonical pool from the configured factory using the pool's `token0`, `token1`, and `fee`.
- Reject provided pools unless the canonical factory returns the same address.
- Add regression coverage for spoofed pools on both TWAP and current-price paths.

## Root Cause

The previous validation trusted `pool.factory()`, so a malicious pool could report the canonical factory while not actually being a pool deployed or registered by that factory.

## Validation

- `./node_modules/.bin/prettier --write src/modules/PRICE/submodules/feeds/UniswapV3Price.sol src/test/modules/PRICE.v2/submodules/feeds/UniswapV3Price.t.sol src/test/mocks/MockUniV3Pair.sol`
- `forge build --contracts src/modules/PRICE/submodules/feeds/UniswapV3Price.sol`
- `./node_modules/.bin/solhint --config ./.solhint.json src/modules/PRICE/submodules/feeds/UniswapV3Price.sol src/test/modules/PRICE.v2/submodules/feeds/UniswapV3Price.t.sol src/test/mocks/MockUniV3Pair.sol`
- `forge test -vvv --match-contract UniswapV3PriceTest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Uniswap V3 pool validation by verifying the pool returned by the canonical factory registry; updated error signature for clearer validation failure information.

* **Tests**
  * Updated pool validation tests to exercise the new factory-based check.
  * Added configurability for Uniswap V3 fee tiers in test utilities to support the new validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->