### PR TITLE
Price Feed Resilience: Recalculate Morpho oracle scale factor

### DIFF
--- a/documentation/oracle_factories.md
+++ b/documentation/oracle_factories.md
@@ -66,8 +66,9 @@ Deploys Morpho-compatible oracles implementing `IMorphoOracle`.
 
 **Special Logic**:
 
-- Calculates scale factor: `10^(loanDecimals - collateralDecimals + 36)`
+- Calculates scale factor from current `PriceCache.assetDecimals()` values: `10^(loanDecimals - collateralDecimals + 36)`
 - Validates decimals bounds to prevent overflow
+- If collateral or loan is a non-contract asset, its decimal scale is PriceCache metadata rather than ERC-20 metadata. Confirm the active value with `PriceCache.assetDecimals(asset)` before configuring or relying on a Morpho market.
 
 ### 3. ERC7726Oracle
 

--- a/documentation/price.md
+++ b/documentation/price.md
@@ -25,6 +25,8 @@ The `PriceCache` policy supports non-contract assets in addition to normal ERC-2
 
 For contract assets, oracle adapters and factories can read decimals and symbols directly from the token contract. For non-contract assets, that metadata must instead be configured in `PriceCache` via `setNonContractAssetMetadata(asset_, decimals_, symbol_)`.
 
+Unlike ERC-20 metadata, a non-contract asset does not have an intrinsic decimal scale. Its decimal scale is the value currently configured in `PriceCache`. Integrations that use non-contract assets should confirm the active value with `PriceCache.assetDecimals(asset_)`, especially after metadata updates. Morpho-compatible oracles recalculate their scale factor from the active cache decimals when read, so a non-contract asset decimal update changes the scale used by `scaleFactor()` and `price()`.
+
 The required conditions for non-contract asset support are:
 
 1. the asset must be registered in `PRICE` as a non-contract asset, unless it is the configured unit of account

--- a/snapshots/MorphoOracleCloneableIsStaleTest.json
+++ b/snapshots/MorphoOracleCloneableIsStaleTest.json
@@ -1,3 +1,3 @@
 {
-    "MorphoOracleCloneable.isStale": "38231"
+    "MorphoOracleCloneable.isStale": "38255"
 }

--- a/snapshots/MorphoOracleCloneablePriceTest.json
+++ b/snapshots/MorphoOracleCloneablePriceTest.json
@@ -1,3 +1,3 @@
 {
-    "MorphoOracleCloneable.price": "62310"
+    "MorphoOracleCloneable.price": "66809"
 }

--- a/snapshots/MorphoOracleCloneableTimestampTest.json
+++ b/snapshots/MorphoOracleCloneableTimestampTest.json
@@ -1,3 +1,3 @@
 {
-    "MorphoOracleCloneable.timestamp": "38190"
+    "MorphoOracleCloneable.timestamp": "38214"
 }

--- a/src/policies/interfaces/price/IMorphoOracle.sol
+++ b/src/policies/interfaces/price/IMorphoOracle.sol
@@ -15,6 +15,19 @@ interface IMorphoOracle is IOracle {
     /// @notice Thrown when the cached direct-pair USD legs are invalid
     error MorphoOracle_InvalidPrice();
 
+    /// @notice Thrown when token decimals result in an invalid scale factor
+    ///
+    /// @param  collateralToken     The collateral token address
+    /// @param  loanToken           The loan token address
+    /// @param  collateralDecimals  The collateral token decimals reported by the active price cache
+    /// @param  loanDecimals        The loan token decimals reported by the active price cache
+    error MorphoOracle_TokenDecimalsOutOfBounds(
+        address collateralToken,
+        address loanToken,
+        uint8 collateralDecimals,
+        uint8 loanDecimals
+    );
+
     /// @notice Thrown when the direct pair cache timestamp is stale
     ///
     /// @param  cachedTimestamp               The cached timestamp used for the collateral/loan pair
@@ -38,7 +51,11 @@ interface IMorphoOracle is IOracle {
     /// @return maxAge_  The configured maximum cache age in seconds
     function maxAge() external view returns (uint48 maxAge_);
 
-    /// @notice The scale factor for the oracle
+    /// @notice The current scale factor for the oracle
+    /// @dev    Uses the active price cache's current asset decimals. For non-contract assets,
+    ///         decimals are PriceCache metadata rather than token metadata, so this value can
+    ///         change when `PriceCache.setNonContractAssetMetadata()` updates decimals. Call
+    ///         `PriceCache.assetDecimals()` to confirm the active NCA scale.
     ///
     /// @return scaleFactor_    The scale factor
     function scaleFactor() external view returns (uint256 scaleFactor_);

--- a/src/policies/price/MorphoOracleCloneable.sol
+++ b/src/policies/price/MorphoOracleCloneable.sol
@@ -11,8 +11,9 @@ import {IMorphoOracle} from "src/policies/interfaces/price/IMorphoOracle.sol";
 import {IOraclePriceCache} from "src/policies/interfaces/price/IOraclePriceCache.sol";
 
 // Libraries
-import {FullMath} from "src/libraries/FullMath.sol";
 import {Clone} from "@clones-with-immutable-args-1.1.2/Clone.sol";
+import {SafeCast} from "@openzeppelin-4.8.0/utils/math/SafeCast.sol";
+import {FullMath} from "src/libraries/FullMath.sol";
 import {String} from "src/libraries/String.sol";
 
 /// @title  MorphoOracleCloneable
@@ -30,8 +31,9 @@ contract MorphoOracleCloneable is IMorphoOracle, IOraclePriceCache, Clone {
     // 0x14: collateral token address (20 bytes)
     // 0x28: loan token address (20 bytes)
     // 0x3C: max age (8 bytes, stored as uint64)
-    // 0x44: scale factor (32 bytes)
-    // 0x64: name (32 bytes)
+    // 0x44: name (32 bytes)
+
+    uint8 internal constant _MORPHO_DECIMALS = 36;
 
     // ========== IMMUTABLE ARGS GETTERS ========== //
 
@@ -60,11 +62,14 @@ contract MorphoOracleCloneable is IMorphoOracle, IOraclePriceCache, Clone {
     }
 
     /// @notice The scale factor for the oracle
-    /// @dev    Does not revert.
+    /// @dev    Uses the current asset decimals reported by the factory's active price cache.
+    ///         For non-contract assets, decimals are PriceCache metadata rather than token
+    ///         metadata, so this value can change when `PriceCache.setNonContractAssetMetadata()`
+    ///         updates decimals. Call `PriceCache.assetDecimals()` to confirm the active NCA scale.
     ///
-    /// @return uint256 The scale factor stored in immutable args
-    function scaleFactor() public pure returns (uint256) {
-        return _getArgUint256(0x44);
+    /// @return uint256 The current scale factor
+    function scaleFactor() public view returns (uint256) {
+        return _scaleFactor(IPriceCache(factory().getPriceCache()));
     }
 
     /// @notice The maximum allowed age for cached prices
@@ -80,7 +85,7 @@ contract MorphoOracleCloneable is IMorphoOracle, IOraclePriceCache, Clone {
     ///
     /// @return string The name stored in immutable args
     function name() public pure returns (string memory) {
-        return String.bytes32ToString(bytes32(abi.encodePacked(_getArgUint256(0x64))));
+        return String.bytes32ToString(bytes32(abi.encodePacked(_getArgUint256(0x44))));
     }
 
     /// @notice Returns the enabled price cache policy for this oracle.
@@ -104,6 +109,11 @@ contract MorphoOracleCloneable is IMorphoOracle, IOraclePriceCache, Clone {
     /// @inheritdoc IOracle
     /// @notice     Returns the price of 1 collateral token quoted in loan tokens, scaled by 1e36
     /// @dev        This function uses cached pair snapshots only.
+    /// @dev        The Morpho scale factor is recomputed from the active price cache's current
+    ///             collateral and loan decimals. If either asset is a non-contract asset, decimals
+    ///             are PriceCache metadata rather than token metadata and can change when
+    ///             `PriceCache.setNonContractAssetMetadata()` updates decimals. Call
+    ///             `PriceCache.assetDecimals()` to confirm the active NCA scale.
     ///
     ///             This function will revert if:
     ///             - The oracle is not enabled in the factory context
@@ -117,7 +127,8 @@ contract MorphoOracleCloneable is IMorphoOracle, IOraclePriceCache, Clone {
     ///             If callers encounter a feed-state revert, they should cache prices then retry.
     ///             A caller can alternatively call `isStale()`, call `cachePrice()` (if the result is true), and then this function.
     function price() external view override returns (uint256) {
-        IPriceCache.CachedPrice memory cachedPrice = _getEnabledPriceCache().getCachedPrice(
+        IPriceCache priceCache = _getEnabledPriceCache();
+        IPriceCache.CachedPrice memory cachedPrice = priceCache.getCachedPrice(
             collateralToken(),
             loanToken()
         );
@@ -134,7 +145,42 @@ contract MorphoOracleCloneable is IMorphoOracle, IOraclePriceCache, Clone {
             revert MorphoOracle_Stale(pairTimestamp, _latestPermissibleTimestamp(maxAge_));
         }
 
-        return cachedPrice.assetPriceUsd.mulDiv(scaleFactor(), cachedPrice.quotePriceUsd);
+        return
+            cachedPrice.assetPriceUsd.mulDiv(_scaleFactor(priceCache), cachedPrice.quotePriceUsd);
+    }
+
+    /// @notice Calculates the current Morpho scale factor from the active price cache
+    /// @dev    Morpho expects prices scaled by 1e36, adjusted for collateral and loan token
+    ///         decimals: `10 ** (36 + loanDecimals - collateralDecimals)`.
+    ///         For non-contract assets, decimals are PriceCache metadata and can change when
+    ///         `PriceCache.setNonContractAssetMetadata()` updates them, so the scale factor is
+    ///         recalculated instead of read from immutable args.
+    ///         Reverts if the exponent is negative or greater than 77, since `10 ** 78` exceeds
+    ///         `uint256`.
+    ///
+    /// @param  priceCache_     The price cache used to resolve the current asset decimals
+    /// @return scaleFactor_    The current Morpho scale factor
+    function _scaleFactor(IPriceCache priceCache_) internal view returns (uint256 scaleFactor_) {
+        address collateralToken_ = collateralToken();
+        address loanToken_ = loanToken();
+        uint8 collateralDecimals = priceCache_.assetDecimals(collateralToken_);
+        uint8 loanDecimals = priceCache_.assetDecimals(loanToken_);
+
+        // Morpho scale = 10^(36 + loanDecimals - collateralDecimals).
+        // Recompute from the active price cache so non-contract asset metadata changes are reflected.
+        int256 exponent = SafeCast.toInt256(loanDecimals) -
+            SafeCast.toInt256(collateralDecimals) +
+            SafeCast.toInt256(_MORPHO_DECIMALS);
+        if (exponent < 0 || exponent > 77) {
+            revert MorphoOracle_TokenDecimalsOutOfBounds(
+                collateralToken_,
+                loanToken_,
+                collateralDecimals,
+                loanDecimals
+            );
+        }
+
+        return 10 ** SafeCast.toUint256(exponent);
     }
 
     function _isStaleFromTimestamp(uint48 timestamp_, uint48 maxAge_) internal view returns (bool) {

--- a/src/policies/price/MorphoOracleFactory.sol
+++ b/src/policies/price/MorphoOracleFactory.sol
@@ -57,15 +57,17 @@ contract MorphoOracleFactory is BaseOracleFactory {
     /// @inheritdoc BaseOracleFactory
     /// @notice Encodes Morpho-specific oracle data for cloning
     /// @dev    Performs Morpho-specific validation (decimals bounds check),
-    ///         calculates scale factor, generates oracle name, and encodes immutable args.
+    ///         generates oracle name, and encodes immutable args.
     ///         Note: baseToken_ is used as collateralToken, quoteToken_ is used as loanToken.
+    ///         If either token is a non-contract asset, decimals are PriceCache metadata rather
+    ///         than token metadata. The clone recalculates from `PriceCache.assetDecimals()` on
+    ///         reads, so later NCA decimal updates can change the live Morpho scale factor.
     function _encodeOracleData(
         address collateralToken_,
         address loanToken_,
         uint48 maxAge_,
         bytes calldata
     ) internal view override returns (bytes memory) {
-        // Calculate scale factor
         uint8 collateralDecimals = priceCache.assetDecimals(collateralToken_);
         uint8 loanDecimals = priceCache.assetDecimals(loanToken_);
 
@@ -80,9 +82,6 @@ contract MorphoOracleFactory is BaseOracleFactory {
         if (exponent < 0 || exponent > 77) {
             revert MorphoOracleFactory_TokenDecimalsOutOfBounds(collateralToken_, loanToken_);
         }
-
-        /// forge-lint: disable-next-line(unsafe-typecast)
-        uint256 scaleFactor = 10 ** uint256(exponent);
 
         // Compose name from token symbols and maxAge: "collateral/loan M {maxAge}s"
         string memory collateralSymbol = priceCache.assetSymbol(collateralToken_);
@@ -100,14 +99,13 @@ contract MorphoOracleFactory is BaseOracleFactory {
 
         // Create clone with immutable args
         // Layout:
-        // factory (20 bytes) | collateral (20 bytes) | loan (20 bytes) | maxAge (8 bytes) | scaleFactor (32 bytes) | name (32 bytes)
+        // factory (20 bytes) | collateral (20 bytes) | loan (20 bytes) | maxAge (8 bytes) | name (32 bytes)
         return
             abi.encodePacked(
                 address(this), // factory address
                 collateralToken_, // collateral token address
                 loanToken_, // loan token address
                 uint64(maxAge_), // max age
-                scaleFactor, // scale factor
                 oracleName // name
             );
     }

--- a/src/test/policies/price/ChainlinkOracleCloneable/latestRoundData.t.sol
+++ b/src/test/policies/price/ChainlinkOracleCloneable/latestRoundData.t.sol
@@ -171,6 +171,54 @@ contract ChainlinkOracleCloneableLatestRoundDataTest is ChainlinkOracleCloneable
         );
     }
 
+    function test_givenQuoteNonContractAssetDecimalsChange_whenPairCacheIsRefreshed_returnsSameAnswer()
+        public
+    {
+        address nonContractQuote = registeredNonContractAsset;
+
+        _setNonContractAssetMetadata(nonContractQuote, 18, "NCA");
+        _setPRICEPrices(nonContractQuote, 1e18);
+
+        address newOracle = _createOracle(address(baseToken), nonContractQuote, DEFAULT_MAX_AGE);
+
+        (, int256 initialAnswer, , , ) = IChainlinkOracle(newOracle).latestRoundData();
+        assertEq(initialAnswer, 2e18, "Initial answer should use the cached USD ratio");
+
+        _setNonContractAssetMetadata(nonContractQuote, 6, "NCA");
+        priceCache.cachePrice(address(baseToken), nonContractQuote);
+
+        (, int256 newAnswer, , , ) = IChainlinkOracle(newOracle).latestRoundData();
+        assertEq(
+            newAnswer,
+            2e18,
+            "Answer should remain the same when only native quote decimals change"
+        );
+    }
+
+    function test_givenBaseNonContractAssetDecimalsChange_whenPairCacheIsRefreshed_returnsSameAnswer()
+        public
+    {
+        address nonContractBase = registeredNonContractAsset;
+
+        _setNonContractAssetMetadata(nonContractBase, 18, "NCA");
+        _setPRICEPrices(nonContractBase, 2e18);
+
+        address newOracle = _createOracle(nonContractBase, address(quoteToken), DEFAULT_MAX_AGE);
+
+        (, int256 initialAnswer, , , ) = IChainlinkOracle(newOracle).latestRoundData();
+        assertEq(initialAnswer, 2e18, "Initial answer should use the cached USD ratio");
+
+        _setNonContractAssetMetadata(nonContractBase, 6, "NCA");
+        priceCache.cachePrice(nonContractBase, address(quoteToken));
+
+        (, int256 newAnswer, , , ) = IChainlinkOracle(newOracle).latestRoundData();
+        assertEq(
+            newAnswer,
+            2e18,
+            "Answer should remain the same when only native base decimals change"
+        );
+    }
+
     function test_whenOracleIsEnabled_gasSnapshotLatestRoundData() public givenPricesAreStored {
         vm.startSnapshotGas("ChainlinkOracleCloneable.latestRoundData");
         oracle.latestRoundData();

--- a/src/test/policies/price/ERC7726Oracle/getQuote.t.sol
+++ b/src/test/policies/price/ERC7726Oracle/getQuote.t.sol
@@ -143,6 +143,40 @@ contract ERC7726OracleGetQuoteTest is ERC7726OracleTest {
         assertEq(outAmount, 3e18, "Quote should use cache decimals for registered assets");
     }
 
+    function test_givenBaseNonContractAssetDecimalsChange_whenPairCacheIsRefreshed_returnsQuoteWithCurrentDecimals()
+        public
+        givenOracleIsEnabled
+    {
+        _setPRICEPrices(registeredNonContractAsset, 2e18);
+        _setNonContractAssetMetadata(registeredNonContractAsset, 18, "NCA");
+        priceCache.cachePrice(registeredNonContractAsset, address(loanToken));
+
+        // inAmount = 1e18
+        // assetPriceUsd = 2e18
+        // baseScale = 1e18
+        // quoteScale = 1e18
+        // quotePriceUsd = 1e18
+        // outAmount = 2e18
+        uint256 initialOutAmount = oracle.getQuote(
+            1e18,
+            registeredNonContractAsset,
+            address(loanToken)
+        );
+        assertEq(initialOutAmount, 2e18, "Initial quote should use 18 base decimals");
+
+        _setNonContractAssetMetadata(registeredNonContractAsset, 6, "NCA");
+        priceCache.cachePrice(registeredNonContractAsset, address(loanToken));
+
+        // inAmount = 1e6
+        // assetPriceUsd = 2e18
+        // baseScale = 1e6
+        // quoteScale = 1e18
+        // quotePriceUsd = 1e18
+        // outAmount = 2e18
+        uint256 newOutAmount = oracle.getQuote(1e6, registeredNonContractAsset, address(loanToken));
+        assertEq(newOutAmount, 2e18, "Quote should use current base decimals");
+    }
+
     function test_givenBaseAssetIsRegisteredNonContractAsset_givenNonContractAssetDecimalsAreSet_givenAssetIsNoLongerApprovedInPRICE_reverts()
         public
         givenOracleIsEnabled
@@ -204,6 +238,44 @@ contract ERC7726OracleGetQuoteTest is ERC7726OracleTest {
             registeredNonContractAsset
         );
         assertEq(outAmount, 5e7, "Quote should use cache decimals for registered assets");
+    }
+
+    function test_givenQuoteNonContractAssetDecimalsChange_whenPairCacheIsRefreshed_returnsQuoteWithCurrentDecimals()
+        public
+        givenOracleIsEnabled
+    {
+        _setPRICEPrices(registeredNonContractAsset, 1e18);
+        _setNonContractAssetMetadata(registeredNonContractAsset, 18, "NCA");
+        priceCache.cachePrice(address(collateralToken), registeredNonContractAsset);
+
+        // inAmount = 1e18
+        // assetPriceUsd = 2e18
+        // baseScale = 1e18
+        // quoteScale = 1e18
+        // quotePriceUsd = 1e18
+        // outAmount = 2e18
+        uint256 initialOutAmount = oracle.getQuote(
+            1e18,
+            address(collateralToken),
+            registeredNonContractAsset
+        );
+        assertEq(initialOutAmount, 2e18, "Initial quote should use 18 quote decimals");
+
+        _setNonContractAssetMetadata(registeredNonContractAsset, 6, "NCA");
+        priceCache.cachePrice(address(collateralToken), registeredNonContractAsset);
+
+        // inAmount = 1e18
+        // assetPriceUsd = 2e18
+        // baseScale = 1e18
+        // quoteScale = 1e6
+        // quotePriceUsd = 1e18
+        // outAmount = 2e6
+        uint256 newOutAmount = oracle.getQuote(
+            1e18,
+            address(collateralToken),
+            registeredNonContractAsset
+        );
+        assertEq(newOutAmount, 2e6, "Quote should use current quote decimals");
     }
 
     function test_givenQuoteAssetIsRegisteredNonContractAsset_givenNonContractAssetDecimalsAreSet_givenAssetIsNoLongerApprovedInPRICE_reverts()

--- a/src/test/policies/price/MorphoOracleCloneable/immutableArgs.t.sol
+++ b/src/test/policies/price/MorphoOracleCloneable/immutableArgs.t.sol
@@ -40,7 +40,7 @@ contract MorphoOracleCloneableImmutableArgsTest is MorphoOracleCloneableTest {
     }
 
     // scaleFactor
-    //  [X] it returns scale factor from immutable args
+    //  [X] it returns scale factor from current price cache asset decimals
 
     function test_scaleFactor() public view {
         // Scale factor = 10^(36 + loanDecimals - collateralDecimals)

--- a/src/test/policies/price/MorphoOracleCloneable/price.t.sol
+++ b/src/test/policies/price/MorphoOracleCloneable/price.t.sol
@@ -387,6 +387,70 @@ contract MorphoOracleCloneablePriceTest is MorphoOracleCloneableTest {
         assertEq(newPrice, 4e36, "Oracle should use updated cache policy prices");
     }
 
+    function test_givenLoanNonContractAssetDecimalsChange_whenPairCacheIsRefreshed_returnsPriceWithCurrentDecimals()
+        public
+    {
+        address nonContractLoan = registeredNonContractAsset;
+
+        _setNonContractAssetMetadata(nonContractLoan, 18, "NCA");
+        _setCachePrice(nonContractLoan, 1e18);
+
+        address newOracle = _createOracle(
+            address(collateralToken),
+            nonContractLoan,
+            DEFAULT_MAX_AGE
+        );
+
+        // collateral = 18 decimals, loan = 18 decimals
+        // scaleFactor = 1e36 (36 + 18 - 18)
+        // price = 2e18 * 1e36 / 1e18 = 2e36
+        assertEq(IMorphoOracle(newOracle).price(), 2e36, "Initial price should use 18 decimals");
+
+        _setNonContractAssetMetadata(nonContractLoan, 6, "NCA");
+        priceCache.cachePrice(address(collateralToken), nonContractLoan);
+
+        // collateral = 18 decimals, loan = 6 decimals
+        // scaleFactor = 1e24 (36 + 6 - 18)
+        // price = 2e18 * 1e24 / 1e18 = 2e24
+        assertEq(
+            IMorphoOracle(newOracle).price(),
+            2e24,
+            "Price should use current loan asset decimals after metadata change"
+        );
+    }
+
+    function test_givenCollateralNonContractAssetDecimalsChange_whenPairCacheIsRefreshed_returnsPriceWithCurrentDecimals()
+        public
+    {
+        address nonContractCollateral = registeredNonContractAsset;
+
+        _setNonContractAssetMetadata(nonContractCollateral, 18, "NCA");
+        _setCachePrice(nonContractCollateral, 2e18);
+
+        address newOracle = _createOracle(
+            nonContractCollateral,
+            address(loanToken),
+            DEFAULT_MAX_AGE
+        );
+
+        // collateral = 18 decimals, loan = 18 decimals
+        // scaleFactor = 1e36 (36 + 18 - 18)
+        // price = 2e18 * 1e36 / 1e18 = 2e36
+        assertEq(IMorphoOracle(newOracle).price(), 2e36, "Initial price should use 18 decimals");
+
+        _setNonContractAssetMetadata(nonContractCollateral, 6, "NCA");
+        priceCache.cachePrice(nonContractCollateral, address(loanToken));
+
+        // collateral = 6 decimals, loan = 18 decimals
+        // scaleFactor = 1e48 (36 + 18 - 6)
+        // price = 2e18 * 1e48 / 1e18 = 2e48
+        assertEq(
+            IMorphoOracle(newOracle).price(),
+            2e48,
+            "Price should use current collateral asset decimals after metadata change"
+        );
+    }
+
     // when cache decimals are changed
     //  [X] it calculates price correctly
 

--- a/src/test/policies/price/MorphoOracleCloneable/price.t.sol
+++ b/src/test/policies/price/MorphoOracleCloneable/price.t.sol
@@ -404,6 +404,11 @@ contract MorphoOracleCloneablePriceTest is MorphoOracleCloneableTest {
         // collateral = 18 decimals, loan = 18 decimals
         // scaleFactor = 1e36 (36 + 18 - 18)
         // price = 2e18 * 1e36 / 1e18 = 2e36
+        assertEq(
+            IMorphoOracle(newOracle).scaleFactor(),
+            1e36,
+            "Initial scale factor should use 18 decimals"
+        );
         assertEq(IMorphoOracle(newOracle).price(), 2e36, "Initial price should use 18 decimals");
 
         _setNonContractAssetMetadata(nonContractLoan, 6, "NCA");
@@ -412,6 +417,11 @@ contract MorphoOracleCloneablePriceTest is MorphoOracleCloneableTest {
         // collateral = 18 decimals, loan = 6 decimals
         // scaleFactor = 1e24 (36 + 6 - 18)
         // price = 2e18 * 1e24 / 1e18 = 2e24
+        assertEq(
+            IMorphoOracle(newOracle).scaleFactor(),
+            1e24,
+            "Scale factor should use current loan decimals"
+        );
         assertEq(
             IMorphoOracle(newOracle).price(),
             2e24,
@@ -436,6 +446,11 @@ contract MorphoOracleCloneablePriceTest is MorphoOracleCloneableTest {
         // collateral = 18 decimals, loan = 18 decimals
         // scaleFactor = 1e36 (36 + 18 - 18)
         // price = 2e18 * 1e36 / 1e18 = 2e36
+        assertEq(
+            IMorphoOracle(newOracle).scaleFactor(),
+            1e36,
+            "Initial scale factor should use 18 decimals"
+        );
         assertEq(IMorphoOracle(newOracle).price(), 2e36, "Initial price should use 18 decimals");
 
         _setNonContractAssetMetadata(nonContractCollateral, 6, "NCA");
@@ -445,10 +460,77 @@ contract MorphoOracleCloneablePriceTest is MorphoOracleCloneableTest {
         // scaleFactor = 1e48 (36 + 18 - 6)
         // price = 2e18 * 1e48 / 1e18 = 2e48
         assertEq(
+            IMorphoOracle(newOracle).scaleFactor(),
+            1e48,
+            "Scale factor should use current collateral decimals"
+        );
+        assertEq(
             IMorphoOracle(newOracle).price(),
             2e48,
             "Price should use current collateral asset decimals after metadata change"
         );
+    }
+
+    function test_givenLoanNonContractAssetDecimalsChangeBeyondMax_whenScaleFactorIsRead_reverts()
+        public
+    {
+        address nonContractLoan = registeredNonContractAsset;
+
+        _setNonContractAssetMetadata(nonContractLoan, 18, "NCA");
+        _setCachePrice(nonContractLoan, 1e18);
+
+        address newOracle = _createOracle(
+            address(collateralToken),
+            nonContractLoan,
+            DEFAULT_MAX_AGE
+        );
+
+        _setNonContractAssetMetadata(nonContractLoan, 60, "NCA");
+        priceCache.cachePrice(address(collateralToken), nonContractLoan);
+
+        // collateral = 18 decimals, loan = 60 decimals
+        // exponent = 36 + 60 - 18 = 78 > 77
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IMorphoOracle.MorphoOracle_TokenDecimalsOutOfBounds.selector,
+                address(collateralToken),
+                nonContractLoan,
+                18,
+                60
+            )
+        );
+        IMorphoOracle(newOracle).scaleFactor();
+    }
+
+    function test_givenCollateralNonContractAssetDecimalsChangeBeyondLoan_whenScaleFactorIsRead_reverts()
+        public
+    {
+        address nonContractCollateral = registeredNonContractAsset;
+
+        _setNonContractAssetMetadata(nonContractCollateral, 18, "NCA");
+        _setCachePrice(nonContractCollateral, 2e18);
+
+        address newOracle = _createOracle(
+            nonContractCollateral,
+            address(loanToken),
+            DEFAULT_MAX_AGE
+        );
+
+        _setNonContractAssetMetadata(nonContractCollateral, 60, "NCA");
+        priceCache.cachePrice(nonContractCollateral, address(loanToken));
+
+        // collateral = 60 decimals, loan = 18 decimals
+        // exponent = 36 + 18 - 60 = -6
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IMorphoOracle.MorphoOracle_TokenDecimalsOutOfBounds.selector,
+                nonContractCollateral,
+                address(loanToken),
+                60,
+                18
+            )
+        );
+        IMorphoOracle(newOracle).scaleFactor();
     }
 
     // when cache decimals are changed
@@ -473,10 +555,10 @@ contract MorphoOracleCloneablePriceTest is MorphoOracleCloneableTest {
         _setCachePrice(address(loanToken), 1e9);
 
         // Oracle should still return correct price
-        // The scaleFactor is immutable and based on token decimals (36 + 18 - 18 = 36)
+        // The scaleFactor is based on token decimals (36 + 18 - 18 = 36)
         // collateralPriceUsd = 2e9 (2 USD, 9 decimals)
         // loanPriceUsd = 1e9 (1 USD, 9 decimals)
-        // scaleFactor = 1e36 (unchanged, based on token decimals)
+        // scaleFactor = 1e36 (based on token decimals)
         // Price calculation: 1e36 * 2e9 / 1e9 = 2e36
         // The result is still 2e36 because the ratio is preserved
         uint256 newPrice = oracle.price();
@@ -548,10 +630,10 @@ contract MorphoOracleCloneablePriceTest is MorphoOracleCloneableTest {
         _setCachePrice(address(loanToken), 1e9);
 
         // Oracle should still return correct price
-        // The scaleFactor is immutable and based on token decimals (36 + 18 - 9 = 45)
+        // The scaleFactor is based on token decimals (36 + 18 - 9 = 45)
         // collateralPriceUsd = 2e9 (2 USD, 9 decimals)
         // loanPriceUsd = 1e9 (1 USD, 9 decimals)
-        // scaleFactor = 1e45 (unchanged, based on token decimals)
+        // scaleFactor = 1e45 (based on token decimals)
         // Price calculation: 1e45 * 2e9 / 1e9 = 2e45
         // The result is still 2e45 because the ratio is preserved
         uint256 newPrice = IMorphoOracle(newOracle).price();
@@ -623,10 +705,10 @@ contract MorphoOracleCloneablePriceTest is MorphoOracleCloneableTest {
         _setCachePrice(address(newLoanToken), 1e9);
 
         // Oracle should still return correct price
-        // The scaleFactor is immutable and based on token decimals (36 + 9 - 18 = 27)
+        // The scaleFactor is based on token decimals (36 + 9 - 18 = 27)
         // collateralPriceUsd = 2e9 (2 USD, 9 decimals)
         // loanPriceUsd = 1e9 (1 USD, 9 decimals)
-        // scaleFactor = 1e27 (unchanged, based on token decimals)
+        // scaleFactor = 1e27 (based on token decimals)
         // Price calculation: 1e27 * 2e9 / 1e9 = 2e27
         // The result is still 2e27 because the ratio is preserved
         uint256 newPrice = IMorphoOracle(newOracle).price();


### PR DESCRIPTION
## Summary

- Recalculate the Morpho oracle scale factor from the active `PriceCache.assetDecimals()` values instead of storing it in clone immutable args.
- Remove the unused immutable scale-factor arg from the Morpho clone layout while retaining creation-time decimal bounds validation.
- Add runtime out-of-bounds handling for NCA decimal metadata changes and cover both loan-side and collateral-side decimal changes in tests.
- Document that non-contract asset decimals are PriceCache metadata and should be confirmed through `PriceCache.assetDecimals()`.

## Validation

- `forge test -vvv --match-path src/test/policies/price/**/*.t.sol`
- `forge test -vvv --match-path src/test/modules/PRICE*.t.sol --no-match-contract .*Fork.*`
- `forge test -vvv --match-contract MorphoOracleCloneablePriceTest`
- `forge test -vvv --match-contract MorphoOracleFactoryCreateOracleTest`
- `forge test -vvv --match-contract MorphoOracleCloneableImmutableArgsTest`
- `forge build --contracts src/policies/price/MorphoOracleCloneable.sol`
- `forge build --contracts src/policies/price/MorphoOracleFactory.sol`

The PRICE fork test was not run because `ALCHEMY_API_KEY` is not set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Oracles now dynamically compute pricing factors from current PriceCache metadata instead of static token decimals for non-contract assets.
  * Added validation to detect and report invalid decimal configurations.

* **Documentation**
  * Clarified that non-contract asset decimals are sourced from PriceCache metadata.
  * Documented how PriceCache metadata updates affect oracle price calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->