### PR TITLE
Add forge lint inline annotations

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,5 +16,11 @@ jobs:
             - name: Bootstrap
               uses: ./.github/actions/bootstrap
 
+            - name: Run forge lint inline annotations
+              uses: 0xJem/forge-lint-inline-action@7f2d23ba91fe2839c0e16034869f4881d3fd2d41 # v0.1.0
+              with:
+                  install-foundry: false
+                  fail-level: error
+
             - name: Run lint check
               run: pnpm run lint:check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,9 @@ on:
             - master
     pull_request:
 
+permissions:
+    contents: read
+
 jobs:
     lint:
         runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add `0xJem/forge-lint-inline-action` to the lint CI workflow.
- Pin the action to the commit behind `v0.1.0` while documenting the release version in the workflow.
- Reuse the existing Foundry install from bootstrap and fail only on Forge lint errors.

## Validation

- `pnpm exec prettier --check .github/workflows/lint.yml`
- `git diff --check -- .github/workflows/lint.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow to enforce stricter permissions and added enhanced linting verification to maintain code quality standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->