### PR TITLE
LZ Bridge (I-01): Add validation for receive bridge OHM

### DIFF
--- a/src/policies/bridge/LZBridgeGateway.sol
+++ b/src/policies/bridge/LZBridgeGateway.sol
@@ -589,7 +589,6 @@ contract LZBridgeGateway is
         (address to, uint256 amount) = abi.decode(data_, (address, uint256));
 
         _requireNonzeroAddress(to, "to");
-        if (to == address(this)) revert LZBridgeGateway_InvalidAddress("to");
 
         // Track bridged supply on canonical chain
         if (IS_CANONICAL) {

--- a/src/policies/bridge/LZBridgeGateway.sol
+++ b/src/policies/bridge/LZBridgeGateway.sol
@@ -588,6 +588,9 @@ contract LZBridgeGateway is
         if (data_.length != _BRIDGE_OHM_DATA_LENGTH) revert LZBridgeGateway_InvalidPayload();
         (address to, uint256 amount) = abi.decode(data_, (address, uint256));
 
+        _requireNonzeroAddress(to, "to");
+        if (to == address(this)) revert LZBridgeGateway_InvalidAddress("to");
+
         // Track bridged supply on canonical chain
         if (IS_CANONICAL) {
             if (bridgedSupply < amount)

--- a/src/test/policies/bridge/LZBridgeGateway/LZBridgeGateway_LzReceive.t.sol
+++ b/src/test/policies/bridge/LZBridgeGateway/LZBridgeGateway_LzReceive.t.sol
@@ -236,6 +236,22 @@ contract LZBridgeGatewayTests_LzReceive is LZBridgeGatewayTestBase {
         gateway2.lzReceive(origin, bytes32(0), bytes(""), address(0), bytes(""));
     }
 
+    function test_lzReceive_revertsIfRecipientIsZeroAddress() external {
+        Origin memory origin = Origin({
+            srcEid: NONCANONICAL_EID,
+            sender: LZConfigLib.addressToBytes32(address(gateway2)),
+            nonce: 1
+        });
+
+        bytes memory payload = abi.encode(uint8(1), abi.encode(address(0), uint256(100e9)));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(ILZBridgeGateway.LZBridgeGateway_InvalidAddress.selector, "to")
+        );
+        vm.prank(address(endpointSetup.endpointList[0]));
+        gateway.lzReceive(origin, bytes32(0), payload, address(0), bytes(""));
+    }
+
     function test_lzReceive_revertsIfBridgeDisabledAndReceiveEnabledFalse() external {
         vm.prank(admin);
         gateway2.disable(bytes(""));

--- a/src/test/policies/bridge/LZBridgeGateway/LZBridgeGateway_LzReceive.t.sol
+++ b/src/test/policies/bridge/LZBridgeGateway/LZBridgeGateway_LzReceive.t.sol
@@ -236,6 +236,10 @@ contract LZBridgeGatewayTests_LzReceive is LZBridgeGatewayTestBase {
         gateway2.lzReceive(origin, bytes32(0), bytes(""), address(0), bytes(""));
     }
 
+    // Note: since both `gateway.burnAndSend` and `LZCrossChainBridge` validate that the recipient
+    // address is non-zero on the source side, reaching this branch would require either a bug
+    // introduced in a future version of the gateway or facilitator or a fault on the LayerZero side.
+    // This test exists as a defense-in-depth check on the receive path.
     function test_lzReceive_revertsIfRecipientIsZeroAddress() external {
         Origin memory origin = Origin({
             srcEid: NONCANONICAL_EID,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Enhanced recipient address validation in bridge transfers. The bridge gateway now validates that recipient addresses are non-zero before processing, preventing potentially invalid transactions from being executed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->