### PR TITLE
Price Feed Resilience: Validate moving average strategy paths

### DIFF
--- a/snapshots/PriceV2GasTest.json
+++ b/snapshots/PriceV2GasTest.json
@@ -1,6 +1,6 @@
 {
-    "OlympusPricev2.getPrice.current": "58227",
+    "OlympusPricev2.getPrice.current": "58464",
     "OlympusPricev2.getPrice.last": "2688",
     "OlympusPricev2.getPriceIn.last": "5208",
-    "OlympusPricev2.storeObservation": "84894"
+    "OlympusPricev2.storeObservation": "109486"
 }

--- a/src/modules/PRICE/OlympusPrice.v2.sol
+++ b/src/modules/PRICE/OlympusPrice.v2.sol
@@ -256,13 +256,18 @@ contract OlympusPricev2 is PRICEv2, IVersioned {
 
     /// @notice             Aggregates an array of prices using the configured strategy
     ///
-    /// @param asset_       The address of the asset
-    /// @param prices_      Array of prices to aggregate
-    /// @return uint256     The aggregated price
-    function _aggregate(address asset_, uint256[] memory prices_) internal view returns (uint256) {
+    /// @param asset_           The address of the asset
+    /// @param prices_          Array of prices to aggregate
+    /// @param forceStrategy_   If true, validate through the strategy even with one price
+    /// @return uint256         The aggregated price
+    function _aggregate(
+        address asset_,
+        uint256[] memory prices_,
+        bool forceStrategy_
+    ) internal view returns (uint256) {
         // If there is only one price, ensure it is not zero and return
         // Otherwise, send to strategy to aggregate
-        if (prices_.length == 1) {
+        if (prices_.length == 1 && !forceStrategy_) {
             if (prices_[0] == 0) revert PRICE_PriceZero(asset_);
             return prices_[0];
         }
@@ -281,17 +286,15 @@ contract OlympusPricev2 is PRICEv2, IVersioned {
         return price;
     }
 
-    /// @notice             Appends the moving average to an array of prices
-    /// @dev                Assumes that the asset stores and uses the moving average
+    /// @notice             Appends a moving average value to an array of prices
     ///
-    /// @param asset_       Asset to get the moving average of
     /// @param prices_      Array of prices to append to
+    /// @param movingAverage_ Moving average value to append
     /// @return uint256[]   The array of prices including the moving average
     function _getInclusivePrices(
-        address asset_,
-        uint256[] memory prices_
-    ) internal view returns (uint256[] memory) {
-        Asset storage asset = _assetData[asset_];
+        uint256[] memory prices_,
+        uint256 movingAverage_
+    ) internal pure returns (uint256[] memory) {
         uint256 numFeeds = prices_.length;
         uint256[] memory inclusivePrices = new uint256[](numFeeds + 1);
         for (uint256 i; i < numFeeds; ) {
@@ -300,8 +303,28 @@ contract OlympusPricev2 is PRICEv2, IVersioned {
                 ++i;
             }
         }
-        inclusivePrices[numFeeds] = asset.cumulativeObs / asset.numObservations;
+        inclusivePrices[numFeeds] = movingAverage_;
         return inclusivePrices;
+    }
+
+    /// @notice             Validates both runtime input shapes for a moving-average strategy
+    /// @dev                The stored observation path must aggregate raw feed values only. The
+    ///                     CURRENT path must aggregate raw feed values plus a moving average. This
+    ///                     uses the raw observation value as a synthetic moving average to avoid
+    ///                     rejecting updates solely because the stored moving average is stale.
+    ///
+    /// @param asset_       Asset to validate
+    /// @return bool        Flag indicating if all feeds were successful
+    function _validateMovingAverageStrategy(address asset_) internal view returns (bool) {
+        (uint256[] memory prices, bool successAllFeeds) = _getFeedPrices(asset_);
+        if (!successAllFeeds) return false;
+
+        uint256 obsPrice = _aggregate(asset_, prices, false);
+
+        _aggregate(asset_, _getInclusivePrices(prices, obsPrice), true);
+        _aggregate(asset_, prices, true);
+
+        return successAllFeeds;
     }
 
     /// @notice                         Gets the current price of the asset
@@ -332,10 +355,10 @@ contract OlympusPricev2 is PRICEv2, IVersioned {
         if (asset.useMovingAverage && includeMovingAverage_) {
             _revertIfMovingAverageStale(asset_, asset.lastObservationTime);
 
-            prices = _getInclusivePrices(asset_, prices);
+            prices = _getInclusivePrices(prices, asset.cumulativeObs / asset.numObservations);
         }
 
-        return (_aggregate(asset_, prices), uint48(block.timestamp), successAllFeeds);
+        return (_aggregate(asset_, prices, false), uint48(block.timestamp), successAllFeeds);
     }
 
     /// @notice                     Reverts if the moving average observation is stale
@@ -531,7 +554,8 @@ contract OlympusPricev2 is PRICEv2, IVersioned {
     /// @dev        - Sets the price strategy using `_updateAssetPriceStrategy()`
     /// @dev        - Sets the price feeds using `_updateAssetPriceFeeds()`
     /// @dev        - Sets the moving average data using `_updateAssetMovingAverage()`
-    /// @dev        - Validates the configuration using `_getCurrentPrice()`, which will revert if there is a mis-configuration
+    /// @dev        - Validates the configuration using `_getCurrentPrice()` or, when using a moving average,
+    /// @dev          both the raw observation and MA-inclusive CURRENT strategy input shapes
     /// @dev        - Adds the asset to the `assets` array and marks it as approved
     ///
     /// @dev        Will revert if:
@@ -586,8 +610,15 @@ contract OlympusPricev2 is PRICEv2, IVersioned {
             observations_
         );
 
-        // Validate configuration
-        (, , bool successAllFeeds) = _getCurrentPrice(asset_, true);
+        // Validate configuration. Observation writes never include the moving average, so a
+        // moving-average strategy must support raw feeds and raw feeds plus a synthetic MA value.
+        bool successAllFeeds;
+        if (useMovingAverage_) {
+            _revertIfMovingAverageStale(asset_, asset.lastObservationTime);
+            successAllFeeds = _validateMovingAverageStrategy(asset_);
+        } else {
+            (, , successAllFeeds) = _getCurrentPrice(asset_, true);
+        }
         if (!successAllFeeds) revert PRICE_PriceFeedCallFailed(asset_);
 
         // Set asset as approved and add to array
@@ -826,7 +857,8 @@ contract OlympusPricev2 is PRICEv2, IVersioned {
     /// @dev        - Validates the final configuration atomically
     /// @dev        - Validates submodules are installed for updated components
     /// @dev        - Calls update functions for flagged updates
-    /// @dev        - Validates final configuration with `_getCurrentPrice()`
+    /// @dev        - Validates final configuration with `_getCurrentPrice()` or, when using a moving average,
+    /// @dev          both the raw observation and MA-inclusive CURRENT strategy input shapes
     /// @dev        - Emits events based on which updates occurred
     ///
     /// @dev        Will revert if:
@@ -897,8 +929,15 @@ contract OlympusPricev2 is PRICEv2, IVersioned {
         }
 
         // Validate final configuration atomically.
-        // Skip MA inclusion so stale heartbeat does not block governance reconfiguration.
-        (, , bool successAllFeeds) = _getCurrentPrice(asset_, false);
+        // Observation writes never include the moving average, so a moving-average strategy must
+        // support raw feeds and raw feeds plus a synthetic MA value. Use the synthetic value here
+        // so a stale stored MA does not block governance reconfiguration.
+        bool successAllFeeds;
+        if (asset.useMovingAverage) {
+            successAllFeeds = _validateMovingAverageStrategy(asset_);
+        } else {
+            (, , successAllFeeds) = _getCurrentPrice(asset_, false);
+        }
         if (!successAllFeeds) revert PRICE_PriceFeedCallFailed(asset_);
 
         // Emit events (based on which updates occurred)

--- a/src/modules/PRICE/OlympusPrice.v2.sol
+++ b/src/modules/PRICE/OlympusPrice.v2.sol
@@ -256,24 +256,20 @@ contract OlympusPricev2 is PRICEv2, IVersioned {
 
     /// @notice             Aggregates an array of prices using the configured strategy
     ///
-    /// @param asset_           The address of the asset
-    /// @param prices_          Array of prices to aggregate
-    /// @param forceStrategy_   If true, validate through the strategy even with one price
-    /// @return uint256         The aggregated price
-    function _aggregate(
-        address asset_,
-        uint256[] memory prices_,
-        bool forceStrategy_
-    ) internal view returns (uint256) {
-        // If there is only one price, ensure it is not zero and return
-        // Otherwise, send to strategy to aggregate
-        if (prices_.length == 1 && !forceStrategy_) {
+    /// @param asset_       The address of the asset
+    /// @param prices_      Array of prices to aggregate
+    /// @return uint256     The aggregated price
+    function _aggregate(address asset_, uint256[] memory prices_) internal view returns (uint256) {
+        Asset storage asset = _assetData[asset_];
+
+        // Single-feed assets without MA do not need a strategy. Early exit.
+        if (prices_.length == 1 && !asset.useMovingAverage) {
             if (prices_[0] == 0) revert PRICE_PriceZero(asset_);
             return prices_[0];
         }
 
-        // Get price from strategy
-        Component memory strategy = abi.decode(_assetData[asset_].strategy, (Component));
+        // Calculate the aggregated result using the strategy
+        Component memory strategy = abi.decode(asset.strategy, (Component));
         (bool success, bytes memory data) = address(_getSubmoduleIfInstalled(strategy.target))
             .staticcall(abi.encodeWithSelector(strategy.selector, prices_, strategy.params));
 
@@ -313,16 +309,22 @@ contract OlympusPricev2 is PRICEv2, IVersioned {
     ///                     uses the raw observation value as a synthetic moving average to avoid
     ///                     rejecting updates solely because the stored moving average is stale.
     ///
+    ///                     Assumes that the asset has useMovingAverage set to true.
+    ///
     /// @param asset_       Asset to validate
     /// @return bool        Flag indicating if all feeds were successful
     function _validateMovingAverageStrategy(address asset_) internal view returns (bool) {
         (uint256[] memory prices, bool successAllFeeds) = _getFeedPrices(asset_);
         if (!successAllFeeds) return false;
 
-        uint256 obsPrice = _aggregate(asset_, prices, false);
+        // First aggregate the raw prices into an observation
+        // This mimics what is performed by storeObservation()
+        // It will also validate the strategy
+        uint256 obsPrice = _aggregate(asset_, prices);
 
-        _aggregate(asset_, _getInclusivePrices(prices, obsPrice), true);
-        _aggregate(asset_, prices, true);
+        // Then attempt to aggregate the raw prices and the observation
+        // This is what would happen normally when calling getPrice() with Variant.CURRENT
+        _aggregate(asset_, _getInclusivePrices(prices, obsPrice));
 
         return successAllFeeds;
     }
@@ -358,7 +360,7 @@ contract OlympusPricev2 is PRICEv2, IVersioned {
             prices = _getInclusivePrices(prices, asset.cumulativeObs / asset.numObservations);
         }
 
-        return (_aggregate(asset_, prices, false), uint48(block.timestamp), successAllFeeds);
+        return (_aggregate(asset_, prices), uint48(block.timestamp), successAllFeeds);
     }
 
     /// @notice                     Reverts if the moving average observation is stale

--- a/src/test/modules/PRICE.v2/PRICE.v2.t.sol
+++ b/src/test/modules/PRICE.v2/PRICE.v2.t.sol
@@ -3378,7 +3378,7 @@ contract PriceV2Test is PriceV2BaseTest {
         vm.stopPrank();
     }
 
-    function test_addAsset_withMedianStrategy_singleFeed_useMovingAverage_revertsWhenCurrentPathHasTooFewValues()
+    function test_addAsset_withMedianStrategy_singleFeed_useMovingAverage_revertsWhenRawFeedObservationPathHasTooFewValues()
         public
     {
         ChainlinkPriceFeeds.OneFeedParams memory onemaFeedParams = ChainlinkPriceFeeds
@@ -3408,7 +3408,7 @@ contract PriceV2Test is PriceV2BaseTest {
                 address(weth),
                 abi.encodeWithSelector(
                     ISimplePriceFeedStrategy.SimpleStrategy_PriceCountInvalid.selector,
-                    2,
+                    1,
                     3
                 )
             )

--- a/src/test/modules/PRICE.v2/PRICE.v2.t.sol
+++ b/src/test/modules/PRICE.v2/PRICE.v2.t.sol
@@ -97,7 +97,7 @@ import {UniswapV3Price} from "modules/PRICE/submodules/feeds/UniswapV3Price.sol"
 //      [X] asset added to assets array
 //      [X] asset added with no strategy, moving average disabled, single feed
 //      [X] asset added with strategy, moving average enabled, single feed
-//      [X] asset added with strategy, moving average enabled, mutiple feeds
+//      [X] asset added with strategy, moving average enabled, multiple feeds
 //      [X] reverts if moving average contains any zero observations
 //      [X] if not storing moving average and no cached value provided, dynamically calculates cache and stores so no zero cache values are stored
 // [X] removeAsset
@@ -3236,10 +3236,81 @@ contract PriceV2Test is PriceV2BaseTest {
         assertEq(asset.feeds, abi.encode(feeds), "feeds");
     }
 
-    function test_addAsset_withMedianStrategy_twoFeeds_movingAverage(uint256 nonce_) public {
-        // Test that 2 feeds + moving average + getMedian works correctly
-        // getMedian requires 3 inputs: 2 feeds + 1 moving average
-        // This verifies that the validation in addAsset() includes the moving average
+    function test_addAsset_withAverageStrategy_twoFeeds_movingAverage(uint256 nonce_) public {
+        // Test that 2 feeds + moving average works when the strategy supports both:
+        // - CURRENT with 2 feeds + 1 moving average
+        // - storeObservation with the 2 raw feed prices
+        ChainlinkPriceFeeds.OneFeedParams memory ohmFeedOneParams = ChainlinkPriceFeeds
+            .OneFeedParams(ohmUsdPriceFeed, uint48(24 hours));
+
+        ChainlinkPriceFeeds.TwoFeedParams memory ohmFeedTwoParams = ChainlinkPriceFeeds
+            .TwoFeedParams(ohmEthPriceFeed, uint48(24 hours), ethUsdPriceFeed, uint48(24 hours));
+
+        IPRICEv2.Component[] memory feeds = new IPRICEv2.Component[](2);
+        feeds[0] = IPRICEv2.Component(
+            toSubKeycode("PRICE.CHAINLINK"),
+            ChainlinkPriceFeeds.getOneFeedPrice.selector,
+            abi.encode(ohmFeedOneParams)
+        );
+        feeds[1] = IPRICEv2.Component(
+            toSubKeycode("PRICE.CHAINLINK"),
+            ChainlinkPriceFeeds.getTwoFeedPriceMul.selector,
+            abi.encode(ohmFeedTwoParams)
+        );
+
+        IPRICEv2.Component memory averageStrategy = IPRICEv2.Component(
+            toSubKeycode("PRICE.SIMPLESTRATEGY"),
+            ISimplePriceFeedStrategy.getAveragePrice.selector,
+            abi.encode(true)
+        );
+
+        uint256[] memory observations = _makeRandomObservations(weth, feeds[0], nonce_, uint256(2));
+
+        vm.startPrank(priceWriter);
+
+        // Expect an event to be emitted
+        vm.expectEmit(true, false, false, true);
+        emit AssetAdded(address(weth));
+
+        price.addAsset(
+            address(weth),
+            true, // storeMovingAverage
+            true, // useMovingAverage
+            uint32(16 hours),
+            uint48(block.timestamp),
+            observations,
+            averageStrategy,
+            feeds
+        );
+
+        // Verify the asset was added correctly
+        IPRICEv2.Asset memory asset = price.getAssetData(address(weth));
+        assertEq(asset.approved, true);
+        assertEq(asset.storeMovingAverage, true);
+        assertEq(asset.useMovingAverage, true);
+
+        // Feed1 = 10e18 and Feed2 = 10e18 (18 decimals).
+        // movingAverage = (observations[0] + observations[1]) / 2 (18 decimals).
+        // Expected CURRENT = (feed1 + feed2 + movingAverage) / 3 (18 decimals).
+        uint256 movingAverage = (observations[0] + observations[1]) / 2;
+        uint256 expectedPrice = (10e18 + 10e18 + movingAverage) / 3;
+        (uint256 price_, ) = price.getPrice(address(weth), IPRICEv2.Variant.CURRENT);
+        assertEq(price_, expectedPrice, "CURRENT should average feeds and moving average");
+
+        vm.warp(block.timestamp + 1);
+        price.storeObservation(address(weth));
+
+        (uint256 lastPrice, ) = price.getPrice(address(weth), IPRICEv2.Variant.LAST);
+        assertEq(lastPrice, 10e18, "LAST should update from the raw feed prices");
+
+        vm.stopPrank();
+    }
+
+    function test_addAsset_withMedianStrategy_twoFeeds_movingAverage_observationPath_reverts()
+        public
+    {
+        // getMedian requires at least 3 inputs. CURRENT has 2 feeds + MA, but
+        // storeObservation excludes MA and would only provide the 2 raw feed prices.
         ChainlinkPriceFeeds.OneFeedParams memory ohmFeedOneParams = ChainlinkPriceFeeds
             .OneFeedParams(ohmUsdPriceFeed, uint48(24 hours));
 
@@ -3261,17 +3332,25 @@ contract PriceV2Test is PriceV2BaseTest {
         IPRICEv2.Component memory medianStrategy = IPRICEv2.Component(
             toSubKeycode("PRICE.SIMPLESTRATEGY"),
             ISimplePriceFeedStrategy.getMedianPrice.selector,
-            abi.encode(0)
+            abi.encode(false)
         );
 
-        uint256[] memory observations = _makeRandomObservations(weth, feeds[0], nonce_, uint256(2));
+        uint256[] memory observations = new uint256[](2);
+        observations[0] = 10e18;
+        observations[1] = 10e18;
 
         vm.startPrank(priceWriter);
-
-        // Expect an event to be emitted
-        vm.expectEmit(true, false, false, true);
-        emit AssetAdded(address(weth));
-
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPRICEv2.PRICE_StrategyFailed.selector,
+                address(weth),
+                abi.encodeWithSelector(
+                    ISimplePriceFeedStrategy.SimpleStrategy_PriceCountInvalid.selector,
+                    2,
+                    3
+                )
+            )
+        );
         price.addAsset(
             address(weth),
             true, // storeMovingAverage
@@ -3283,18 +3362,67 @@ contract PriceV2Test is PriceV2BaseTest {
             feeds
         );
 
-        // Verify the asset was added correctly
-        IPRICEv2.Asset memory asset = price.getAssetData(address(weth));
-        assertEq(asset.approved, true);
-        assertEq(asset.storeMovingAverage, true);
-        assertEq(asset.useMovingAverage, true);
+        vm.stopPrank();
+    }
 
-        // Feed1 = 10e18 and Feed2 = 10e18.
-        // MA = (obs[0] + obs[1]) / 2 = (10.512e18 + 10e18) / 2 = 10.256e18.
-        // Median strategy sorts [10e18, 10e18, 10.256e18] and selects middle => 10e18.
-        uint256 expectedPrice = 10e18;
-        (uint256 price_, ) = price.getPrice(address(weth), IPRICEv2.Variant.LAST);
-        assertEq(price_, expectedPrice, "Cached price should equal median of feeds and MA");
+    function test_addAsset_withMedianStrategy_threeFeeds_movingAverage() public {
+        ChainlinkPriceFeeds.OneFeedParams memory reserveFeedParams = ChainlinkPriceFeeds
+            .OneFeedParams(reserveUsdPriceFeed, uint48(24 hours));
+        ChainlinkPriceFeeds.OneFeedParams memory ohmFeedOneParams = ChainlinkPriceFeeds
+            .OneFeedParams(ohmUsdPriceFeed, uint48(24 hours));
+        ChainlinkPriceFeeds.TwoFeedParams memory ohmFeedTwoParams = ChainlinkPriceFeeds
+            .TwoFeedParams(ohmEthPriceFeed, uint48(24 hours), ethUsdPriceFeed, uint48(24 hours));
+
+        IPRICEv2.Component[] memory feeds = new IPRICEv2.Component[](3);
+        feeds[0] = IPRICEv2.Component(
+            toSubKeycode("PRICE.CHAINLINK"),
+            ChainlinkPriceFeeds.getOneFeedPrice.selector,
+            abi.encode(reserveFeedParams)
+        );
+        feeds[1] = IPRICEv2.Component(
+            toSubKeycode("PRICE.CHAINLINK"),
+            ChainlinkPriceFeeds.getOneFeedPrice.selector,
+            abi.encode(ohmFeedOneParams)
+        );
+        feeds[2] = IPRICEv2.Component(
+            toSubKeycode("PRICE.CHAINLINK"),
+            ChainlinkPriceFeeds.getTwoFeedPriceMul.selector,
+            abi.encode(ohmFeedTwoParams)
+        );
+
+        IPRICEv2.Component memory medianStrategy = IPRICEv2.Component(
+            toSubKeycode("PRICE.SIMPLESTRATEGY"),
+            ISimplePriceFeedStrategy.getMedianPrice.selector,
+            abi.encode(true)
+        );
+
+        uint256[] memory observations = new uint256[](2);
+        observations[0] = 10e18;
+        observations[1] = 10e18;
+
+        vm.startPrank(priceWriter);
+        price.addAsset(
+            address(weth),
+            true, // storeMovingAverage
+            true, // useMovingAverage
+            uint32(16 hours),
+            uint48(block.timestamp),
+            observations,
+            medianStrategy,
+            feeds
+        );
+
+        // Raw feeds are 1e18, 10e18, 10e18. MA is 10e18.
+        // CURRENT median over [1e18, 10e18, 10e18, 10e18] = 10e18.
+        (uint256 currentPrice, ) = price.getPrice(address(weth), IPRICEv2.Variant.CURRENT);
+        assertEq(currentPrice, 10e18, "CURRENT should median feeds and moving average");
+
+        vm.warp(block.timestamp + 1);
+        price.storeObservation(address(weth));
+
+        // Observation median over raw feeds [1e18, 10e18, 10e18] = 10e18.
+        (uint256 lastPrice, ) = price.getPrice(address(weth), IPRICEv2.Variant.LAST);
+        assertEq(lastPrice, 10e18, "LAST should update from the raw feed median");
 
         vm.stopPrank();
     }
@@ -3443,6 +3571,13 @@ contract PriceV2Test is PriceV2BaseTest {
         uint256 expectedPrice = observations[1];
         (uint256 lastPrice, ) = price.getPrice(address(weth), IPRICEv2.Variant.LAST);
         assertEq(lastPrice, expectedPrice, "LAST should equal latest stored observation");
+
+        vm.warp(block.timestamp + 1);
+        vm.prank(priceWriter);
+        price.storeObservation(address(weth));
+
+        (uint256 updatedLastPrice, ) = price.getPrice(address(weth), IPRICEv2.Variant.LAST);
+        assertEq(updatedLastPrice, 10e18, "LAST should update from the raw feed price");
     }
 
     function testRevert_addAsset_invalidPriceFeed() public {
@@ -3646,6 +3781,13 @@ contract PriceV2Test is PriceV2BaseTest {
 
         (uint256 cachedPrice, ) = price.getPrice(address(onema), IPRICEv2.Variant.LAST);
         assertEq(cachedPrice, 5e18, "LAST should equal latest stored observation");
+
+        vm.warp(block.timestamp + 1);
+        vm.prank(priceWriter);
+        price.storeObservation(address(onema));
+
+        (uint256 updatedCachedPrice, ) = price.getPrice(address(onema), IPRICEv2.Variant.LAST);
+        assertEq(updatedCachedPrice, 10e18, "LAST should update from the raw feed price");
     }
 
     // Note: Tests for updateAsset are in updateAsset.t.sol

--- a/src/test/modules/PRICE.v2/PRICE.v2.t.sol
+++ b/src/test/modules/PRICE.v2/PRICE.v2.t.sol
@@ -3365,6 +3365,53 @@ contract PriceV2Test is PriceV2BaseTest {
         vm.stopPrank();
     }
 
+    function test_addAsset_withMedianStrategy_singleFeed_movingAverage_reverts() public {
+        ChainlinkPriceFeeds.OneFeedParams memory onemaFeedParams = ChainlinkPriceFeeds
+            .OneFeedParams(onemaUsdPriceFeed, uint48(24 hours));
+
+        IPRICEv2.Component[] memory feeds = new IPRICEv2.Component[](1);
+        feeds[0] = IPRICEv2.Component(
+            toSubKeycode("PRICE.CHAINLINK"),
+            ChainlinkPriceFeeds.getOneFeedPrice.selector,
+            abi.encode(onemaFeedParams)
+        );
+
+        IPRICEv2.Component memory medianStrategy = IPRICEv2.Component(
+            toSubKeycode("PRICE.SIMPLESTRATEGY"),
+            ISimplePriceFeedStrategy.getMedianPrice.selector,
+            abi.encode(false)
+        );
+
+        uint256[] memory observations = new uint256[](2);
+        observations[0] = 5e18;
+        observations[1] = 5e18;
+
+        vm.startPrank(priceWriter);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPRICEv2.PRICE_StrategyFailed.selector,
+                address(weth),
+                abi.encodeWithSelector(
+                    ISimplePriceFeedStrategy.SimpleStrategy_PriceCountInvalid.selector,
+                    2,
+                    3
+                )
+            )
+        );
+        price.addAsset(
+            address(weth),
+            true, // storeMovingAverage
+            true, // useMovingAverage
+            uint32(16 hours),
+            uint48(block.timestamp),
+            observations,
+            medianStrategy,
+            feeds
+        );
+
+        vm.stopPrank();
+    }
+
     function test_addAsset_withMedianStrategy_threeFeeds_movingAverage() public {
         ChainlinkPriceFeeds.OneFeedParams memory reserveFeedParams = ChainlinkPriceFeeds
             .OneFeedParams(reserveUsdPriceFeed, uint48(24 hours));
@@ -3578,6 +3625,53 @@ contract PriceV2Test is PriceV2BaseTest {
 
         (uint256 updatedLastPrice, ) = price.getPrice(address(weth), IPRICEv2.Variant.LAST);
         assertEq(updatedLastPrice, 10e18, "LAST should update from the raw feed price");
+    }
+
+    function test_addAsset_withAverageStrategyStrict_singleFeed_movingAverage_reverts() public {
+        ChainlinkPriceFeeds.OneFeedParams memory ohmFeedOneParams = ChainlinkPriceFeeds
+            .OneFeedParams(ohmUsdPriceFeed, uint48(24 hours));
+
+        IPRICEv2.Component[] memory feeds = new IPRICEv2.Component[](1);
+        feeds[0] = IPRICEv2.Component(
+            toSubKeycode("PRICE.CHAINLINK"),
+            ChainlinkPriceFeeds.getOneFeedPrice.selector,
+            abi.encode(ohmFeedOneParams)
+        );
+
+        IPRICEv2.Component memory averageStrategy = IPRICEv2.Component(
+            toSubKeycode("PRICE.SIMPLESTRATEGY"),
+            ISimplePriceFeedStrategy.getAveragePrice.selector,
+            abi.encode(true)
+        );
+
+        uint256[] memory observations = new uint256[](2);
+        observations[0] = 10e18;
+        observations[1] = 10e18;
+
+        vm.startPrank(priceWriter);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPRICEv2.PRICE_StrategyFailed.selector,
+                address(weth),
+                abi.encodeWithSelector(
+                    ISimplePriceFeedStrategy.SimpleStrategy_PriceCountInvalid.selector,
+                    1,
+                    2
+                )
+            )
+        );
+        price.addAsset(
+            address(weth),
+            true, // storeMovingAverage
+            true, // useMovingAverage
+            uint32(16 hours),
+            uint48(block.timestamp),
+            observations,
+            averageStrategy,
+            feeds
+        );
+
+        vm.stopPrank();
     }
 
     function testRevert_addAsset_invalidPriceFeed() public {

--- a/src/test/modules/PRICE.v2/PRICE.v2.t.sol
+++ b/src/test/modules/PRICE.v2/PRICE.v2.t.sol
@@ -1929,14 +1929,16 @@ contract PriceV2Test is PriceV2BaseTest {
         price.storeObservation(address(onema));
     }
 
-    function test_storeObservation_includesMovingAverage() public {
+    function test_storeObservation_withFirstNonZeroStrategy_singleFeed_useMovingAverage_excludesMovingAverageFromStoredObservation()
+        public
+    {
         // Initial observations that return the same value as the Chainlink price feeds
         uint256[] memory observations = new uint256[](2);
         observations[0] = 5e18;
         observations[1] = 5e18;
 
         // Add an asset that uses the moving average
-        // The strategy is the average price of the single price feed
+        // The strategy supports the single raw-feed observation path
         // 2 observations are stored at any time
         vm.startPrank(priceWriter);
         ChainlinkPriceFeeds.OneFeedParams memory onemaFeedParams = ChainlinkPriceFeeds
@@ -1958,7 +1960,7 @@ contract PriceV2Test is PriceV2BaseTest {
             observations, // uint256[] memory observations_
             IPRICEv2.Component(
                 toSubKeycode("PRICE.SIMPLESTRATEGY"),
-                ISimplePriceFeedStrategy.getAveragePrice.selector,
+                ISimplePriceFeedStrategy.getFirstNonZeroPrice.selector,
                 abi.encode(0) // no params required
             ), // Component memory strategy_
             feeds // Component[] feeds_
@@ -2013,7 +2015,9 @@ contract PriceV2Test is PriceV2BaseTest {
         assertEq(t2_movingAverage, 7.5e18, "t2: moving average did not match");
     }
 
-    function test_storeObservation_twoPriceFeeds_includesMovingAverage() public {
+    function test_storeObservation_withAverageStrategy_twoFeeds_useMovingAverage_excludesMovingAverageFromStoredObservation()
+        public
+    {
         // Initial observations that return the same value as the Chainlink price feeds
         uint256[] memory observations = new uint256[](2);
         observations[0] = 5e18;
@@ -2819,7 +2823,9 @@ contract PriceV2Test is PriceV2BaseTest {
         );
     }
 
-    function test_addAsset_strategy_movingAverage_multiplePriceFeeds(uint256 nonce_) public {
+    function test_addAsset_withAverageStrategy_multipleFeeds_useMovingAverage_addsAssetWithStoredMovingAverage(
+        uint256 nonce_
+    ) public {
         ChainlinkPriceFeeds.OneFeedParams memory ohmFeedOneParams = ChainlinkPriceFeeds
             .OneFeedParams(ohmUsdPriceFeed, uint48(24 hours));
 
@@ -3175,7 +3181,9 @@ contract PriceV2Test is PriceV2BaseTest {
         );
     }
 
-    function test_addAsset_strategy_movingAverage_singlePriceFeed(uint256 nonce_) public {
+    function test_addAsset_withFirstNonZeroStrategy_singleFeed_useMovingAverage_storesMovingAverageAndRawFeedObservation(
+        uint256 nonce_
+    ) public {
         ChainlinkPriceFeeds.OneFeedParams memory ohmFeedOneParams = ChainlinkPriceFeeds
             .OneFeedParams(ohmUsdPriceFeed, uint48(24 hours));
 
@@ -3186,16 +3194,11 @@ contract PriceV2Test is PriceV2BaseTest {
             abi.encode(ohmFeedOneParams) // bytes memory params
         );
 
-        IPRICEv2.Component memory averageStrategy = IPRICEv2.Component(
-            toSubKeycode("PRICE.SIMPLESTRATEGY"),
-            ISimplePriceFeedStrategy.getAveragePrice.selector,
-            abi.encode(0) // no params required
-        );
+        IPRICEv2.Component memory strategy = _simpleStrategyFirstNonZero();
 
         uint256[] memory observations = _makeRandomObservations(weth, feeds[0], nonce_, uint256(2));
         uint256 expectedCumulativeObservations = observations[0] + observations[1];
 
-        // Try and add the asset
         vm.startPrank(priceWriter);
 
         // Expect an event to be emitted
@@ -3209,7 +3212,7 @@ contract PriceV2Test is PriceV2BaseTest {
             uint32(16 hours), // uint32 movingAverageDuration_
             uint48(block.timestamp), // uint48 lastObservationTime_
             observations, // uint256[] memory observations_
-            averageStrategy, // Component memory strategy_
+            strategy, // Component memory strategy_
             feeds //
         );
 
@@ -3232,11 +3235,21 @@ contract PriceV2Test is PriceV2BaseTest {
             expectedCumulativeObservations,
             "weth"
         );
-        assertEq(asset.strategy, abi.encode(averageStrategy), "strategy");
+        assertEq(asset.strategy, abi.encode(strategy), "strategy");
         assertEq(asset.feeds, abi.encode(feeds), "feeds");
+
+        vm.warp(block.timestamp + 1);
+        price.storeObservation(address(weth));
+
+        (uint256 updatedLastPrice, ) = price.getPrice(address(weth), IPRICEv2.Variant.LAST);
+        assertEq(updatedLastPrice, 10e18, "LAST should update from the raw feed price");
+
+        vm.stopPrank();
     }
 
-    function test_addAsset_withAverageStrategy_twoFeeds_movingAverage(uint256 nonce_) public {
+    function test_addAsset_withStrictAverageStrategy_twoFeeds_useMovingAverage_storesMovingAverageAndRawFeedAverageObservation(
+        uint256 nonce_
+    ) public {
         // Test that 2 feeds + moving average works when the strategy supports both:
         // - CURRENT with 2 feeds + 1 moving average
         // - storeObservation with the 2 raw feed prices
@@ -3306,7 +3319,7 @@ contract PriceV2Test is PriceV2BaseTest {
         vm.stopPrank();
     }
 
-    function test_addAsset_withMedianStrategy_twoFeeds_movingAverage_observationPath_reverts()
+    function test_addAsset_withMedianStrategy_twoFeeds_useMovingAverage_revertsWhenRawFeedObservationPathHasTooFewValues()
         public
     {
         // getMedian requires at least 3 inputs. CURRENT has 2 feeds + MA, but
@@ -3365,7 +3378,9 @@ contract PriceV2Test is PriceV2BaseTest {
         vm.stopPrank();
     }
 
-    function test_addAsset_withMedianStrategy_singleFeed_movingAverage_reverts() public {
+    function test_addAsset_withMedianStrategy_singleFeed_useMovingAverage_revertsWhenCurrentPathHasTooFewValues()
+        public
+    {
         ChainlinkPriceFeeds.OneFeedParams memory onemaFeedParams = ChainlinkPriceFeeds
             .OneFeedParams(onemaUsdPriceFeed, uint48(24 hours));
 
@@ -3412,7 +3427,9 @@ contract PriceV2Test is PriceV2BaseTest {
         vm.stopPrank();
     }
 
-    function test_addAsset_withMedianStrategy_threeFeeds_movingAverage() public {
+    function test_addAsset_withMedianStrategy_threeFeeds_useMovingAverage_storesMovingAverageAndRawFeedMedianObservation()
+        public
+    {
         ChainlinkPriceFeeds.OneFeedParams memory reserveFeedParams = ChainlinkPriceFeeds
             .OneFeedParams(reserveUsdPriceFeed, uint48(24 hours));
         ChainlinkPriceFeeds.OneFeedParams memory ohmFeedOneParams = ChainlinkPriceFeeds
@@ -3570,7 +3587,7 @@ contract PriceV2Test is PriceV2BaseTest {
         vm.stopPrank();
     }
 
-    function test_addAsset_withAverageStrategy_withMovingAverage_singlePriceFeed(
+    function test_addAsset_withAverageStrategy_singleFeed_useMovingAverage_revertsWhenRawFeedObservationPathHasTooFewValues(
         uint256 nonce_
     ) public {
         ChainlinkPriceFeeds.OneFeedParams memory ohmFeedOneParams = ChainlinkPriceFeeds
@@ -3591,11 +3608,18 @@ contract PriceV2Test is PriceV2BaseTest {
 
         uint256[] memory observations = _makeRandomObservations(weth, feeds[0], nonce_, uint256(2));
 
-        // Expect an event to be emitted
-        vm.expectEmit(true, false, false, true);
-        emit AssetAdded(address(weth));
-
         vm.startPrank(priceWriter);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPRICEv2.PRICE_StrategyFailed.selector,
+                address(weth),
+                abi.encodeWithSelector(
+                    ISimplePriceFeedStrategy.SimpleStrategy_PriceCountInvalid.selector,
+                    1,
+                    2
+                )
+            )
+        );
         price.addAsset(
             address(weth),
             true, // storeMovingAverage
@@ -3608,26 +3632,11 @@ contract PriceV2Test is PriceV2BaseTest {
         );
 
         vm.stopPrank();
-
-        // Verify the asset was added correctly
-        IPRICEv2.Asset memory asset = price.getAssetData(address(weth));
-        assertEq(asset.approved, true);
-        assertEq(asset.storeMovingAverage, true);
-        assertEq(asset.useMovingAverage, true);
-
-        uint256 expectedPrice = observations[1];
-        (uint256 lastPrice, ) = price.getPrice(address(weth), IPRICEv2.Variant.LAST);
-        assertEq(lastPrice, expectedPrice, "LAST should equal latest stored observation");
-
-        vm.warp(block.timestamp + 1);
-        vm.prank(priceWriter);
-        price.storeObservation(address(weth));
-
-        (uint256 updatedLastPrice, ) = price.getPrice(address(weth), IPRICEv2.Variant.LAST);
-        assertEq(updatedLastPrice, 10e18, "LAST should update from the raw feed price");
     }
 
-    function test_addAsset_withAverageStrategyStrict_singleFeed_movingAverage_reverts() public {
+    function test_addAsset_withStrictAverageStrategy_singleFeed_useMovingAverage_revertsWhenRawFeedObservationPathHasTooFewValues()
+        public
+    {
         ChainlinkPriceFeeds.OneFeedParams memory ohmFeedOneParams = ChainlinkPriceFeeds
             .OneFeedParams(ohmUsdPriceFeed, uint48(24 hours));
 
@@ -3838,7 +3847,9 @@ contract PriceV2Test is PriceV2BaseTest {
         assertEq(cachedPrice, 5e18, "LAST should equal latest stored observation");
     }
 
-    function test_addAsset_useMovingAverageTrue() public {
+    function test_addAsset_withFirstNonZeroStrategy_singleFeed_useMovingAverage_lastUsesStoredObservation()
+        public
+    {
         uint256[] memory observations = new uint256[](2);
         observations[0] = 5e18;
         observations[1] = 5e18;
@@ -3856,11 +3867,6 @@ contract PriceV2Test is PriceV2BaseTest {
 
         onemaUsdPriceFeed.setLatestAnswer(int256(10e8)); // Feed returns 10e18
 
-        // Expected inclusive price:
-        // 1. Initial observations: [5e18, 5e18]. MA = 5e18.
-        // 2. Feed returns: 10e18.
-        // 3. Strategy result: Average(Feed=10e18, MA=5e18) = (10 + 5) / 2 = 7.5e18.
-
         price.addAsset(
             address(onema),
             true, // storeMovingAverage
@@ -3868,7 +3874,7 @@ contract PriceV2Test is PriceV2BaseTest {
             uint32(observations.length) * OBSERVATION_FREQUENCY,
             uint48(block.timestamp),
             observations,
-            _simpleStrategyAverage(),
+            _simpleStrategyFirstNonZero(),
             feeds
         );
         vm.stopPrank();

--- a/src/test/modules/PRICE.v2/PriceV2BaseTest.sol
+++ b/src/test/modules/PRICE.v2/PriceV2BaseTest.sol
@@ -817,6 +817,16 @@ abstract contract PriceV2BaseTest is Test {
             );
     }
 
+    // Helper function to create a strict simple strategy component (average price)
+    function _simpleStrategyAverageStrict() internal pure returns (IPRICEv2.Component memory) {
+        return
+            IPRICEv2.Component(
+                toSubKeycode("PRICE.SIMPLESTRATEGY"),
+                ISimplePriceFeedStrategy.getAveragePrice.selector,
+                abi.encode(true)
+            );
+    }
+
     // Helper function to verify LAST price matches expected value
     function _assertLastPrice(
         address asset,

--- a/src/test/modules/PRICE.v2/updateAsset.t.sol
+++ b/src/test/modules/PRICE.v2/updateAsset.t.sol
@@ -1607,15 +1607,14 @@ contract PriceV2UpdateAssetTest is PriceV2BaseTest {
             observations: new uint256[](0)
         });
 
-        // The raw observation path has one feed and would return directly, but CURRENT
-        // has feed + moving average and must be validated against the median strategy.
+        // The raw observation path has one feed and must be validated against the median strategy.
         vm.expectRevert(
             abi.encodeWithSelector(
                 IPRICEv2.PRICE_StrategyFailed.selector,
                 asset_SingleFeed_NoStrategy_StoreMA,
                 abi.encodeWithSelector(
                     ISimplePriceFeedStrategy.SimpleStrategy_PriceCountInvalid.selector,
-                    2,
+                    1,
                     3
                 )
             )

--- a/src/test/modules/PRICE.v2/updateAsset.t.sol
+++ b/src/test/modules/PRICE.v2/updateAsset.t.sol
@@ -32,10 +32,10 @@ contract PriceV2UpdateAssetTest is PriceV2BaseTest {
     // Store asset addresses for test use
     address internal asset_SingleFeed_NoStrategy_NoMA;
     address internal asset_SingleFeed_Strategy_WithMA;
-    address internal asset_SingleFeed_AverageStrategy_WithMA;
     address internal asset_SingleFeed_NoStrategy_StoreMA;
     address internal asset_MultipleFeeds_Strategy_StoreMA;
     address internal asset_MultipleFeeds_Strategy_WithMA;
+    address internal asset_ThreeFeeds_MedianStrategy_WithMA;
     address internal asset_MultipleFeeds_Strategy;
 
     function setUp() public virtual override {
@@ -90,29 +90,6 @@ contract PriceV2UpdateAssetTest is PriceV2BaseTest {
         );
 
         asset_SingleFeed_Strategy_WithMA = address(testAsset1);
-        vm.stopPrank();
-        _;
-    }
-
-    // Asset with 1 feed, average strategy, MA used
-    modifier givenAsset_SingleFeed_AverageStrategy_WithMA() {
-        vm.startPrank(priceWriter);
-
-        IPRICEv2.Component[] memory feeds = new IPRICEv2.Component[](1);
-        feeds[0] = _singleFeed(onemaUsdPriceFeed);
-
-        price.addAsset(
-            address(testAsset1),
-            true, // storeMovingAverage
-            true, // useMovingAverage
-            uint32(2 * OBSERVATION_FREQUENCY), // movingAverageDuration (2 observations)
-            uint48(block.timestamp),
-            _makeRandomObservations(testAsset1, feeds[0], 1, uint256(2)), // 2 observations
-            _simpleStrategyAverageStrict(), // strategy
-            feeds
-        );
-
-        asset_SingleFeed_AverageStrategy_WithMA = address(testAsset1);
         vm.stopPrank();
         _;
     }
@@ -184,6 +161,41 @@ contract PriceV2UpdateAssetTest is PriceV2BaseTest {
         );
 
         asset_MultipleFeeds_Strategy_WithMA = address(testAsset1);
+        vm.stopPrank();
+        _;
+    }
+
+    // Asset with 3 feeds, median strategy, MA used
+    modifier givenAsset_ThreeFeeds_MedianStrategy_WithMA() {
+        vm.startPrank(priceWriter);
+
+        IPRICEv2.Component[] memory feeds = new IPRICEv2.Component[](3);
+        feeds[0] = _singleFeed(reserveUsdPriceFeed);
+        feeds[1] = _singleFeed(ohmUsdPriceFeed);
+        feeds[2] = _twoFeedMul(ohmEthPriceFeed, ethUsdPriceFeed);
+
+        IPRICEv2.Component memory strategy = IPRICEv2.Component(
+            toSubKeycode("PRICE.SIMPLESTRATEGY"),
+            ISimplePriceFeedStrategy.getMedianPrice.selector,
+            abi.encode(true)
+        );
+
+        uint256[] memory observations = new uint256[](2);
+        observations[0] = 10e18;
+        observations[1] = 10e18;
+
+        price.addAsset(
+            address(testAsset2),
+            true, // storeMovingAverage
+            true, // useMovingAverage
+            uint32(2 * OBSERVATION_FREQUENCY), // movingAverageDuration (2 observations)
+            uint48(block.timestamp),
+            observations,
+            strategy,
+            feeds
+        );
+
+        asset_ThreeFeeds_MedianStrategy_WithMA = address(testAsset2);
         vm.stopPrank();
         _;
     }
@@ -746,91 +758,6 @@ contract PriceV2UpdateAssetTest is PriceV2BaseTest {
         );
     }
 
-    function test_whenUpdatingPriceFeeds_whenSingleFeed_whenNotUpdatingStrategy_givenUseMovingAverageTrue_givenStrategyRequiresTwoValues_whenLastObservationCurrent_reverts()
-        public
-        givenAsset_SingleFeed_AverageStrategy_WithMA
-    {
-        IPRICEv2.Component[] memory newFeeds = new IPRICEv2.Component[](1);
-        newFeeds[0] = _singleFeed(onemaUsdPriceFeed);
-
-        IPRICEv2.UpdateAssetParams memory params = IPRICEv2.UpdateAssetParams({
-            updateFeeds: true,
-            updateStrategy: false,
-            updateMovingAverage: false,
-            feeds: newFeeds,
-            strategy: _emptyStrategy(),
-            useMovingAverage: false,
-            storeMovingAverage: false,
-            movingAverageDuration: uint32(0),
-            lastObservationTime: uint48(0),
-            observations: new uint256[](0)
-        });
-
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IPRICEv2.PRICE_StrategyFailed.selector,
-                asset_SingleFeed_AverageStrategy_WithMA,
-                abi.encodeWithSelector(
-                    ISimplePriceFeedStrategy.SimpleStrategy_PriceCountInvalid.selector,
-                    1,
-                    2
-                )
-            )
-        );
-        vm.prank(priceWriter);
-        price.updateAsset(asset_SingleFeed_AverageStrategy_WithMA, params);
-    }
-
-    function test_whenUpdatingPriceFeeds_whenSingleFeed_whenNotUpdatingStrategy_givenUseMovingAverageTrue_givenStrategyRequiresTwoValues_whenLastObservationStale_reverts()
-        public
-        givenAsset_SingleFeed_AverageStrategy_WithMA
-    {
-        IPRICEv2.Asset memory oldAssetData = price.getAssetData(
-            asset_SingleFeed_AverageStrategy_WithMA
-        );
-
-        IPRICEv2.Component[] memory newFeeds = new IPRICEv2.Component[](1);
-        newFeeds[0] = _singleFeed(onemaUsdPriceFeed);
-
-        IPRICEv2.UpdateAssetParams memory params = IPRICEv2.UpdateAssetParams({
-            updateFeeds: true,
-            updateStrategy: false,
-            updateMovingAverage: false,
-            feeds: newFeeds,
-            strategy: _emptyStrategy(),
-            useMovingAverage: false,
-            storeMovingAverage: false,
-            movingAverageDuration: uint32(0),
-            lastObservationTime: uint48(0),
-            observations: new uint256[](0)
-        });
-
-        vm.warp(block.timestamp + OBSERVATION_FREQUENCY);
-
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IPRICEv2.PRICE_MovingAverageStale.selector,
-                asset_SingleFeed_AverageStrategy_WithMA,
-                oldAssetData.lastObservationTime
-            )
-        );
-        price.getPrice(asset_SingleFeed_AverageStrategy_WithMA, IPRICEv2.Variant.CURRENT);
-
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IPRICEv2.PRICE_StrategyFailed.selector,
-                asset_SingleFeed_AverageStrategy_WithMA,
-                abi.encodeWithSelector(
-                    ISimplePriceFeedStrategy.SimpleStrategy_PriceCountInvalid.selector,
-                    1,
-                    2
-                )
-            )
-        );
-        vm.prank(priceWriter);
-        price.updateAsset(asset_SingleFeed_AverageStrategy_WithMA, params);
-    }
-
     // when the price feed configuration is being updated, when the number of price feeds is > 1, when there are duplicate price feeds: it reverts
 
     function test_whenUpdatingPriceFeeds_whenMultipleFeeds_whenDuplicateFeeds_reverts()
@@ -1118,6 +1045,291 @@ contract PriceV2UpdateAssetTest is PriceV2BaseTest {
             asset_MultipleFeeds_Strategy_StoreMA,
             20e18,
             "LAST should remain unchanged"
+        );
+
+        vm.warp(block.timestamp + 1);
+        vm.prank(priceWriter);
+        price.storeObservation(asset_MultipleFeeds_Strategy_StoreMA);
+
+        // onemaUsdPriceFeed = 5e8 (8 decimals), normalized to PRICE decimals:
+        // 5e8 * 1e10 = 5e18.
+        _assertLastPrice(
+            asset_MultipleFeeds_Strategy_StoreMA,
+            5e18,
+            "LAST should update from the first raw feed price"
+        );
+    }
+
+    function test_whenUpdatingPriceFeeds_whenMultipleFeeds_whenUpdatingStrategy_whenUseMovingAverageTrue_whenMedianStrategyRequiresMoreRawFeeds_whenLastObservationCurrent_reverts()
+        public
+        givenAsset_MultipleFeeds_Strategy_StoreMA
+    {
+        IPRICEv2.Component[] memory newFeeds = new IPRICEv2.Component[](2);
+        newFeeds[0] = _singleFeed(onemaUsdPriceFeed);
+        newFeeds[1] = _twoFeedMul(ohmEthPriceFeed, ethUsdPriceFeed);
+
+        IPRICEv2.Component memory newStrategy = IPRICEv2.Component(
+            toSubKeycode("PRICE.SIMPLESTRATEGY"),
+            ISimplePriceFeedStrategy.getMedianPrice.selector,
+            abi.encode(true)
+        );
+
+        IPRICEv2.UpdateAssetParams memory params = IPRICEv2.UpdateAssetParams({
+            updateFeeds: true,
+            updateStrategy: true,
+            updateMovingAverage: false,
+            feeds: newFeeds,
+            strategy: newStrategy,
+            useMovingAverage: true,
+            storeMovingAverage: false,
+            movingAverageDuration: uint32(0),
+            lastObservationTime: uint48(0),
+            observations: new uint256[](0)
+        });
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPRICEv2.PRICE_StrategyFailed.selector,
+                asset_MultipleFeeds_Strategy_StoreMA,
+                abi.encodeWithSelector(
+                    ISimplePriceFeedStrategy.SimpleStrategy_PriceCountInvalid.selector,
+                    2,
+                    3
+                )
+            )
+        );
+        vm.prank(priceWriter);
+        price.updateAsset(asset_MultipleFeeds_Strategy_StoreMA, params);
+    }
+
+    function test_whenUpdatingPriceFeeds_whenMultipleFeeds_whenUpdatingStrategy_whenUseMovingAverageTrue_whenMedianStrategyRequiresMoreRawFeeds_whenLastObservationStale_reverts()
+        public
+        givenAsset_MultipleFeeds_Strategy_StoreMA
+    {
+        IPRICEv2.Asset memory oldAssetData = price.getAssetData(
+            asset_MultipleFeeds_Strategy_StoreMA
+        );
+
+        IPRICEv2.Component[] memory newFeeds = new IPRICEv2.Component[](2);
+        newFeeds[0] = _singleFeed(onemaUsdPriceFeed);
+        newFeeds[1] = _twoFeedMul(ohmEthPriceFeed, ethUsdPriceFeed);
+
+        IPRICEv2.Component memory newStrategy = IPRICEv2.Component(
+            toSubKeycode("PRICE.SIMPLESTRATEGY"),
+            ISimplePriceFeedStrategy.getMedianPrice.selector,
+            abi.encode(true)
+        );
+
+        IPRICEv2.UpdateAssetParams memory params = IPRICEv2.UpdateAssetParams({
+            updateFeeds: true,
+            updateStrategy: true,
+            updateMovingAverage: false,
+            feeds: newFeeds,
+            strategy: newStrategy,
+            useMovingAverage: true,
+            storeMovingAverage: false,
+            movingAverageDuration: uint32(0),
+            lastObservationTime: uint48(0),
+            observations: new uint256[](0)
+        });
+
+        vm.warp(block.timestamp + OBSERVATION_FREQUENCY);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPRICEv2.PRICE_StrategyFailed.selector,
+                asset_MultipleFeeds_Strategy_StoreMA,
+                abi.encodeWithSelector(
+                    ISimplePriceFeedStrategy.SimpleStrategy_PriceCountInvalid.selector,
+                    2,
+                    3
+                )
+            )
+        );
+        vm.prank(priceWriter);
+        price.updateAsset(asset_MultipleFeeds_Strategy_StoreMA, params);
+
+        IPRICEv2.Asset memory assetData = price.getAssetData(asset_MultipleFeeds_Strategy_StoreMA);
+        assertEq(
+            assetData.lastObservationTime,
+            oldAssetData.lastObservationTime,
+            "lastObservationTime should not change"
+        );
+    }
+
+    function test_whenUpdatingStrategy_whenUseMovingAverageTrue_whenNotUpdatingPriceFeeds_givenStoreMovingAverageTrue_whenMedianStrategyRequiresMoreRawFeeds_whenLastObservationCurrent_reverts()
+        public
+        givenAsset_MultipleFeeds_Strategy_StoreMA
+    {
+        IPRICEv2.Component memory newStrategy = IPRICEv2.Component(
+            toSubKeycode("PRICE.SIMPLESTRATEGY"),
+            ISimplePriceFeedStrategy.getMedianPrice.selector,
+            abi.encode(true)
+        );
+
+        IPRICEv2.UpdateAssetParams memory params = IPRICEv2.UpdateAssetParams({
+            updateFeeds: false,
+            updateStrategy: true,
+            updateMovingAverage: false,
+            feeds: new IPRICEv2.Component[](0),
+            strategy: newStrategy,
+            useMovingAverage: true,
+            storeMovingAverage: false,
+            movingAverageDuration: uint32(0),
+            lastObservationTime: uint48(0),
+            observations: new uint256[](0)
+        });
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPRICEv2.PRICE_StrategyFailed.selector,
+                asset_MultipleFeeds_Strategy_StoreMA,
+                abi.encodeWithSelector(
+                    ISimplePriceFeedStrategy.SimpleStrategy_PriceCountInvalid.selector,
+                    2,
+                    3
+                )
+            )
+        );
+        vm.prank(priceWriter);
+        price.updateAsset(asset_MultipleFeeds_Strategy_StoreMA, params);
+    }
+
+    function test_whenUpdatingStrategy_whenUseMovingAverageTrue_whenNotUpdatingPriceFeeds_givenStoreMovingAverageTrue_whenMedianStrategyRequiresMoreRawFeeds_whenLastObservationStale_reverts()
+        public
+        givenAsset_MultipleFeeds_Strategy_StoreMA
+    {
+        IPRICEv2.Asset memory oldAssetData = price.getAssetData(
+            asset_MultipleFeeds_Strategy_StoreMA
+        );
+
+        IPRICEv2.Component memory newStrategy = IPRICEv2.Component(
+            toSubKeycode("PRICE.SIMPLESTRATEGY"),
+            ISimplePriceFeedStrategy.getMedianPrice.selector,
+            abi.encode(true)
+        );
+
+        IPRICEv2.UpdateAssetParams memory params = IPRICEv2.UpdateAssetParams({
+            updateFeeds: false,
+            updateStrategy: true,
+            updateMovingAverage: false,
+            feeds: new IPRICEv2.Component[](0),
+            strategy: newStrategy,
+            useMovingAverage: true,
+            storeMovingAverage: false,
+            movingAverageDuration: uint32(0),
+            lastObservationTime: uint48(0),
+            observations: new uint256[](0)
+        });
+
+        vm.warp(block.timestamp + OBSERVATION_FREQUENCY);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPRICEv2.PRICE_StrategyFailed.selector,
+                asset_MultipleFeeds_Strategy_StoreMA,
+                abi.encodeWithSelector(
+                    ISimplePriceFeedStrategy.SimpleStrategy_PriceCountInvalid.selector,
+                    2,
+                    3
+                )
+            )
+        );
+        vm.prank(priceWriter);
+        price.updateAsset(asset_MultipleFeeds_Strategy_StoreMA, params);
+
+        IPRICEv2.Asset memory assetData = price.getAssetData(asset_MultipleFeeds_Strategy_StoreMA);
+        assertEq(
+            assetData.lastObservationTime,
+            oldAssetData.lastObservationTime,
+            "lastObservationTime should not change"
+        );
+    }
+
+    function test_whenUpdatingPriceFeeds_whenNotUpdatingStrategy_givenUseMovingAverageTrue_givenMedianStrategy_whenUpdatedFeedsInsufficient_whenLastObservationCurrent_reverts()
+        public
+        givenAsset_ThreeFeeds_MedianStrategy_WithMA
+    {
+        IPRICEv2.Component[] memory newFeeds = new IPRICEv2.Component[](2);
+        newFeeds[0] = _singleFeed(onemaUsdPriceFeed);
+        newFeeds[1] = _twoFeedMul(ohmEthPriceFeed, ethUsdPriceFeed);
+
+        IPRICEv2.UpdateAssetParams memory params = IPRICEv2.UpdateAssetParams({
+            updateFeeds: true,
+            updateStrategy: false,
+            updateMovingAverage: false,
+            feeds: newFeeds,
+            strategy: _emptyStrategy(),
+            useMovingAverage: false,
+            storeMovingAverage: false,
+            movingAverageDuration: uint32(0),
+            lastObservationTime: uint48(0),
+            observations: new uint256[](0)
+        });
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPRICEv2.PRICE_StrategyFailed.selector,
+                asset_ThreeFeeds_MedianStrategy_WithMA,
+                abi.encodeWithSelector(
+                    ISimplePriceFeedStrategy.SimpleStrategy_PriceCountInvalid.selector,
+                    2,
+                    3
+                )
+            )
+        );
+        vm.prank(priceWriter);
+        price.updateAsset(asset_ThreeFeeds_MedianStrategy_WithMA, params);
+    }
+
+    function test_whenUpdatingPriceFeeds_whenNotUpdatingStrategy_givenUseMovingAverageTrue_givenMedianStrategy_whenUpdatedFeedsInsufficient_whenLastObservationStale_reverts()
+        public
+        givenAsset_ThreeFeeds_MedianStrategy_WithMA
+    {
+        IPRICEv2.Asset memory oldAssetData = price.getAssetData(
+            asset_ThreeFeeds_MedianStrategy_WithMA
+        );
+
+        IPRICEv2.Component[] memory newFeeds = new IPRICEv2.Component[](2);
+        newFeeds[0] = _singleFeed(onemaUsdPriceFeed);
+        newFeeds[1] = _twoFeedMul(ohmEthPriceFeed, ethUsdPriceFeed);
+
+        IPRICEv2.UpdateAssetParams memory params = IPRICEv2.UpdateAssetParams({
+            updateFeeds: true,
+            updateStrategy: false,
+            updateMovingAverage: false,
+            feeds: newFeeds,
+            strategy: _emptyStrategy(),
+            useMovingAverage: false,
+            storeMovingAverage: false,
+            movingAverageDuration: uint32(0),
+            lastObservationTime: uint48(0),
+            observations: new uint256[](0)
+        });
+
+        vm.warp(block.timestamp + OBSERVATION_FREQUENCY);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPRICEv2.PRICE_StrategyFailed.selector,
+                asset_ThreeFeeds_MedianStrategy_WithMA,
+                abi.encodeWithSelector(
+                    ISimplePriceFeedStrategy.SimpleStrategy_PriceCountInvalid.selector,
+                    2,
+                    3
+                )
+            )
+        );
+        vm.prank(priceWriter);
+        price.updateAsset(asset_ThreeFeeds_MedianStrategy_WithMA, params);
+
+        IPRICEv2.Asset memory assetData = price.getAssetData(
+            asset_ThreeFeeds_MedianStrategy_WithMA
+        );
+        assertEq(
+            assetData.lastObservationTime,
+            oldAssetData.lastObservationTime,
+            "lastObservationTime should not change"
         );
     }
 

--- a/src/test/modules/PRICE.v2/updateAsset.t.sol
+++ b/src/test/modules/PRICE.v2/updateAsset.t.sol
@@ -32,6 +32,7 @@ contract PriceV2UpdateAssetTest is PriceV2BaseTest {
     // Store asset addresses for test use
     address internal asset_SingleFeed_NoStrategy_NoMA;
     address internal asset_SingleFeed_Strategy_WithMA;
+    address internal asset_SingleFeed_AverageStrategy_WithMA;
     address internal asset_SingleFeed_NoStrategy_StoreMA;
     address internal asset_MultipleFeeds_Strategy_StoreMA;
     address internal asset_MultipleFeeds_Strategy_WithMA;
@@ -89,6 +90,29 @@ contract PriceV2UpdateAssetTest is PriceV2BaseTest {
         );
 
         asset_SingleFeed_Strategy_WithMA = address(testAsset1);
+        vm.stopPrank();
+        _;
+    }
+
+    // Asset with 1 feed, average strategy, MA used
+    modifier givenAsset_SingleFeed_AverageStrategy_WithMA() {
+        vm.startPrank(priceWriter);
+
+        IPRICEv2.Component[] memory feeds = new IPRICEv2.Component[](1);
+        feeds[0] = _singleFeed(onemaUsdPriceFeed);
+
+        price.addAsset(
+            address(testAsset1),
+            true, // storeMovingAverage
+            true, // useMovingAverage
+            uint32(2 * OBSERVATION_FREQUENCY), // movingAverageDuration (2 observations)
+            uint48(block.timestamp),
+            _makeRandomObservations(testAsset1, feeds[0], 1, uint256(2)), // 2 observations
+            _simpleStrategyAverageStrict(), // strategy
+            feeds
+        );
+
+        asset_SingleFeed_AverageStrategy_WithMA = address(testAsset1);
         vm.stopPrank();
         _;
     }
@@ -575,6 +599,18 @@ contract PriceV2UpdateAssetTest is PriceV2BaseTest {
         // 5e8 * 1e10 = 5e18.
         // LAST should remain the pre-update latest stored observation.
         _assertLastPrice(asset_SingleFeed_Strategy_WithMA, 5e18, "LAST should remain unchanged");
+
+        vm.warp(block.timestamp + 1);
+        vm.prank(priceWriter);
+        price.storeObservation(asset_SingleFeed_Strategy_WithMA);
+
+        // alphaUsdPriceFeed = 50e8 (8 decimals), normalized to PRICE decimals:
+        // 50e8 * 1e10 = 50e18.
+        _assertLastPrice(
+            asset_SingleFeed_Strategy_WithMA,
+            50e18,
+            "LAST should update from the raw feed price"
+        );
     }
 
     // when the price feed configuration is being updated, when the number of price feeds is 1, when the strategy configuration is being updated, when useMovingAverage is false, when the strategy configuration is not empty: reverts
@@ -696,6 +732,103 @@ contract PriceV2UpdateAssetTest is PriceV2BaseTest {
         // 5e8 * 1e10 = 5e18.
         // LAST should remain the pre-update latest stored observation.
         _assertLastPrice(asset_SingleFeed_Strategy_WithMA, 5e18, "LAST should remain unchanged");
+
+        vm.warp(block.timestamp + 1);
+        vm.prank(priceWriter);
+        price.storeObservation(asset_SingleFeed_Strategy_WithMA);
+
+        // alphaUsdPriceFeed = 50e8 (8 decimals), normalized to PRICE decimals:
+        // 50e8 * 1e10 = 50e18.
+        _assertLastPrice(
+            asset_SingleFeed_Strategy_WithMA,
+            50e18,
+            "LAST should update from the raw feed price"
+        );
+    }
+
+    function test_whenUpdatingPriceFeeds_whenSingleFeed_whenNotUpdatingStrategy_givenUseMovingAverageTrue_givenStrategyRequiresTwoValues_whenLastObservationCurrent_reverts()
+        public
+        givenAsset_SingleFeed_AverageStrategy_WithMA
+    {
+        IPRICEv2.Component[] memory newFeeds = new IPRICEv2.Component[](1);
+        newFeeds[0] = _singleFeed(onemaUsdPriceFeed);
+
+        IPRICEv2.UpdateAssetParams memory params = IPRICEv2.UpdateAssetParams({
+            updateFeeds: true,
+            updateStrategy: false,
+            updateMovingAverage: false,
+            feeds: newFeeds,
+            strategy: _emptyStrategy(),
+            useMovingAverage: false,
+            storeMovingAverage: false,
+            movingAverageDuration: uint32(0),
+            lastObservationTime: uint48(0),
+            observations: new uint256[](0)
+        });
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPRICEv2.PRICE_StrategyFailed.selector,
+                asset_SingleFeed_AverageStrategy_WithMA,
+                abi.encodeWithSelector(
+                    ISimplePriceFeedStrategy.SimpleStrategy_PriceCountInvalid.selector,
+                    1,
+                    2
+                )
+            )
+        );
+        vm.prank(priceWriter);
+        price.updateAsset(asset_SingleFeed_AverageStrategy_WithMA, params);
+    }
+
+    function test_whenUpdatingPriceFeeds_whenSingleFeed_whenNotUpdatingStrategy_givenUseMovingAverageTrue_givenStrategyRequiresTwoValues_whenLastObservationStale_reverts()
+        public
+        givenAsset_SingleFeed_AverageStrategy_WithMA
+    {
+        IPRICEv2.Asset memory oldAssetData = price.getAssetData(
+            asset_SingleFeed_AverageStrategy_WithMA
+        );
+
+        IPRICEv2.Component[] memory newFeeds = new IPRICEv2.Component[](1);
+        newFeeds[0] = _singleFeed(onemaUsdPriceFeed);
+
+        IPRICEv2.UpdateAssetParams memory params = IPRICEv2.UpdateAssetParams({
+            updateFeeds: true,
+            updateStrategy: false,
+            updateMovingAverage: false,
+            feeds: newFeeds,
+            strategy: _emptyStrategy(),
+            useMovingAverage: false,
+            storeMovingAverage: false,
+            movingAverageDuration: uint32(0),
+            lastObservationTime: uint48(0),
+            observations: new uint256[](0)
+        });
+
+        vm.warp(block.timestamp + OBSERVATION_FREQUENCY);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPRICEv2.PRICE_MovingAverageStale.selector,
+                asset_SingleFeed_AverageStrategy_WithMA,
+                oldAssetData.lastObservationTime
+            )
+        );
+        price.getPrice(asset_SingleFeed_AverageStrategy_WithMA, IPRICEv2.Variant.CURRENT);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPRICEv2.PRICE_StrategyFailed.selector,
+                asset_SingleFeed_AverageStrategy_WithMA,
+                abi.encodeWithSelector(
+                    ISimplePriceFeedStrategy.SimpleStrategy_PriceCountInvalid.selector,
+                    1,
+                    2
+                )
+            )
+        );
+        vm.prank(priceWriter);
+        price.updateAsset(asset_SingleFeed_AverageStrategy_WithMA, params);
     }
 
     // when the price feed configuration is being updated, when the number of price feeds is > 1, when there are duplicate price feeds: it reverts
@@ -916,6 +1049,18 @@ contract PriceV2UpdateAssetTest is PriceV2BaseTest {
             20e18,
             "LAST should remain unchanged"
         );
+
+        vm.warp(block.timestamp + 1);
+        vm.prank(priceWriter);
+        price.storeObservation(asset_MultipleFeeds_Strategy_StoreMA);
+
+        // onemaUsdPriceFeed = 5e8 (8 decimals), normalized to PRICE decimals:
+        // 5e8 * 1e10 = 5e18.
+        _assertLastPrice(
+            asset_MultipleFeeds_Strategy_StoreMA,
+            5e18,
+            "LAST should update from the first raw feed price"
+        );
     }
 
     // when the price feed configuration is being updated, when the number of price feeds is > 1, when the strategy configuration is being updated, when the strategy configuration is not empty, when useMovingAverage is true: it replaces the price feed configuration, it replaces the strategy configuration, it emits an AssetPriceFeedsUpdated event, it emits an AssetStrategyUpdated event
@@ -973,6 +1118,71 @@ contract PriceV2UpdateAssetTest is PriceV2BaseTest {
             asset_MultipleFeeds_Strategy_StoreMA,
             20e18,
             "LAST should remain unchanged"
+        );
+    }
+
+    function test_whenUpdatingPriceFeeds_whenMultipleFeeds_whenUpdatingStrategy_whenUseMovingAverageTrue_whenMedianStrategySupportsCurrentAndObservation()
+        public
+        givenAsset_MultipleFeeds_Strategy_StoreMA
+    {
+        IPRICEv2.Asset memory oldAssetData = price.getAssetData(
+            asset_MultipleFeeds_Strategy_StoreMA
+        );
+
+        IPRICEv2.Component[] memory newFeeds = new IPRICEv2.Component[](3);
+        newFeeds[0] = _singleFeed(reserveUsdPriceFeed);
+        newFeeds[1] = _singleFeed(ohmUsdPriceFeed);
+        newFeeds[2] = _twoFeedMul(ohmEthPriceFeed, ethUsdPriceFeed);
+
+        IPRICEv2.Component memory newStrategy = IPRICEv2.Component(
+            toSubKeycode("PRICE.SIMPLESTRATEGY"),
+            ISimplePriceFeedStrategy.getMedianPrice.selector,
+            abi.encode(true)
+        );
+
+        IPRICEv2.UpdateAssetParams memory params = IPRICEv2.UpdateAssetParams({
+            updateFeeds: true,
+            updateStrategy: true,
+            updateMovingAverage: false,
+            feeds: newFeeds,
+            strategy: newStrategy,
+            useMovingAverage: true,
+            storeMovingAverage: false,
+            movingAverageDuration: uint32(0),
+            lastObservationTime: uint48(0),
+            observations: new uint256[](0)
+        });
+
+        vm.expectEmit(true, true, true, true);
+        emit AssetPriceFeedsUpdated(asset_MultipleFeeds_Strategy_StoreMA);
+        vm.expectEmit(true, true, true, true);
+        emit AssetPriceStrategyUpdated(asset_MultipleFeeds_Strategy_StoreMA);
+
+        vm.prank(priceWriter);
+        price.updateAsset(asset_MultipleFeeds_Strategy_StoreMA, params);
+
+        IPRICEv2.Asset memory assetData = price.getAssetData(asset_MultipleFeeds_Strategy_StoreMA);
+        _assertFeedsUpdated(assetData, newFeeds);
+        _assertStrategyUpdated(assetData, newStrategy, true);
+        _assertMovingAverageUnchanged(oldAssetData, assetData);
+
+        // Raw feeds are 1e18, 10e18, 10e18. The existing MA is greater than 10e18.
+        // CURRENT median over [1e18, 10e18, 10e18, MA] = 10e18.
+        (uint256 currentPrice, ) = price.getPrice(
+            asset_MultipleFeeds_Strategy_StoreMA,
+            IPRICEv2.Variant.CURRENT
+        );
+        assertEq(currentPrice, 10e18, "CURRENT should median feeds and moving average");
+
+        vm.warp(block.timestamp + 1);
+        vm.prank(priceWriter);
+        price.storeObservation(asset_MultipleFeeds_Strategy_StoreMA);
+
+        // Observation median over raw feeds [1e18, 10e18, 10e18] = 10e18.
+        _assertLastPrice(
+            asset_MultipleFeeds_Strategy_StoreMA,
+            10e18,
+            "LAST should update from the raw feed median"
         );
     }
 
@@ -1071,6 +1281,17 @@ contract PriceV2UpdateAssetTest is PriceV2BaseTest {
         _assertFeedsUpdated(assetData, newFeeds);
         _assertStrategyUnchanged(oldAssetData, assetData);
         _assertMovingAverageUnchanged(oldAssetData, assetData);
+
+        vm.prank(priceWriter);
+        price.storeObservation(asset_SingleFeed_Strategy_WithMA);
+
+        // alphaUsdPriceFeed = 50e8 (8 decimals), normalized to PRICE decimals:
+        // 50e8 * 1e10 = 50e18.
+        _assertLastPrice(
+            asset_SingleFeed_Strategy_WithMA,
+            50e18,
+            "LAST should update from the raw feed price"
+        );
     }
 
     // when the asset strategy configuration is being updated, given the strategy submodule is not installed: it reverts
@@ -1149,6 +1370,48 @@ contract PriceV2UpdateAssetTest is PriceV2BaseTest {
         price.updateAsset(asset_MultipleFeeds_Strategy, params);
     }
 
+    // when the asset strategy configuration is being updated, when useMovingAverage is true, given there is a single feed and stored moving average, when the updated strategy requires three values: it reverts
+
+    function test_whenUpdatingStrategy_whenUseMovingAverageTrue_givenSingleFeedAndStoredMovingAverage_whenStrategyRequiresThreeValues_reverts()
+        public
+        givenAsset_SingleFeed_NoStrategy_StoreMA
+    {
+        IPRICEv2.Component memory newStrategy = IPRICEv2.Component(
+            toSubKeycode("PRICE.SIMPLESTRATEGY"),
+            ISimplePriceFeedStrategy.getMedianPrice.selector,
+            abi.encode(false)
+        );
+
+        IPRICEv2.UpdateAssetParams memory params = IPRICEv2.UpdateAssetParams({
+            updateFeeds: false,
+            updateStrategy: true,
+            updateMovingAverage: false,
+            feeds: new IPRICEv2.Component[](0),
+            strategy: newStrategy,
+            useMovingAverage: true,
+            storeMovingAverage: false,
+            movingAverageDuration: uint32(0),
+            lastObservationTime: uint48(0),
+            observations: new uint256[](0)
+        });
+
+        // The raw observation path has one feed and would return directly, but CURRENT
+        // has feed + moving average and must be validated against the median strategy.
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPRICEv2.PRICE_StrategyFailed.selector,
+                asset_SingleFeed_NoStrategy_StoreMA,
+                abi.encodeWithSelector(
+                    ISimplePriceFeedStrategy.SimpleStrategy_PriceCountInvalid.selector,
+                    2,
+                    3
+                )
+            )
+        );
+        vm.prank(priceWriter);
+        price.updateAsset(asset_SingleFeed_NoStrategy_StoreMA, params);
+    }
+
     // when the asset strategy configuration is being updated, when useMovingAverage is true, when the moving average configuration is not being updated, given storeMovingAverage is true, when the updated strategy configuration is empty: it reverts
 
     function test_whenUpdatingStrategy_whenUseMovingAverageTrue_whenNotUpdatingMovingAverage_givenStoreMovingAverageTrue_whenStrategyEmpty_reverts()
@@ -1181,6 +1444,91 @@ contract PriceV2UpdateAssetTest is PriceV2BaseTest {
         price.updateAsset(asset_SingleFeed_Strategy_WithMA, params);
     }
 
+    // when the asset strategy configuration is being updated, when useMovingAverage is true, when the moving average configuration is not being updated, given storeMovingAverage is true, when the updated strategy configuration is not empty, when the strategy requires two values, when the last stored observation is current: it reverts
+
+    function test_whenUpdatingStrategy_whenUseMovingAverageTrue_whenNotUpdatingMovingAverage_givenStoreMovingAverageTrue_whenStrategyRequiresTwoValues_whenLastObservationCurrent_reverts()
+        public
+        givenAsset_SingleFeed_Strategy_WithMA
+    {
+        IPRICEv2.Component memory newStrategy = _simpleStrategyAverageStrict();
+
+        IPRICEv2.UpdateAssetParams memory params = IPRICEv2.UpdateAssetParams({
+            updateFeeds: false,
+            updateStrategy: true,
+            updateMovingAverage: false,
+            feeds: new IPRICEv2.Component[](0),
+            strategy: newStrategy,
+            useMovingAverage: true,
+            storeMovingAverage: false,
+            movingAverageDuration: uint32(0),
+            lastObservationTime: uint48(0),
+            observations: new uint256[](0)
+        });
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPRICEv2.PRICE_StrategyFailed.selector,
+                asset_SingleFeed_Strategy_WithMA,
+                abi.encodeWithSelector(
+                    ISimplePriceFeedStrategy.SimpleStrategy_PriceCountInvalid.selector,
+                    1,
+                    2
+                )
+            )
+        );
+        vm.prank(priceWriter);
+        price.updateAsset(asset_SingleFeed_Strategy_WithMA, params);
+    }
+
+    // when the asset strategy configuration is being updated, when useMovingAverage is true, when the moving average configuration is not being updated, given storeMovingAverage is true, when the updated strategy configuration is not empty, when the strategy requires two values, when the last stored observation is stale: it reverts
+
+    function test_whenUpdatingStrategy_whenUseMovingAverageTrue_whenNotUpdatingMovingAverage_givenStoreMovingAverageTrue_whenStrategyRequiresTwoValues_whenLastObservationStale_reverts()
+        public
+        givenAsset_SingleFeed_Strategy_WithMA
+    {
+        IPRICEv2.Asset memory oldAssetData = price.getAssetData(asset_SingleFeed_Strategy_WithMA);
+
+        IPRICEv2.Component memory newStrategy = _simpleStrategyAverageStrict();
+
+        IPRICEv2.UpdateAssetParams memory params = IPRICEv2.UpdateAssetParams({
+            updateFeeds: false,
+            updateStrategy: true,
+            updateMovingAverage: false,
+            feeds: new IPRICEv2.Component[](0),
+            strategy: newStrategy,
+            useMovingAverage: true,
+            storeMovingAverage: false,
+            movingAverageDuration: uint32(0),
+            lastObservationTime: uint48(0),
+            observations: new uint256[](0)
+        });
+
+        vm.warp(block.timestamp + OBSERVATION_FREQUENCY);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPRICEv2.PRICE_MovingAverageStale.selector,
+                asset_SingleFeed_Strategy_WithMA,
+                oldAssetData.lastObservationTime
+            )
+        );
+        price.getPrice(asset_SingleFeed_Strategy_WithMA, IPRICEv2.Variant.CURRENT);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPRICEv2.PRICE_StrategyFailed.selector,
+                asset_SingleFeed_Strategy_WithMA,
+                abi.encodeWithSelector(
+                    ISimplePriceFeedStrategy.SimpleStrategy_PriceCountInvalid.selector,
+                    1,
+                    2
+                )
+            )
+        );
+        vm.prank(priceWriter);
+        price.updateAsset(asset_SingleFeed_Strategy_WithMA, params);
+    }
+
     // when the asset strategy configuration is being updated, when useMovingAverage is true, when the moving average configuration is not being updated, given storeMovingAverage is true, when the updated strategy configuration is not empty: it replaces the strategy configuration, it emits an AssetStrategyUpdated event
 
     function test_whenUpdatingStrategy_whenUseMovingAverageTrue_whenNotUpdatingMovingAverage_givenStoreMovingAverageTrue_whenStrategyNotEmpty()
@@ -1189,7 +1537,7 @@ contract PriceV2UpdateAssetTest is PriceV2BaseTest {
     {
         IPRICEv2.Asset memory oldAssetData = price.getAssetData(asset_SingleFeed_Strategy_WithMA);
 
-        IPRICEv2.Component memory newStrategy = _simpleStrategyAverage();
+        IPRICEv2.Component memory newStrategy = _simpleStrategyFirstNonZero();
 
         IPRICEv2.UpdateAssetParams memory params = IPRICEv2.UpdateAssetParams({
             updateFeeds: false,
@@ -1215,6 +1563,77 @@ contract PriceV2UpdateAssetTest is PriceV2BaseTest {
         _assertFeedsUnchanged(oldAssetData, assetData);
         _assertStrategyUpdated(assetData, newStrategy, true);
         _assertMovingAverageUnchanged(oldAssetData, assetData);
+
+        vm.warp(block.timestamp + 1);
+        vm.prank(priceWriter);
+        price.storeObservation(asset_SingleFeed_Strategy_WithMA);
+
+        _assertLastPrice(
+            asset_SingleFeed_Strategy_WithMA,
+            5e18,
+            "LAST should update from the raw feed price"
+        );
+    }
+
+    // when the asset strategy configuration is being updated, when useMovingAverage is true, when the moving average configuration is not being updated, given storeMovingAverage is true, when the updated strategy supports the raw feed and feed plus moving average configurations, when the last stored observation is stale: it replaces the strategy configuration and emits an AssetStrategyUpdated event
+
+    function test_whenUpdatingStrategy_whenUseMovingAverageTrue_whenNotUpdatingMovingAverage_givenStoreMovingAverageTrue_whenStrategySupportsFeedAndMovingAverage_whenLastObservationStale()
+        public
+        givenAsset_SingleFeed_Strategy_WithMA
+    {
+        IPRICEv2.Asset memory oldAssetData = price.getAssetData(asset_SingleFeed_Strategy_WithMA);
+
+        IPRICEv2.Component memory newStrategy = _simpleStrategyFirstNonZero();
+
+        IPRICEv2.UpdateAssetParams memory params = IPRICEv2.UpdateAssetParams({
+            updateFeeds: false,
+            updateStrategy: true,
+            updateMovingAverage: false,
+            feeds: new IPRICEv2.Component[](0),
+            strategy: newStrategy,
+            useMovingAverage: true,
+            storeMovingAverage: false,
+            movingAverageDuration: uint32(0),
+            lastObservationTime: uint48(0),
+            observations: new uint256[](0)
+        });
+
+        vm.warp(block.timestamp + OBSERVATION_FREQUENCY);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPRICEv2.PRICE_MovingAverageStale.selector,
+                asset_SingleFeed_Strategy_WithMA,
+                oldAssetData.lastObservationTime
+            )
+        );
+        price.getPrice(asset_SingleFeed_Strategy_WithMA, IPRICEv2.Variant.CURRENT);
+
+        vm.expectEmit(true, true, true, true);
+        emit AssetPriceStrategyUpdated(asset_SingleFeed_Strategy_WithMA);
+
+        vm.prank(priceWriter);
+        price.updateAsset(asset_SingleFeed_Strategy_WithMA, params);
+
+        IPRICEv2.Asset memory assetData = price.getAssetData(asset_SingleFeed_Strategy_WithMA);
+        _assertFeedsUnchanged(oldAssetData, assetData);
+        _assertStrategyUpdated(assetData, newStrategy, true);
+        _assertMovingAverageUnchanged(oldAssetData, assetData);
+
+        vm.prank(priceWriter);
+        price.storeObservation(asset_SingleFeed_Strategy_WithMA);
+
+        _assertLastPrice(
+            asset_SingleFeed_Strategy_WithMA,
+            5e18,
+            "LAST should update from the raw feed price"
+        );
+
+        (uint256 currentPrice, ) = price.getPrice(
+            asset_SingleFeed_Strategy_WithMA,
+            IPRICEv2.Variant.CURRENT
+        );
+        assertEq(currentPrice, 5e18, "CURRENT should work after storing the observation");
     }
 
     // when the asset strategy configuration is being updated, when useMovingAverage is true, when the moving average configuration is not being updated, given storeMovingAverage is false: it reverts
@@ -1346,6 +1765,16 @@ contract PriceV2UpdateAssetTest is PriceV2BaseTest {
             asset_SingleFeed_NoStrategy_NoMA,
             120e18,
             "LAST should be the most recent stored observation"
+        );
+
+        vm.warp(block.timestamp + 1);
+        vm.prank(priceWriter);
+        price.storeObservation(asset_SingleFeed_NoStrategy_NoMA);
+
+        _assertLastPrice(
+            asset_SingleFeed_NoStrategy_NoMA,
+            50e18,
+            "LAST should update from the raw feed price"
         );
     }
 
@@ -1612,6 +2041,16 @@ contract PriceV2UpdateAssetTest is PriceV2BaseTest {
             IPRICEv2.Variant.LAST
         );
         assertGt(lastPrice, 0, "LAST price should be non-zero");
+
+        vm.warp(block.timestamp + 1);
+        vm.prank(priceWriter);
+        price.storeObservation(asset_SingleFeed_Strategy_WithMA);
+
+        _assertLastPrice(
+            asset_SingleFeed_Strategy_WithMA,
+            5e18,
+            "LAST should update from the raw feed price"
+        );
     }
 
     // when the moving average configuration is being updated, when the last observation time is in the future: it reverts
@@ -1896,6 +2335,13 @@ contract PriceV2UpdateAssetTest is PriceV2BaseTest {
 
         (uint256 lastPrice, ) = price.getPrice(address(onema), IPRICEv2.Variant.LAST);
         assertEq(lastPrice, 5e18, "LAST should remain the most recent stored observation");
+
+        vm.warp(block.timestamp + 1);
+        vm.prank(priceWriter);
+        price.storeObservation(address(onema));
+
+        (uint256 updatedLastPrice, ) = price.getPrice(address(onema), IPRICEv2.Variant.LAST);
+        assertEq(updatedLastPrice, 10e18, "LAST should update from the raw feed price");
     }
 
     // when the moving average configuration is being updated, when the strategy configuration is not being updated, when params.useMovingAverage is false but existing strategy uses MA: LAST remains observation-based
@@ -1956,6 +2402,13 @@ contract PriceV2UpdateAssetTest is PriceV2BaseTest {
 
         (uint256 lastPrice, ) = price.getPrice(address(onema), IPRICEv2.Variant.LAST);
         assertEq(lastPrice, 5e18, "LAST should remain the most recent stored observation");
+
+        vm.warp(block.timestamp + 1);
+        vm.prank(priceWriter);
+        price.storeObservation(address(onema));
+
+        (uint256 updatedLastPrice, ) = price.getPrice(address(onema), IPRICEv2.Variant.LAST);
+        assertEq(updatedLastPrice, 10e18, "LAST should update from the raw feed price");
     }
 
     // when the moving average configured is being updated, when store moving average is true: LAST remains observation-based

--- a/src/test/modules/PRICE.v2/updateAsset.t.sol
+++ b/src/test/modules/PRICE.v2/updateAsset.t.sol
@@ -1924,13 +1924,13 @@ contract PriceV2UpdateAssetTest is PriceV2BaseTest {
 
     // when the asset strategy configuration is being updated, when useMovingAverage is true, when the moving average configuration is being updated, when storeMovingAverage is true, when the updated strategy configuration is not empty: it replaces the strategy configuration, it replaces the moving average configuration, it emits an AssetStrategyUpdated event, it emits an AssetMovingAverageUpdated event
 
-    function test_whenUpdatingStrategy_whenUseMovingAverageTrue_whenUpdatingMovingAverage_whenStoreMovingAverageTrue_whenStrategyNotEmpty()
+    function test_givenSingleFeedNoStrategyNoMovingAverage_whenUpdatingStrategyToFirstNonZeroAndEnablingMovingAverage_updatesStrategyAndMovingAverage()
         public
         givenAsset_SingleFeed_NoStrategy_NoMA
     {
         IPRICEv2.Asset memory oldAssetData = price.getAssetData(asset_SingleFeed_NoStrategy_NoMA);
 
-        IPRICEv2.Component memory newStrategy = _simpleStrategyAverage();
+        IPRICEv2.Component memory newStrategy = _simpleStrategyFirstNonZero();
 
         uint256[] memory newObs = new uint256[](3);
         newObs[0] = 100e18;
@@ -2216,7 +2216,7 @@ contract PriceV2UpdateAssetTest is PriceV2BaseTest {
 
     // when the asset strategy configuration is being updated, when not updating moving average configuration: moving average parameters are ignored
 
-    function test_whenUpdatingStrategy_whenNotUpdatingMovingAverage()
+    function test_givenSingleFeedAssetStoresAndUsesMovingAverage_whenUpdatingStrategyToFirstNonZeroWithoutUpdatingMovingAverage_storeObservationUsesRawFeed()
         public
         givenAsset_SingleFeed_Strategy_WithMA
     {
@@ -2232,7 +2232,7 @@ contract PriceV2UpdateAssetTest is PriceV2BaseTest {
             updateStrategy: true,
             updateMovingAverage: false, // Don't update MA
             feeds: new IPRICEv2.Component[](0),
-            strategy: _simpleStrategyAverage(),
+            strategy: _simpleStrategyFirstNonZero(),
             useMovingAverage: true,
             storeMovingAverage: false, // These should be ignored
             movingAverageDuration: uint32(3 * OBSERVATION_FREQUENCY), // These should be ignored
@@ -2558,7 +2558,7 @@ contract PriceV2UpdateAssetTest is PriceV2BaseTest {
 
     // when the moving average configuration is being updated, when the strategy configuration is not being updated, when params.useMovingAverage is false but existing strategy uses MA: LAST remains observation-based
 
-    function test_whenUpdatingMovingAverage_whenNotUpdatingStrategy_whenParamsUseMovingAverageFalse_lastRemainsObservationBased()
+    function test_givenFirstNonZeroStrategyUsesMovingAverage_whenUpdatingMovingAverageWithUseMovingAverageFalseParam_lastRemainsObservationBased()
         public
     {
         uint256[] memory observations = new uint256[](2);
@@ -2585,11 +2585,7 @@ contract PriceV2UpdateAssetTest is PriceV2BaseTest {
             uint32(observations.length) * OBSERVATION_FREQUENCY,
             uint48(block.timestamp),
             observations,
-            IPRICEv2.Component(
-                toSubKeycode("PRICE.SIMPLESTRATEGY"),
-                ISimplePriceFeedStrategy.getAveragePrice.selector,
-                abi.encode(0)
-            ),
+            _simpleStrategyFirstNonZero(),
             feeds
         );
 
@@ -2625,7 +2621,7 @@ contract PriceV2UpdateAssetTest is PriceV2BaseTest {
 
     // when the moving average configured is being updated, when store moving average is true: LAST remains observation-based
 
-    function test_whenUpdatingMovingAverage_whenUseMovingAverageTrue_lastRemainsObservationBased()
+    function test_givenFirstNonZeroStrategyUsesMovingAverage_whenUpdatingMovingAverageWithUseMovingAverageTrue_lastRemainsObservationBased()
         public
     {
         uint256[] memory observations = new uint256[](2);
@@ -2652,11 +2648,7 @@ contract PriceV2UpdateAssetTest is PriceV2BaseTest {
             uint32(observations.length) * OBSERVATION_FREQUENCY,
             uint48(block.timestamp),
             observations,
-            IPRICEv2.Component(
-                toSubKeycode("PRICE.SIMPLESTRATEGY"),
-                ISimplePriceFeedStrategy.getAveragePrice.selector,
-                abi.encode(0)
-            ),
+            _simpleStrategyFirstNonZero(),
             feeds
         );
 


### PR DESCRIPTION
## Summary
- validate moving-average asset configurations against both raw observation and MA-inclusive current-price strategy paths
- keep stored observations feed-only while using a synthetic raw observation value for MA-inclusive validation
- expand addAsset/updateAsset coverage for average and median strategy edge cases

## Validation
- forge test --match-path src/test/modules/PRICE.v2/PRICE.v2.t.sol
- forge test --match-path src/test/modules/PRICE.v2/updateAsset.t.sol
- forge build --sizes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Updates**
  * Gas consumption metrics adjusted for price query and observation storage operations

* **Bug Fixes**
  * Strengthened validation logic for moving average strategies to prevent misconfigurations across different input shapes

* **Tests**
  * Expanded test coverage for moving average behavior across single and multi-feed configurations
  * Added edge-case validation tests for strategy compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->