### PR TITLE
Price Feed Resilience: Filter OHM feed deviations

### DIFF
--- a/documentation/price_v1_upgrade.md
+++ b/documentation/price_v1_upgrade.md
@@ -107,7 +107,7 @@ Create an args file with price feed addresses (JSON format with `.functions[].na
 2. Configure USDS (Chainlink USDS-USD + Chainlink DAI-USD + Pyth feeds, deviation-based strategy)
 3. Configure sUSDS (ERC4626 wrapper, uses USDS price)
 4. Configure wETH (Chainlink + RedStone + Pyth feeds, deviation-based strategy)
-5. Configure OHM (2x Uniswap V3 feeds + Chainlink OHM-ETH × ETH-USD, average strategy, migrated 30-day moving average)
+5. Configure OHM (2x Uniswap V3 feeds + Chainlink OHM-ETH × ETH-USD, deviation-filtered average strategy, migrated 30-day moving average)
 
 **Automatic validation:** The batch script simulates a full 24-hour Heart cycle (3 beats) to validate PRICE configuration before proposing the batch.
 

--- a/snapshots/OlympusPricev1_2ForkTest.json
+++ b/snapshots/OlympusPricev1_2ForkTest.json
@@ -1,6 +1,6 @@
 {
-    "getPrice_OHM": "661740",
-    "heartbeat": "825978",
-    "heartbeat_emissionManager": "1556093",
-    "heartbeat_yrf": "1210407"
+    "getPrice_OHM": "672524",
+    "heartbeat": "834762",
+    "heartbeat_emissionManager": "1558430",
+    "heartbeat_yrf": "1219191"
 }

--- a/src/scripts/ops/batches/ConfigurePriceV1_2.sol
+++ b/src/scripts/ops/batches/ConfigurePriceV1_2.sol
@@ -444,14 +444,21 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
         address uniswapOhmWeth = _readBatchArgAddress("configurePriceV1_2", "uniswapOhmWeth");
         address uniswapOhmSusds = _readBatchArgAddress("configurePriceV1_2", "uniswapOhmSusds");
 
-        // Read strict mode from args file
+        // Read deviation parameters from args file
+        uint16 ohmDeviationBps = SafeCast.encodeUInt16(
+            _readBatchArgUint256("configurePriceV1_2", "ohmDeviationBps")
+        );
         bool ohmStrictMode = _readBatchArgBool("configurePriceV1_2", "ohmStrictMode");
 
         console2.log("Uniswap OHM/WETH:", uniswapOhmWeth);
         console2.log("Uniswap OHM/sUSDS:", uniswapOhmSusds);
 
-        // Create strategy component: getAveragePrice with strict mode
-        IPRICEv2.Component memory strategy = _encodeAverageStrategy(ohmStrictMode);
+        // Create strategy component: getAveragePriceExcludingDeviations
+        IPRICEv2.Component memory strategy = _encodeDeviationStrategy(
+            SimplePriceFeedStrategy.getAveragePriceExcludingDeviations.selector,
+            ohmDeviationBps,
+            ohmStrictMode
+        );
         IPRICEv2.Component[] memory feeds = _getOhmFeeds();
 
         IPriceConfigv2.PriceFeedExpectation[] memory feedExpectations = _readFeedExpectations(

--- a/src/scripts/ops/batches/args/ConfigurePriceV1_2.json
+++ b/src/scripts/ops/batches/args/ConfigurePriceV1_2.json
@@ -7,6 +7,7 @@
                 "chainlinkEthBtc": "0xAc559F25B1619171CbC396a50854A3240b6A4e99",
                 "chainlinkEthUsd": "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
                 "chainlinkUsdsUsd": "0xfF30586cD0F29eD462364C7e81375FC0C71219b1",
+                "ohmDeviationBps": 200,
                 "ohmExpectedPrice": "19500000000000000000",
                 "ohmExpectedToleranceBps": 1283,
                 "ohmObservationWindow": 1800,

--- a/src/test/modules/PRICE/OlympusPricev1_2Fork.t.sol
+++ b/src/test/modules/PRICE/OlympusPricev1_2Fork.t.sol
@@ -88,6 +88,7 @@ contract OlympusPricev1_2ForkTest is Test {
     uint256 internal constant BPS_MAX = 10_000;
     uint256 internal constant WETH_DEVIATION_BPS = 500; // 5% deviation
     uint256 internal constant USDS_DEVIATION_BPS = 100; // 1% deviation
+    uint256 internal constant OHM_DEVIATION_BPS = 200; // 2% deviation
     uint256 internal constant PYTH_ETH_USD_MAX_CONFIDENCE = 10e18;
     uint256 internal constant PYTH_USDS_USD_MAX_CONFIDENCE = 0.1e18;
     uint48 internal constant WETH_UPDATE_THRESHOLD = 2 * 86400; // 48 hours (differs from production to allow for warping)
@@ -232,11 +233,17 @@ contract OlympusPricev1_2ForkTest is Test {
     function _configureOhmAsset() internal {
         vm.startPrank(DAO_MS); // DAO_MS has price_admin permissions
 
-        // Create strategy component: getAveragePrice with strict mode
+        // Create strategy component: getAveragePriceExcludingDeviations
         IPRICEv2.Component memory ohmStrategy = IPRICEv2.Component({
             target: toSubKeycode("PRICE.SIMPLESTRATEGY"),
-            selector: SimplePriceFeedStrategy.getAveragePrice.selector,
-            params: abi.encode(true) // strict mode
+            selector: SimplePriceFeedStrategy.getAveragePriceExcludingDeviations.selector,
+            params: abi.encode(
+                ISimplePriceFeedStrategy.DeviationParams({
+                    /// forge-lint: disable-next-line(unsafe-typecast)
+                    deviationBps: uint16(OHM_DEVIATION_BPS),
+                    revertOnInsufficientCount: true // strict mode
+                })
+            )
         });
 
         // Create feed components for the two Uniswap pools using getTokenTWAP, and the Chainlink OHM/ETH feed
@@ -567,6 +574,52 @@ contract OlympusPricev1_2ForkTest is Test {
         // Validate OHM price (uses Uniswap V3 TWAP feeds)
         uint256 ohmPrice = price.getPrice(OHM);
         _assertPriceInRange(ohmPrice, OHM_MIN_PRICE, OHM_MAX_PRICE, "OHM");
+    }
+
+    function test_priceValidation_ohmUsesDeviationFilteredAverage() public view {
+        IPRICEv2.Asset memory ohmAsset = price.getAssetData(OHM);
+        IPRICEv2.Component memory ohmStrategy = abi.decode(ohmAsset.strategy, (IPRICEv2.Component));
+        ISimplePriceFeedStrategy.DeviationParams memory params = abi.decode(
+            ohmStrategy.params,
+            (ISimplePriceFeedStrategy.DeviationParams)
+        );
+
+        assertEq(
+            ohmStrategy.selector,
+            SimplePriceFeedStrategy.getAveragePriceExcludingDeviations.selector,
+            "OHM should use deviation-filtered average"
+        );
+        assertEq(
+            params.deviationBps,
+            OHM_DEVIATION_BPS,
+            "OHM deviation threshold should match config"
+        );
+        assertTrue(params.revertOnInsufficientCount, "OHM strategy should use strict mode");
+    }
+
+    function test_priceValidation_ohmDeviationStrategyExcludesOutlier() public view {
+        uint256[] memory prices = new uint256[](3);
+        prices[0] = 202e17;
+        prices[1] = 205e17;
+        prices[2] = 30e18;
+
+        uint256 resolvedPrice = strategy.getAveragePriceExcludingDeviations(
+            prices,
+            abi.encode(
+                ISimplePriceFeedStrategy.DeviationParams({
+                    /// forge-lint: disable-next-line(unsafe-typecast)
+                    deviationBps: uint16(OHM_DEVIATION_BPS),
+                    revertOnInsufficientCount: true
+                })
+            )
+        );
+
+        // prices[0] = 20.2e18 (18 decimals)
+        // prices[1] = 20.5e18 (18 decimals)
+        // prices[2] = 30e18 (18 decimals)
+        // Median benchmark is 20.5e18. With a 2% threshold, 30e18 deviates and is excluded.
+        // Expected: (20.2e18 + 20.5e18) / 2 = 20.35e18.
+        assertEq(resolvedPrice, 2035e16, "OHM strategy should exclude the outlier");
     }
 
     function _warpToNextHeartbeat() internal {


### PR DESCRIPTION
## Summary

Configures the OHM PRICE v1.2 asset to use `getAveragePriceExcludingDeviations()` instead of the plain average strategy, with a 2% deviation threshold. This makes the added non-DEX OHM feed act as a tighter manipulation check against the two DEX TWAP feeds.

## Changes

- Adds `ohmDeviationBps` to the PRICE v1.2 batch args and sets it to `200` bps.
- Encodes OHM with `SimplePriceFeedStrategy.getAveragePriceExcludingDeviations()` in `ConfigurePriceV1_2`.
- Updates the fork-test mirror and adds assertions for the OHM strategy selector/params plus an outlier-exclusion case.
- Refreshes the affected gas snapshots and PRICE upgrade documentation.

## Validation

- `forge build --contracts src/scripts/ops/batches/ConfigurePriceV1_2.sol`
- `forge build --contracts src/test/modules/PRICE/OlympusPricev1_2Fork.t.sol`
- `forge test --match-path src/test/modules/PRICE/OlympusPricev1_2Fork.t.sol -vvv`
- Prettier on changed files
- `solhint` on changed Solidity files
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented deviation-filtered average strategy for OHM asset pricing, which excludes outlier price feeds to improve pricing accuracy.
  * Configured 2% deviation threshold to filter extreme price deviations from price feeds.

* **Tests**
  * Added validation tests to verify deviation-filtered pricing behavior and strategy configuration for OHM.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->