### PR TITLE
LZ Bridge: clear sub-action target kind entries and correct docs

### DIFF
--- a/src/policies/bridge/LZBridgeAndDelegateConfig.sol
+++ b/src/policies/bridge/LZBridgeAndDelegateConfig.sol
@@ -89,8 +89,11 @@ contract LZBridgeAndDelegateConfig is
     address public override facilitator;
 
     /// @notice Records, per queued sub-action, the `TargetKind` it was validated against at
-    ///         queue time: `_subActionTargetKind[actionId][index]`.
-    mapping(uint64 => mapping(uint256 => TargetKind)) private _subActionTargetKind;
+    ///         queue time: `subActionTargetKind[actionId][index]`.
+    /// @dev Returns `NONE` for unknown action ids or indices. Entries are cleared when
+    ///      consumed by `_executeSubAction` and on cancellation by `_onActionCancelled`, so
+    ///      no stale entries remain once an action completes.
+    mapping(uint64 actionId_ => mapping(uint256 index_ => TargetKind)) public subActionTargetKind;
 
     // ========== INITIALIZATION ========== //
 
@@ -266,7 +269,7 @@ contract LZBridgeAndDelegateConfig is
             _revertActionInvalid(action_.target, action_.selector);
         }
 
-        _subActionTargetKind[actionId_][index_] = kind;
+        subActionTargetKind[actionId_][index_] = kind;
     }
 
     /// @inheritdoc TimelockBatchQueue
@@ -307,6 +310,8 @@ contract LZBridgeAndDelegateConfig is
     ///      that kind still holds the queued address before forwarding the call.
     ///      The payload-shape checks performed at queue time are deliberately not re-run here,
     ///      since storage already holds the queued action and ABI decoding will revert on mismatch.
+    ///      The recorded kind is consumed exactly once, so its entry is cleared before
+    ///      dispatch; a revert in the dispatched call rolls the deletion back with the batch.
     ///
     ///      Reverts if:
     ///      - The recorded kind's target slot no longer holds the queued address
@@ -316,7 +321,8 @@ contract LZBridgeAndDelegateConfig is
         uint256 index_,
         ITimelockBatchQueue.BatchAction memory action_
     ) internal override {
-        TargetKind kind = _subActionTargetKind[actionId_][index_];
+        TargetKind kind = subActionTargetKind[actionId_][index_];
+        delete subActionTargetKind[actionId_][index_];
         if (kind == TargetKind.GATEWAY) {
             _requireTargetUnchanged(actionId_, index_, action_.target, gateway);
             _executeGatewaySubAction(action_);
@@ -331,6 +337,15 @@ contract LZBridgeAndDelegateConfig is
             _executeSelfSubAction(action_);
         } else {
             _revertActionInvalid(action_.target, action_.selector);
+        }
+    }
+
+    /// @inheritdoc TimelockBatchQueue
+    /// @dev Clears the per-sub-action `TargetKind` entries recorded at queue time so no
+    ///      stale entries remain after cancellation.
+    function _onActionCancelled(uint64 actionId_, uint256 subActionCount_) internal override {
+        for (uint256 i = 0; i < subActionCount_; ++i) {
+            delete subActionTargetKind[actionId_][i];
         }
     }
 

--- a/src/policies/bridge/LZBridgeAndDelegateConfig.sol
+++ b/src/policies/bridge/LZBridgeAndDelegateConfig.sol
@@ -35,6 +35,9 @@ import {ADMIN_ROLE, EMERGENCY_ROLE, BRIDGE_ADMIN_ROLE, BRIDGE_RATE_LIMITER_ROLE}
 ///      rotations cannot be smuggled into an arbitrary batch. Cancellation is gated to the
 ///      emergency role only, so the proposer cannot rescind its own queued action; the
 ///      emergency role is intended for a multisig veto independent of the proposer roles.
+///      Disabling the policy suspends queueing and execution but does not clear queued
+///      actions; before re-enabling, the emergency role must cancel any queued action that
+///      should not become executable again.
 contract LZBridgeAndDelegateConfig is
     Policy,
     PolicyEnablerV2,
@@ -280,6 +283,13 @@ contract LZBridgeAndDelegateConfig is
     ///      per sub-action in `_executeSubAction`: dispatch is by the `TargetKind` recorded at
     ///      queue time.
     ///
+    ///      Disabling the policy suspends execution but does not clear the queue: queued
+    ///      actions remain in storage and become executable again once the policy is
+    ///      re-enabled, for as long as their execution windows have not expired. Before
+    ///      re-enabling, the emergency role must therefore cancel every queued action that
+    ///      should not survive the disable, such as an action queued by a compromised
+    ///      proposer.
+    ///
     ///      Reverts if:
     ///      - The policy is disabled
     function _validateExecution(
@@ -293,7 +303,7 @@ contract LZBridgeAndDelegateConfig is
     /// @inheritdoc TimelockBatchQueue
     /// @dev Cancellation is restricted to the emergency role; the proposer cannot rescind
     ///      its own queued action. Intentionally permitted while the policy is disabled so
-    ///      stale or malicious queued actions can be cleared.
+    ///      stale or unwanted queued actions can be cleared before the policy is re-enabled.
     ///
     ///      Reverts if:
     ///      - The caller does not have the emergency role

--- a/src/policies/interfaces/ILZBridgeGateway.sol
+++ b/src/policies/interfaces/ILZBridgeGateway.sol
@@ -179,9 +179,10 @@ interface ILZBridgeGateway is IOffsettingRateLimiter {
     ///
     ///      The delegate is authorized to configure anything on the LayerZero endpoint
     ///      on behalf of this contract (e.g. send/receive libraries, DVN config).
-    ///      Pass `address(0)` to clear the delegate.
+    ///      `delegate_` must be nonzero: the delegate cannot be cleared, only replaced
+    ///      with another nonzero address.
     ///
-    /// @param delegate_ The new delegate address, or `address(0)` to clear.
+    /// @param delegate_ The new delegate address; must be nonzero.
     function setDelegate(address delegate_) external;
 
     /// @notice One-shot bootstrap of the bridged supply on the canonical chain.

--- a/src/policies/interfaces/utils/ITimelockBatchQueue.sol
+++ b/src/policies/interfaces/utils/ITimelockBatchQueue.sol
@@ -12,6 +12,12 @@ pragma solidity >=0.8.15;
 ///
 ///         Atomicity is a property of the batch lifecycle: a revert in any sub-action validator
 ///         or executor reverts the entire batch.
+///
+///         Ordering is a property of a single batch only: sub-actions execute in array order
+///         within their batch, but no ordering is enforced across separately queued actions,
+///         so independently queued batches may execute in any order once their timelocks
+///         elapse. Actions with execution-order dependencies must be queued within a single
+///         batch; independent batches must not be assumed to execute in queue order.
 interface ITimelockBatchQueue {
     // ========== EVENTS ========== //
 
@@ -233,7 +239,9 @@ interface ITimelockBatchQueue {
     /// @dev    Implementations must revert from implementation-specific hooks if the caller or
     ///         any sub-action should not be executed. Standard action state and timestamp
     ///         checks revert from the abstract implementation. The batch is atomic: a revert
-    ///         in any sub-action reverts the entire batch.
+    ///         in any sub-action reverts the entire batch. Cross-batch ordering is not
+    ///         enforced: once their timelocks elapse, separately queued actions may be
+    ///         executed in any order, regardless of the order in which they were queued.
     ///
     /// @param  actionId_ The queued action ID.
     function executeQueuedAction(uint64 actionId_) external;

--- a/src/policies/utils/TimelockBatchQueue.sol
+++ b/src/policies/utils/TimelockBatchQueue.sol
@@ -12,6 +12,11 @@ import {ITimelockBatchQueue} from "src/policies/interfaces/utils/ITimelockBatchQ
 ///         construction: a revert in any sub-action validator or executor rolls back the entire
 ///         batch.
 ///
+///         Sub-actions execute in array order within a batch, but no ordering is enforced
+///         across separately queued actions: execution is permissionless once a timelock
+///         elapses, so independently queued batches may execute in any order. Actions with
+///         execution-order dependencies must be queued within a single batch.
+///
 ///         Lifecycle:
 ///         - `_queueAction` enforces the configured batch size bounds, calls
 ///           `_onSubActionQueued` per sub-action and `_onBatchQueued` once for cross-sub

--- a/src/policies/utils/TimelockBatchQueue.sol
+++ b/src/policies/utils/TimelockBatchQueue.sol
@@ -27,7 +27,9 @@ import {ITimelockBatchQueue} from "src/policies/interfaces/utils/ITimelockBatchQ
 ///           `TimelockActionExecuted` event is emitted.
 ///         - `cancelQueuedAction` validates standard cancellable state, delegates
 ///           implementation-specific cancellation authorization to `_validateCancellation`,
-///           clears the stored sub-actions, and emits `TimelockActionCancelled`.
+///           clears the stored sub-actions, calls `_onActionCancelled` so derived contracts
+///           can clear per-sub-action state recorded at queue time, and emits
+///           `TimelockActionCancelled`.
 ///
 ///         Derived contracts must implement the virtual hooks by reverting on failure. Hooks
 ///         should not return booleans; a successful return means the hook accepted the
@@ -149,6 +151,7 @@ abstract contract TimelockBatchQueue is ITimelockBatchQueue, ERC165 {
     ///             - The action has already been executed
     ///             - The action has been cancelled
     ///             - `_validateCancellation` reverts
+    ///             - `_onActionCancelled` reverts
     function cancelQueuedAction(uint64 actionId_) external {
         ITimelockBatchQueue.QueuedAction storage action = _queuedActions[actionId_];
         _validateCancellableState(actionId_, action);
@@ -156,7 +159,11 @@ abstract contract TimelockBatchQueue is ITimelockBatchQueue, ERC165 {
         _validateCancellation(msg.sender, actionId_, action);
 
         action.cancelled = true;
+
+        uint256 len = action.actions.length;
         delete action.actions;
+
+        _onActionCancelled(actionId_, len);
 
         emit TimelockActionCancelled(actionId_, msg.sender);
     }
@@ -359,6 +366,17 @@ abstract contract TimelockBatchQueue is ITimelockBatchQueue, ERC165 {
         uint64 actionId_,
         ITimelockBatchQueue.QueuedAction storage action_
     ) internal view virtual;
+
+    /// @notice Hook invoked once when a queued action is cancelled, after the stored
+    ///         sub-actions have been cleared.
+    /// @dev    Default implementation is a no-op. Derived contracts override to clear any
+    ///         per-sub-action state recorded at queue time by `_onSubActionQueued`. The
+    ///         sub-action count is captured before the stored array is deleted, so
+    ///         implementations can iterate the indices that were recorded.
+    ///
+    /// @param  actionId_       The cancelled action ID.
+    /// @param  subActionCount_ The number of sub-actions the action held before clearing.
+    function _onActionCancelled(uint64 actionId_, uint256 subActionCount_) internal virtual {}
 
     /// @notice Execute a single sub-action of a batched queued action.
     /// @dev    Derived contracts must revert on failure. Called by the base contract once per

--- a/src/test/policies/bridge/LZBridgeAndDelegateConfig/LZBridgeAndDelegateConfig_CancelQueuedAction.t.sol
+++ b/src/test/policies/bridge/LZBridgeAndDelegateConfig/LZBridgeAndDelegateConfig_CancelQueuedAction.t.sol
@@ -4,8 +4,10 @@ pragma solidity >=0.8.30;
 import {LZBridgeAndDelegateConfigTestBase} from "src/test/policies/bridge/LZBridgeAndDelegateConfig/LZBridgeAndDelegateConfigTestBase.sol";
 
 // Interfaces
-import {ITimelockBatchQueue} from "src/policies/interfaces/utils/ITimelockBatchQueue.sol";
+import {IGracePeriod} from "src/bases/interfaces/IGracePeriod.sol";
+import {ILZBridgeAndDelegateConfig} from "src/policies/interfaces/ILZBridgeAndDelegateConfig.sol";
 import {ILZBridgeGateway} from "src/policies/interfaces/ILZBridgeGateway.sol";
+import {ITimelockBatchQueue} from "src/policies/interfaces/utils/ITimelockBatchQueue.sol";
 
 // Contracts
 import {ROLESv1} from "src/modules/ROLES/ROLES.v1.sol";
@@ -53,6 +55,50 @@ contract LZBridgeAndDelegateConfigTests_CancelQueuedAction is LZBridgeAndDelegat
         // operators can flush stale entries before re-enabling.
         vm.prank(emergency);
         config.cancelQueuedAction(actionId);
+    }
+
+    /// @dev The per-sub-action `TargetKind` entries recorded at queue time are cleared on
+    ///      cancellation, so no stale storage remains for the cancelled action.
+    function test_cancel_clearsSubActionTargetKind() external {
+        ITimelockBatchQueue.BatchAction[] memory batch = new ITimelockBatchQueue.BatchAction[](2);
+        batch[0] = ITimelockBatchQueue.BatchAction({
+            target: address(gateway),
+            selector: ILZBridgeGateway.increaseBridgedSupply.selector,
+            payload: abi.encode(uint256(1))
+        });
+        batch[1] = ITimelockBatchQueue.BatchAction({
+            target: address(facilitator),
+            selector: IGracePeriod.setGracePeriod.selector,
+            payload: abi.encode(uint32(123))
+        });
+
+        vm.prank(bridgeAdmin);
+        uint64 actionId = config.queue(batch);
+
+        assertEq(
+            uint256(config.subActionTargetKind(actionId, 0)),
+            uint256(ILZBridgeAndDelegateConfig.TargetKind.GATEWAY),
+            "Sub-action 0 kind should be GATEWAY after queueing"
+        );
+        assertEq(
+            uint256(config.subActionTargetKind(actionId, 1)),
+            uint256(ILZBridgeAndDelegateConfig.TargetKind.FACILITATOR),
+            "Sub-action 1 kind should be FACILITATOR after queueing"
+        );
+
+        vm.prank(emergency);
+        config.cancelQueuedAction(actionId);
+
+        assertEq(
+            uint256(config.subActionTargetKind(actionId, 0)),
+            uint256(ILZBridgeAndDelegateConfig.TargetKind.NONE),
+            "Sub-action 0 kind should be cleared after cancellation"
+        );
+        assertEq(
+            uint256(config.subActionTargetKind(actionId, 1)),
+            uint256(ILZBridgeAndDelegateConfig.TargetKind.NONE),
+            "Sub-action 1 kind should be cleared after cancellation"
+        );
     }
 
     function test_cancel_revertsForUnknownAction() external {

--- a/src/test/policies/bridge/LZBridgeAndDelegateConfig/LZBridgeAndDelegateConfig_ExecuteQueuedAction.t.sol
+++ b/src/test/policies/bridge/LZBridgeAndDelegateConfig/LZBridgeAndDelegateConfig_ExecuteQueuedAction.t.sol
@@ -136,6 +136,50 @@ contract LZBridgeAndDelegateConfigTests_ExecuteQueuedAction is LZBridgeAndDelega
         );
     }
 
+    /// @dev The per-sub-action `TargetKind` entries recorded at queue time are consumed and
+    ///      cleared by execution, so no stale storage remains for the completed action.
+    function test_execute_clearsSubActionTargetKind() external {
+        ITimelockBatchQueue.BatchAction[] memory batch = new ITimelockBatchQueue.BatchAction[](2);
+        batch[0] = ITimelockBatchQueue.BatchAction({
+            target: address(gateway),
+            selector: ILZBridgeGateway.increaseBridgedSupply.selector,
+            payload: abi.encode(uint256(1))
+        });
+        batch[1] = ITimelockBatchQueue.BatchAction({
+            target: address(facilitator),
+            selector: IGracePeriod.setGracePeriod.selector,
+            payload: abi.encode(uint32(123))
+        });
+
+        vm.prank(bridgeAdmin);
+        uint64 actionId = config.queue(batch);
+
+        assertEq(
+            uint256(config.subActionTargetKind(actionId, 0)),
+            uint256(ILZBridgeAndDelegateConfig.TargetKind.GATEWAY),
+            "Sub-action 0 kind should be GATEWAY after queueing"
+        );
+        assertEq(
+            uint256(config.subActionTargetKind(actionId, 1)),
+            uint256(ILZBridgeAndDelegateConfig.TargetKind.FACILITATOR),
+            "Sub-action 1 kind should be FACILITATOR after queueing"
+        );
+
+        _warpPastTimelock();
+        config.executeQueuedAction(actionId);
+
+        assertEq(
+            uint256(config.subActionTargetKind(actionId, 0)),
+            uint256(ILZBridgeAndDelegateConfig.TargetKind.NONE),
+            "Sub-action 0 kind should be cleared after execution"
+        );
+        assertEq(
+            uint256(config.subActionTargetKind(actionId, 1)),
+            uint256(ILZBridgeAndDelegateConfig.TargetKind.NONE),
+            "Sub-action 1 kind should be cleared after execution"
+        );
+    }
+
     // ========== STATE GUARDS ========== //
 
     function test_execute_revertsBeforeTimelockElapsed() external {

--- a/src/test/policies/utils/TimelockBatchQueue/TimelockBatchQueue.t.sol
+++ b/src/test/policies/utils/TimelockBatchQueue/TimelockBatchQueue.t.sol
@@ -29,6 +29,11 @@ contract MockTimelockBatchQueue is TimelockBatchQueue {
         bytes32 payloadHash;
     }
 
+    struct OnActionCancelledCall {
+        uint64 actionId;
+        uint256 subActionCount;
+    }
+
     uint48 public constant MIN_DELAY = 1 days;
     uint48 public constant MAX_DELAY = 30 days;
     uint256 internal constant _NO_REJECT_INDEX = type(uint256).max;
@@ -50,6 +55,7 @@ contract MockTimelockBatchQueue is TimelockBatchQueue {
     uint256[] public executedValues;
 
     ExecuteSubActionCall[] internal _executeSubActionCalls;
+    OnActionCancelledCall[] internal _onActionCancelledCalls;
 
     constructor(uint48 initialTimelockDelay_) TimelockBatchQueue(initialTimelockDelay_) {}
 
@@ -125,6 +131,10 @@ contract MockTimelockBatchQueue is TimelockBatchQueue {
         return _executeSubActionCalls;
     }
 
+    function getOnActionCancelledCalls() external view returns (OnActionCancelledCall[] memory) {
+        return _onActionCancelledCalls;
+    }
+
     function getExecutedValues() external view returns (uint256[] memory) {
         return executedValues;
     }
@@ -177,6 +187,12 @@ contract MockTimelockBatchQueue is TimelockBatchQueue {
         if (rejectCancellation) revert MockTimelockBatchQueue_CancellationRejected();
         if (cancellationCaller != address(0) && caller_ != cancellationCaller)
             revert MockTimelockBatchQueue_CancellationRejected();
+    }
+
+    function _onActionCancelled(uint64 actionId_, uint256 subActionCount_) internal override {
+        _onActionCancelledCalls.push(
+            OnActionCancelledCall({actionId: actionId_, subActionCount: subActionCount_})
+        );
     }
 
     function _executeSubAction(
@@ -1098,6 +1114,7 @@ contract TimelockBatchQueueTest is Test {
     //  [X] one TimelockSubActionExecuted then TimelockActionExecuted emitted, in order
     //  [X] action.executed = true and actions cleared
     //  [X] executedValues records the decoded payload
+    //  [X] _onActionCancelled is not called
     function test_executeQueuedAction_singleAction_succeeds() public {
         uint64 actionId = _queueSingleAction();
         _warpReady(actionId, type(uint256).max);
@@ -1125,6 +1142,8 @@ contract TimelockBatchQueueTest is Test {
         assertEq(calls[0].index, 0, "call index");
         assertEq(calls[0].target, target1, "call target");
         assertEq(calls[0].selector, selector1, "call selector");
+
+        assertEq(queue.getOnActionCancelledCalls().length, 0, "_onActionCancelled not called");
     }
 
     // given a 3-element batch is ready
@@ -1218,6 +1237,7 @@ contract TimelockBatchQueueTest is Test {
     //  [X] cancelQueuedAction reverts
     //  [X] action.cancelled remains false
     //  [X] actions retained
+    //  [X] _onActionCancelled is not called
     function test_cancelQueuedAction_givenValidateCancellationRejects_reverts() public {
         uint64 actionId = _queueSingleAction();
         queue.setRejectCancellation(true);
@@ -1227,10 +1247,12 @@ contract TimelockBatchQueueTest is Test {
         queue.cancelQueuedAction(actionId);
         assertEq(queue.getQueuedAction(actionId).cancelled, false, "cancelled false");
         assertEq(queue.getQueuedActionLength(actionId), 1, "actions retained");
+        assertEq(queue.getOnActionCancelledCalls().length, 0, "_onActionCancelled not called");
     }
 
     // given a single-action queue
     //  [X] cancelQueuedAction emits TimelockActionCancelled, sets cancelled, clears actions
+    //  [X] _onActionCancelled is called once with (actionId, 1)
     function test_cancelQueuedAction_single_succeeds(address canceller_) public {
         vm.assume(canceller_ != address(0));
         uint64 actionId = _queueSingleAction();
@@ -1241,10 +1263,17 @@ contract TimelockBatchQueueTest is Test {
         ITimelockBatchQueue.QueuedAction memory a = queue.getQueuedAction(actionId);
         assertEq(a.cancelled, true, "cancelled");
         assertEq(a.actions.length, 0, "actions cleared");
+
+        MockTimelockBatchQueue.OnActionCancelledCall[] memory calls = queue
+            .getOnActionCancelledCalls();
+        assertEq(calls.length, 1, "_onActionCancelled called once");
+        assertEq(calls[0].actionId, actionId, "_onActionCancelled actionId");
+        assertEq(calls[0].subActionCount, 1, "_onActionCancelled subActionCount");
     }
 
     // given a 3-element batch
     //  [X] cancelQueuedAction emits TimelockActionCancelled, sets cancelled, clears actions
+    //  [X] _onActionCancelled is called once with (actionId, 3)
     function test_cancelQueuedAction_batch_succeeds(address canceller_) public {
         vm.assume(canceller_ != address(0));
         (uint64 actionId, ) = _queueThreeBatch();
@@ -1255,6 +1284,12 @@ contract TimelockBatchQueueTest is Test {
         ITimelockBatchQueue.QueuedAction memory a = queue.getQueuedAction(actionId);
         assertEq(a.cancelled, true, "cancelled");
         assertEq(a.actions.length, 0, "actions cleared");
+
+        MockTimelockBatchQueue.OnActionCancelledCall[] memory calls = queue
+            .getOnActionCancelledCalls();
+        assertEq(calls.length, 1, "_onActionCancelled called once");
+        assertEq(calls[0].actionId, actionId, "_onActionCancelled actionId");
+        assertEq(calls[0].subActionCount, 3, "_onActionCancelled subActionCount");
     }
 
     // given an action is past executableAt but not yet expired


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sub-action target kind tracking is now properly exposed and consumed on execution.

* **Bug Fixes**
  * Cancellation now clears stale target kind records, preventing orphaned data after action cancellations.

* **Documentation**
  * Clarified execution ordering semantics: sub-actions execute sequentially within batches; cross-batch ordering is not enforced.
  * Updated delegate management: delegates cannot be cleared, only replaced with another valid address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->