### PR TITLE
chore(lint): exclude irrelevant forge lint rules

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -42,6 +42,9 @@ script_execution_protection = false
 [fuzz]
 runs = 256
 
+[lint]
+exclude_lints = ["asm-keccak256", "mixed-case-variable", "mixed-case-function"]
+
 [rpc_endpoints]
 # Place ALCHEMY_API_KEY in the environment or .env file
 mainnet = { endpoint = "https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}", retries = 3, retry_backoff = 10000, compute_units_per_second = 500 }


### PR DESCRIPTION
## Summary
- add repo-wide Foundry lint exclusions for asm-keccak256, mixed-case-variable, and mixed-case-function
- remove the need for local suppressions for rules the repo intentionally does not follow

## Validation
- forge config | rg -n "\[lint\]|exclude_lints|severity|lint_on_build"
- forge lint 2>&1 | rg "^(warning|note|error)\[(asm-keccak256|mixed-case-variable|mixed-case-function)\]"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting configuration to exclude specific lint rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->