### PR TITLE
Cross-port sUSDe batch script helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /out/
 cache/
 node_modules/
+.pnpm-store/
 .env
 .env.*
 remappings.txt

--- a/src/scripts/env.json
+++ b/src/scripts/env.json
@@ -443,7 +443,8 @@
                 },
                 "multisig": {
                     "dao": "0x245cc372C84B3645Bf0Ffe6538620B04a217988B",
-                    "emergency": "0xa8A6ff2606b24F61AFA986381D8991DFcCCd2D55"
+                    "emergency": "0xa8A6ff2606b24F61AFA986381D8991DFcCCd2D55",
+                    "treasuryWorkingGroup": "0x2075e3b46470cfcE124Daaf52b46Dcf965727Dd1"
                 },
                 "periphery": {
                     "CCIPCrossChainBridge": "0xFbf6383dC3F6010d403Ecdf12DDC1311701D143D",

--- a/src/scripts/ops/ChangeKernelExecutor.s.sol
+++ b/src/scripts/ops/ChangeKernelExecutor.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Unlicensed
-pragma solidity 0.8.15;
+pragma solidity >=0.8.24;
 
 import {WithEnvironment} from "src/scripts/WithEnvironment.s.sol";
 import {ChainUtils} from "src/scripts/ops/lib/ChainUtils.sol";

--- a/src/scripts/ops/lib/BatchScriptV2.sol
+++ b/src/scripts/ops/lib/BatchScriptV2.sol
@@ -95,6 +95,25 @@ abstract contract BatchScriptV2 is WithEnvironment {
         _;
     }
 
+    /// @notice Set up with the Treasury Working Group multisig as owner
+    /// @dev    Reads from olympus.multisig.treasuryWorkingGroup in env.json
+    ///         Parameter useDaoMS_ is ignored but present for signature compatibility with safeBatchV2.sh
+    modifier setUpWithTreasuryWorkingGroupMS(
+        bool useDaoMS_,
+        bool signOnly_,
+        string memory argsFilePath_,
+        string memory ledgerDerivationPath_,
+        bytes memory signature_
+    ) {
+        string memory chainName = ChainUtils._getChainName(block.chainid);
+        _loadEnv(chainName);
+        _loadArgs(argsFilePath_);
+
+        address owner = _envAddressNotZero("olympus.multisig.treasuryWorkingGroup");
+        _setUpBatchScript(signOnly_, owner, ledgerDerivationPath_, signature_);
+        _;
+    }
+
     function _hasSignature() internal view returns (bool) {
         return bytes(_signature).length > 0;
     }

--- a/src/scripts/ops/lib/BatchScriptV2.sol
+++ b/src/scripts/ops/lib/BatchScriptV2.sol
@@ -64,6 +64,10 @@ abstract contract BatchScriptV2 is WithEnvironment {
     /// @dev    If set, this function will be called after batch simulation to validate state
     bytes4 internal _postBatchValidateSelector;
 
+    /// @notice Whether to skip heartbeat validation during batch simulation
+    /// @dev    Defaults to false (heartbeat validation enabled). Set to true in derived scripts to skip.
+    bool internal _skipHeartbeatValidation;
+
     // TODOs
     // [X] Add Ledger signer support
     // [X] Check for --broadcast flag before proposing batch
@@ -215,6 +219,15 @@ abstract contract BatchScriptV2 is WithEnvironment {
         return nonce;
     }
 
+    function _logSafeTxDetails(address to, bytes memory data, uint256 nonce) internal view {
+        bytes32 safeTxHash = _multiSig.getSafeTxHash(to, 0, data, Enum.Operation.DelegateCall, nonce);
+        console2.log("  Safe tx hash (idempotency key):");
+        console2.logBytes32(safeTxHash);
+        console2.log("  Multisend target:", to);
+        console2.log("  Multisend calldata hash:");
+        console2.logBytes32(keccak256(data));
+    }
+
     function _proposeMultisigBatchTransactions() internal returns (bytes32 txHash) {
         if (_signOnly) {
             revert("BatchScriptV2: Cannot propose batch when signOnly is true");
@@ -235,6 +248,8 @@ abstract contract BatchScriptV2 is WithEnvironment {
             signature: _signature, // Empty signature, will be signed later
             nonce: nonce
         });
+
+        _logSafeTxDetails(to, data, nonce);
 
         // If there is no signature, get the signature
         if (!_hasSignature()) {
@@ -281,6 +296,8 @@ abstract contract BatchScriptV2 is WithEnvironment {
 
             (address to, bytes memory data) = _multiSig.getProposeTransactionsTargetAndData(_batchTargets, _batchData);
 
+            _logSafeTxDetails(to, data, nonce);
+
             // This will revert if the user is using a Ledger and the derivation path is not provided
             bytes memory signature = _multiSig.sign(
                 to,
@@ -293,6 +310,15 @@ abstract contract BatchScriptV2 is WithEnvironment {
             console2.log("Batch signed. Signature:");
             console2.logBytes(signature);
             return;
+        }
+
+        {
+            uint256 nonce = _getNonce();
+            (address to, bytes memory data) = _multiSig.getProposeTransactionsTargetAndData(
+                _batchTargets,
+                _batchData
+            );
+            _logSafeTxDetails(to, data, nonce);
         }
 
         // Check if we're in broadcast mode before proposing
@@ -434,15 +460,15 @@ abstract contract BatchScriptV2 is WithEnvironment {
                 headers,
                 string.concat(
                     "{",
-                    '"callArgs": {',
-                    '"from": "',
+                    "\"callArgs\": {",
+                    "\"from\": \"",
                     vm.toString(_owner),
-                    '", "to": "',
+                    "\", \"to\": \"",
                     vm.toString(_batchTargets[i]),
-                    '", "gas": "0x7a1200", "gasPrice": "0x10", "value": "0x0", ',
-                    '"data": "',
+                    "\", \"gas\": \"0x7a1200\", \"gasPrice\": \"0x10\", \"value\": \"0x0\", ",
+                    "\"data\": \"",
                     vm.toString(_batchData[i]),
-                    '"',
+                    "\"",
                     "}}"
                 )
             );
@@ -695,9 +721,18 @@ abstract contract BatchScriptV2 is WithEnvironment {
         _runPostBatchValidation();
 
         // Validate heart beat
-        _validateHeartBeat();
+        if (_skipHeartbeatValidation) {
+            console2.log(
+                "\n!!! HEARTBEAT VALIDATION DISABLED - PROCEED AT YOUR OWN RISK !!!"
+            );
+            console2.log(
+                "!!! Skipping heartbeat check means the batch may break protocol operations !!!"
+            );
+        } else {
+            _validateHeartBeat();
+        }
 
-        // Revert to snapshot - removes BOTH simulation and validation artifacts
+        // Revert to snapshot - removes simulation and validation artifacts
         vm.revertToStateAndDelete(snapshotId);
         console2.log("Restored state from snapshot (simulation + validation artifacts removed)");
     }

--- a/src/test/proposals/OIP_194A.t.sol
+++ b/src/test/proposals/OIP_194A.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.24;
 
 import {ProposalTest} from "./ProposalTest.sol";
 


### PR DESCRIPTION
## Summary

- Cross-port selected batch script helper changes from `feat/susde-aave-loop` without bringing over the full sUSDe Aave loop implementation.
- Add `.pnpm-store/` to `.gitignore`.
- Add Treasury Working Group multisig setup support via `setUpWithTreasuryWorkingGroupMS` and `olympus.multisig.treasuryWorkingGroup`.
- Add optional heartbeat validation skipping and Safe transaction detail logging in `BatchScriptV2`.
- Update new-file pragma issues in `ChangeKernelExecutor.s.sol` and `OIP_194A.t.sol` to meet the current Solidity baseline.

## Source commits

- Treasury Working Group setup cross-port: `f75cf2f91`
- Heartbeat validation skip cross-port: `f38523880`
- Safe tx detail logging cross-port: `ef972d057`

## Validation

- `pnpm install`
- `pnpm run build`
- `pnpm exec prettier --write src/scripts/ops/lib/BatchScriptV2.sol src/scripts/env.json`
- `pnpm exec solhint --config ./.solhint.json src/scripts/ops/lib/BatchScriptV2.sol`
- `forge build --contracts src/scripts/ops/ChangeKernelExecutor.s.sol`
- `forge build --contracts src/test/proposals/OIP_194A.t.sol`
- `pnpm run lint` completed successfully with existing Solhint warnings only; no tracked files changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added treasury working group multisig support with Safe transaction logging and optional heartbeat validation skipping.

* **Chores**
  * Updated compiler version constraints across deployment and test scripts.
  * Updated configuration and ignore patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->