### PR TITLE
Patch brace-expansion vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
         "pnpm": ">=10.33.0"
     },
     "scripts": {
-        "preinstall": "npx only-allow@1.2.2 pnpm",
         "postinstall": "./shell/postinstall.sh",
         "build": "forge build",
         "prettier": "prettier --no-error-on-unmatched-pattern --write 'src/**/*.sol' '**/*.html' '.*/**/*.{sh,json,yaml,yml,toml}' '**/*.{sh,json,yaml,yml,toml}'",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   brace-expansion@>=2.0.0 <2.0.3: ^2.0.3
+  brace-expansion@>=5.0.0 <5.0.6: ^5.0.6
   cross-spawn@>=7.0.0 <7.0.5: ^7.0.5
   fast-uri: 3.1.2
   glob@>=11.0.0 <11.1.0: ^11.1.0
@@ -129,8 +130,8 @@ packages:
   brace-expansion@2.1.0:
     resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   c3-linearization@0.3.0:
@@ -688,7 +689,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -907,7 +908,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimatch@5.1.9:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ strictDepBuilds: true
 blockExoticSubdeps: true
 overrides:
     "brace-expansion@>=2.0.0 <2.0.3": "^2.0.3"
+    "brace-expansion@>=5.0.0 <5.0.6": "^5.0.6"
     "cross-spawn@>=7.0.0 <7.0.5": "^7.0.5"
     "fast-uri": "3.1.2"
     "glob@>=11.0.0 <11.1.0": "^11.1.0"


### PR DESCRIPTION
## Summary

- Add a pnpm workspace override for `brace-expansion@>=5.0.0 <5.0.6` so vulnerable `5.0.5` resolves to patched `5.0.6`.
- Regenerate `pnpm-lock.yaml` for the patched transitive dependency path.
- Remove the `npx only-allow` preinstall guard now that pnpm enforcement is handled through package manager metadata.

## Validation

- `pnpm audit --audit-level moderate` - no known vulnerabilities found
- `pnpm run lint` - passed with existing warnings
- `pnpm build` - passed with existing warnings
- `pnpm run lint:check` - passed with existing warnings
- `pnpm run test:unit` - passed, 191 suites / 2482 tests
- `coderabbit review --agent --base develop` - 0 findings

Full `pnpm run test` was not run locally because this worktree has no `.env` and no `ALCHEMY_API_KEY`; `shell/test_all.sh` sources `.env` before running fork tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the package manager validation script from the installation process.
  * Updated dependency version constraints for `brace-expansion`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OlympusDAO/olympus-v3/pull/291?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->