### PR TITLE
Replace Pyth price feeds with API3

### DIFF
--- a/documentation/price.md
+++ b/documentation/price.md
@@ -59,42 +59,43 @@ This allows `ERC7726OracleCloneable`, `MorphoOracleFactory`, and `ChainlinkOracl
 
 ## Assets
 
-| Asset | Address | Price Feeds | Strategy | Store MA | Use MA | MA Duration |
-| ----- | ------- | ----------- | -------- | -------- | ------ | ----------- |
-| USDS | [0xdC0...84F](https://etherscan.io/address/0xdC035D45d973E3EC169d2276DDab16f1e407384F) | [Chainlink USDS-USD](https://etherscan.io/address/0xfF30586cD0F29eD462364C7e81375FC0C71219b1), [Chainlink DAI-USD](https://etherscan.io/address/0xAed0c38402a5d19df6E4c03F4E2DceD6e29c1ee9), [Pyth USDS-USD](https://insights.pyth.network/price-feeds/Crypto.USDS%2FUSD) | `getAveragePriceExcludingDeviations()` with 1% price-feed deviation and revert on insufficient price feeds | No | No | 0 |
-| sUSDS | [0xa39...fbD](https://etherscan.io/address/0xa3931d71877C0E7a3148CB7Eb4463524FEc27fbD) | ERC4626 Submodule | None | No | No | 0 |
-| wETH | [0xc02...cc2](https://etherscan.io/address/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2) | [Chainlink ETH-USD](https://etherscan.io/address/0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419), [RedStone ETH-USD](https://etherscan.io/address/0x67F6838e58859d612E4ddF04dA396d6DABB66Dc4), [Pyth ETH-USD](https://insights.pyth.network/price-feeds/Crypto.ETH%2FUSD), [ETH-BTC](https://etherscan.io/address/0xAc559F25B1619171CbC396a50854A3240b6A4e99)x[BTC-USD](https://etherscan.io/address/0xF4030086522a5bEEa4988F8cA5B36dbC97BeE88c) | `getAveragePriceExcludingDeviations()` with 5% price-feed deviation and revert on insufficient price feeds | No | No | 0 |
-| OHM | [0x64a...1d5](https://etherscan.io/address/0x64aa3364f17a4d01c6f1751fd97c2bd3d7e7f1d5) | [Uniswap V3 OHM/WETH](https://etherscan.io/address/0x88051b0eea095007d3bef21ab287be961f3d8598), [Uniswap V3 OHM/sUSDS](https://etherscan.io/address/0x0858e2b0f9d75f7300b38d64482ac2c8df06a755), [Chainlink OHM-ETH](https://etherscan.io/address/0x9a72298ae3886221820B1c878d12D872087D3a23)x[Chainlink ETH-USD](https://etherscan.io/address/0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419) | `getAveragePriceExcludingDeviations()` with 2% price-feed deviation and revert on insufficient price feeds | Yes | No | 2592000 (30 days) |
+| Asset | Address                                                                                | Price Feeds                                                                                                                                                                                                                                                                                                                                                                                                                                               | Strategy                                                                                                   | Store MA | Use MA | MA Duration       |
+| ----- | -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | -------- | ------ | ----------------- |
+| USDS  | [0xdC0...84F](https://etherscan.io/address/0xdC035D45d973E3EC169d2276DDab16f1e407384F) | [Chainlink USDS-USD](https://etherscan.io/address/0xfF30586cD0F29eD462364C7e81375FC0C71219b1), [Chainlink DAI-USD](https://etherscan.io/address/0xAed0c38402a5d19df6E4c03F4E2DceD6e29c1ee9), API3 USDS-USD                                                                                                                                                                                                                                                | `getAveragePriceExcludingDeviations()` with 1% price-feed deviation and revert on insufficient price feeds | No       | No     | 0                 |
+| sUSDS | [0xa39...fbD](https://etherscan.io/address/0xa3931d71877C0E7a3148CB7Eb4463524FEc27fbD) | ERC4626 Submodule                                                                                                                                                                                                                                                                                                                                                                                                                                         | None                                                                                                       | No       | No     | 0                 |
+| wETH  | [0xc02...cc2](https://etherscan.io/address/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2) | [Chainlink ETH-USD](https://etherscan.io/address/0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419), [RedStone ETH-USD](https://etherscan.io/address/0x67F6838e58859d612E4ddF04dA396d6DABB66Dc4), [API3 ETH-USD](https://etherscan.io/address/0x5b0cf2b36a65a6BB085D501B971e4c102B9Cd473), [ETH-BTC](https://etherscan.io/address/0xAc559F25B1619171CbC396a50854A3240b6A4e99)x[BTC-USD](https://etherscan.io/address/0xF4030086522a5bEEa4988F8cA5B36dbC97BeE88c) | `getAveragePriceExcludingDeviations()` with 5% price-feed deviation and revert on insufficient price feeds | No       | No     | 0                 |
+| OHM   | [0x64a...1d5](https://etherscan.io/address/0x64aa3364f17a4d01c6f1751fd97c2bd3d7e7f1d5) | [Uniswap V3 OHM/WETH](https://etherscan.io/address/0x88051b0eea095007d3bef21ab287be961f3d8598), [Uniswap V3 OHM/sUSDS](https://etherscan.io/address/0x0858e2b0f9d75f7300b38d64482ac2c8df06a755), [Chainlink OHM-ETH](https://etherscan.io/address/0x9a72298ae3886221820B1c878d12D872087D3a23)x[Chainlink ETH-USD](https://etherscan.io/address/0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419)                                                                | `getAveragePriceExcludingDeviations()` with 2% price-feed deviation and revert on insufficient price feeds | Yes      | No     | 2592000 (30 days) |
 
 ### Final Configuration Values
 
-The following values match `src/scripts/ops/batches/args/ConfigurePriceV1_2.json`.
+The following values describe the target oracle configuration. Update `src/scripts/ops/batches/args/ConfigurePriceV1_2.json` with the live API3 USDS-USD reader proxy before deployment.
 
-| Asset | Strategy | Price-Feed Deviation | Revert on Insufficient Price Feeds | Expected Price | Expected Tolerance |
-| ----- | -------- | -------------------- | ---------------------------------- | -------------- | ------------------ |
-| USDS | `getAveragePriceExcludingDeviations()` | 100 bps | Yes | 1e18 | 100 bps |
-| sUSDS | None, uses ERC4626 feed only | N/A | N/A | 1.095038992740982406e18 | 100 bps |
-| wETH | `getAveragePriceExcludingDeviations()` | 500 bps | Yes | 2282.17e18 | 500 bps |
-| OHM | `getAveragePriceExcludingDeviations()` | 200 bps | Yes | 19.5e18 | 500 bps |
+| Asset | Strategy                               | Price-Feed Deviation | Revert on Insufficient Price Feeds | Expected Price          | Expected Tolerance |
+| ----- | -------------------------------------- | -------------------- | ---------------------------------- | ----------------------- | ------------------ |
+| USDS  | `getAveragePriceExcludingDeviations()` | 100 bps              | Yes                                | 1e18                    | 100 bps            |
+| sUSDS | None, uses ERC4626 feed only           | N/A                  | N/A                                | 1.095038992740982406e18 | 100 bps            |
+| wETH  | `getAveragePriceExcludingDeviations()` | 500 bps              | Yes                                | 2282.17e18              | 500 bps            |
+| OHM   | `getAveragePriceExcludingDeviations()` | 200 bps              | Yes                                | 19.5e18                 | 500 bps            |
 
-| Asset | Feed Path | Source | Update Threshold | Observation Window | Max Confidence |
-| ----- | --------- | ------ | ---------------- | ------------------ | -------------- |
-| USDS | Chainlink USDS-USD | `chainlinkUsdsUsd` | 86,400 sec (24 hours) | N/A | N/A |
-| USDS | Chainlink DAI-USD | `chainlinkDaiUsd` | 86,400 sec (24 hours) | N/A | N/A |
-| USDS | Pyth USDS-USD | `pythUsdsUsdFeedId` | 86,400 sec (24 hours) | N/A | 0.01e18 ($0.01) |
-| sUSDS | ERC4626 derived from USDS | `getPriceFromUnderlying(sUSDS)` | N/A | N/A | N/A |
-| wETH | Chainlink ETH-USD | `chainlinkEthUsd` | 3,600 sec (1 hour) | N/A | N/A |
-| wETH | RedStone ETH-USD | `redstoneEthUsd` | 86,400 sec (24 hours) | N/A | N/A |
-| wETH | Pyth ETH-USD | `pythEthUsdFeedId` | 3,600 sec (1 hour) | N/A | 10e18 ($10) |
-| wETH | Chainlink ETH-BTC leg | `chainlinkEthBtc` | 86,400 sec (24 hours) | N/A | N/A |
-| wETH | Chainlink BTC-USD leg | `chainlinkBtcUsd` | 3,600 sec (1 hour) | N/A | N/A |
-| OHM | Uniswap V3 OHM/WETH | `uniswapOhmWeth` | N/A | 1,500 sec (25 min) | N/A |
-| OHM | Uniswap V3 OHM/sUSDS | `uniswapOhmSusds` | N/A | 1,500 sec (25 min) | N/A |
-| OHM | Chainlink OHM-ETH leg | env `external.chainlink.ohmEthPriceFeed` | 86,400 sec (24 hours) | N/A | N/A |
-| OHM | Chainlink ETH-USD leg | `chainlinkEthUsd` | 3,600 sec (1 hour) | N/A | N/A |
+| Asset | Feed Path                 | Source                                   | Update Threshold      | Observation Window | Max Confidence |
+| ----- | ------------------------- | ---------------------------------------- | --------------------- | ------------------ | -------------- |
+| USDS  | Chainlink USDS-USD        | `chainlinkUsdsUsd`                       | 86,400 sec (24 hours) | N/A                | N/A            |
+| USDS  | Chainlink DAI-USD         | `chainlinkDaiUsd`                        | 86,400 sec (24 hours) | N/A                | N/A            |
+| USDS  | API3 USDS-USD             | `api3UsdsUsd`                            | 90,000 sec (25 hours) | N/A                | N/A            |
+| sUSDS | ERC4626 derived from USDS | `getPriceFromUnderlying(sUSDS)`          | N/A                   | N/A                | N/A            |
+| wETH  | Chainlink ETH-USD         | `chainlinkEthUsd`                        | 3,600 sec (1 hour)    | N/A                | N/A            |
+| wETH  | RedStone ETH-USD          | `redstoneEthUsd`                         | 86,400 sec (24 hours) | N/A                | N/A            |
+| wETH  | API3 ETH-USD              | `api3EthUsd`                             | 90,000 sec (25 hours) | N/A                | N/A            |
+| wETH  | Chainlink ETH-BTC leg     | `chainlinkEthBtc`                        | 86,400 sec (24 hours) | N/A                | N/A            |
+| wETH  | Chainlink BTC-USD leg     | `chainlinkBtcUsd`                        | 3,600 sec (1 hour)    | N/A                | N/A            |
+| OHM   | Uniswap V3 OHM/WETH       | `uniswapOhmWeth`                         | N/A                   | 1,500 sec (25 min) | N/A            |
+| OHM   | Uniswap V3 OHM/sUSDS      | `uniswapOhmSusds`                        | N/A                   | 1,500 sec (25 min) | N/A            |
+| OHM   | Chainlink OHM-ETH leg     | env `external.chainlink.ohmEthPriceFeed` | 86,400 sec (24 hours) | N/A                | N/A            |
+| OHM   | Chainlink ETH-USD leg     | `chainlinkEthUsd`                        | 3,600 sec (1 hour)    | N/A                | N/A            |
 
-- Ultimately, price resolution for all assets into USD will be reliant on a combination of Chainlink, RedStone, Pyth and Chainlink-derived (ETH-BTC × BTC-USD) oracles.
-- The price of USDS will be determined as the average of the price feeds from 3 sources: 2 Chainlink feeds (USDS-USD and DAI-USD) and 1 Pyth feed (USDS-USD).
+- Ultimately, price resolution for all assets into USD will be reliant on a combination of Chainlink, RedStone, API3 and Chainlink-derived (ETH-BTC × BTC-USD) oracles.
+- Pyth feeds are not included in the target configuration because the protocol would need paid Hermes access to reliably operate the required feed updates. This would add an external subscription dependency for the PRICE module and make the oracle path reliant on a paid off-chain update service.
+- The price of USDS will be determined as the average of the price feeds from 3 sources: 2 Chainlink feeds (USDS-USD and DAI-USD) and 1 API3 feed (USDS-USD).
     - After any zero value or deviating values (> 1% from the median) have been excluded, the average is taken.
     - This ensures that price feeds that are deviating don't alter the average.
     - Strict mode will be enabled, which means that if there are insufficient remaining values to make an average (2), the price resolution will fail.
@@ -117,20 +118,20 @@ The following values match `src/scripts/ops/batches/args/ConfigurePriceV1_2.json
 
 The **update threshold** is the maximum number of seconds that can elapse since the last price feed update before the price is considered stale. If a feed's last update is older than this threshold, the feed returns zero and is excluded from price calculation.
 
-| Asset | Feed | Update Threshold |
-| ----- | ---- | ---------------- |
-| USDS | Chainlink USDS-USD | 86,400 sec (24 hours) |
-| USDS | Chainlink DAI-USD | 86,400 sec (24 hours) |
-| USDS | Pyth USDS-USD | 86,400 sec (24 hours) |
-| wETH | Chainlink ETH-USD | 3,600 sec (1 hour) |
-| wETH | RedStone ETH-USD | 86,400 sec (24 hours) |
-| wETH | Pyth ETH-USD | 3,600 sec (1 hour) |
-| wETH | Chainlink ETH-BTC leg | 86,400 sec (24 hours) |
-| wETH | Chainlink BTC-USD leg | 3,600 sec (1 hour) |
-| OHM | Chainlink OHM-ETH | 86,400 sec (24 hours) |
-| OHM | Chainlink OHM-ETH × ETH-USD | 3,600 sec (1 hour) for ETH-USD |
+| Asset | Feed                        | Update Threshold               |
+| ----- | --------------------------- | ------------------------------ |
+| USDS  | Chainlink USDS-USD          | 86,400 sec (24 hours)          |
+| USDS  | Chainlink DAI-USD           | 86,400 sec (24 hours)          |
+| USDS  | API3 USDS-USD               | 90,000 sec (25 hours)          |
+| wETH  | Chainlink ETH-USD           | 3,600 sec (1 hour)             |
+| wETH  | RedStone ETH-USD            | 86,400 sec (24 hours)          |
+| wETH  | API3 ETH-USD                | 90,000 sec (25 hours)          |
+| wETH  | Chainlink ETH-BTC leg       | 86,400 sec (24 hours)          |
+| wETH  | Chainlink BTC-USD leg       | 3,600 sec (1 hour)             |
+| OHM   | Chainlink OHM-ETH           | 86,400 sec (24 hours)          |
+| OHM   | Chainlink OHM-ETH × ETH-USD | 3,600 sec (1 hour) for ETH-USD |
 
-> **IMPORTANT:** Pyth price feeds require regular price updates to remain valid. If the feed is not updated within the `updateThreshold` period, the price resolution will fail. Use the [pyth-price-pusher](https://github.com/OlympusDAO/pyth-price-pusher) tool to manage automated price updates for all Pyth feeds.
+> **IMPORTANT:** API3 feeds are consumed through Chainlink-interface compatible reader proxies. The configured update threshold is 25 hours for feeds with a 24-hour heartbeat. This gives a one-hour grace period for heartbeat updates that land slightly late, while still failing stale feeds promptly if an update is missed. API3 feed operation also requires regular payment to keep the reader proxy active and the feed updating.
 
 #### Observation Window (Uniswap TWAP Only)
 
@@ -140,35 +141,10 @@ The **observation window** is used only for Uniswap V3 price feeds to calculate 
 - The TWAP is calculated by averaging observations within the window
 - A longer window = more manipulation resistance but slower price updates
 
-| Asset | Feed | Observation Window |
-| ----- | ---- | ------------------ |
-| OHM | Uniswap V3 OHM/WETH | 1,500 sec (25 min) |
-| OHM | Uniswap V3 OHM/sUSDS | 1,500 sec (25 min) |
-
-#### Max Confidence Interval (Pyth Only)
-
-The **max confidence interval** is a Pyth-specific parameter that sets the maximum acceptable confidence interval for a price. Pyth returns a confidence value representing the uncertainty range around the reported price. If the confidence interval exceeds this threshold, the feed is considered unreliable and returns zero.
-
-- Confidence is measured in the same decimals as the price (18 decimals)
-- Higher confidence values = more uncertainty in the price
-- A zero confidence indicates a very precise price
-
-| Asset | Pyth Feed | Max Confidence |
-| ----- | --------- | -------------- |
-| USDS | Pyth USDS-USD | 0.01e18 ($0.01) |
-| wETH | Pyth ETH-USD | 10e18 ($10) |
-
-**How Confidence is Used:**
-
-1. Pyth returns both a `price` and a `conf` (confidence) value
-2. The contract converts `maxConfidence` from 18-decimal scale to Pyth's native scale (based on the feed's exponent)
-3. If the converted value exceeds `uint64`, it is clamped to `type(uint64).max`
-4. If `priceData.conf > maxConfidenceInPythScale`, the feed reverts with `Pyth_FeedConfidenceExcessive`
-5. For Pyth two-feed reads, the contract validates each feed independently, derives a conservative confidence interval for the output product or ratio, and compares it against `outputMaxConfidence`
-6. If the derived output confidence exceeds `outputMaxConfidence`, the feed reverts with `Pyth_DerivedFeedConfidenceExcessive`
-7. For division, if the denominator confidence is greater than or equal to the denominator price, the feed reverts with `Pyth_DerivedFeedConfidenceInvalid`
-
-Pyth two-feed parameters include `firstMaxConfidence`, `secondMaxConfidence`, and `outputMaxConfidence`, all in output decimals. The first two thresholds cap each input feed independently. `outputMaxConfidence` caps the uncertainty of the derived price that callers actually consume.
+| Asset | Feed                 | Observation Window |
+| ----- | -------------------- | ------------------ |
+| OHM   | Uniswap V3 OHM/WETH  | 1,500 sec (25 min) |
+| OHM   | Uniswap V3 OHM/sUSDS | 1,500 sec (25 min) |
 
 ### wETH Price Resolution
 
@@ -178,7 +154,7 @@ sequenceDiagram
     participant WETH
     participant CL_ETH as Chainlink ETH-USD
     participant RS_ETH as RedStone ETH-USD
-    participant Pyth_ETH as Pyth ETH-USD
+    participant API3_ETH as API3 ETH-USD
     participant CL_ETHBTC as Chainlink ETH-BTC
     participant CL_BTCUSD as Chainlink BTC-USD
 
@@ -192,9 +168,9 @@ sequenceDiagram
     and RedStone ETH-USD Path
         WETH->>RS_ETH: latestRoundData()
         RS_ETH-->>WETH: ETH-USD price
-    and Pyth ETH-USD Path
-        WETH->>Pyth_ETH: latestRoundData()
-        Pyth_ETH-->>WETH: ETH-USD price
+    and API3 ETH-USD Path
+        WETH->>API3_ETH: latestRoundData()
+        API3_ETH-->>WETH: ETH-USD price
     and Chainlink-derived Path
         WETH->>CL_ETHBTC: latestRoundData()
         CL_ETHBTC-->>WETH: ETH-BTC price
@@ -215,7 +191,7 @@ sequenceDiagram
     participant USDS
     participant CL_USDS as Chainlink USDS-USD
     participant CL_DAI as Chainlink DAI-USD
-    participant Pyth_USDS as Pyth USDS-USD
+    participant API3_USDS as API3 USDS-USD
 
     User->>USDS: getPrice(USDS)
 
@@ -227,9 +203,9 @@ sequenceDiagram
     and Chainlink DAI-USD Path
         USDS->>CL_DAI: latestRoundData()
         CL_DAI-->>USDS: DAI-USD price
-    and Pyth USDS-USD Path
-        USDS->>Pyth_USDS: latestRoundData()
-        Pyth_USDS-->>USDS: USDS-USD price
+    and API3 USDS-USD Path
+        USDS->>API3_USDS: latestRoundData()
+        API3_USDS-->>USDS: USDS-USD price
     end
 
     Note over USDS: Filter: Exclude zero and values deviating >1% from median<br/>Average: Sum of valid values / count
@@ -248,7 +224,7 @@ sequenceDiagram
     participant WETH
     participant CL_ETH as Chainlink ETH-USD
     participant RS_ETH as RedStone ETH-USD
-    participant Pyth_ETH as Pyth ETH-USD
+    participant API3_ETH as API3 ETH-USD
     participant CL_ETHBTC as Chainlink ETH-BTC
     participant CL_BTCUSD as Chainlink BTC-USD
     participant SUSDS
@@ -256,7 +232,7 @@ sequenceDiagram
     participant USDS
     participant CL_USDS as Chainlink USDS-USD
     participant CL_DAI as Chainlink DAI-USD
-    participant Pyth_USDS as Pyth USDS-USD
+    participant API3_USDS as API3 USDS-USD
 
     User->>OHM: getPrice(OHM)
 
@@ -274,9 +250,9 @@ sequenceDiagram
         and RedStone ETH-USD Path
             WETH->>RS_ETH: latestRoundData()
             RS_ETH-->>WETH: ETH-USD price
-        and Pyth ETH-USD Path
-            WETH->>Pyth_ETH: latestRoundData()
-            Pyth_ETH-->>WETH: ETH-USD price
+        and API3 ETH-USD Path
+            WETH->>API3_ETH: latestRoundData()
+            API3_ETH-->>WETH: ETH-USD price
         and Chainlink-derived Path
             WETH->>CL_ETHBTC: latestRoundData()
             CL_ETHBTC-->>WETH: ETH-BTC price
@@ -305,9 +281,9 @@ sequenceDiagram
         and Chainlink DAI-USD Path
             USDS->>CL_DAI: latestRoundData()
             CL_DAI-->>USDS: DAI-USD price
-        and Pyth USDS-USD Path
-            USDS->>Pyth_USDS: latestRoundData()
-            Pyth_USDS-->>USDS: USDS-USD price
+        and API3 USDS-USD Path
+            USDS->>API3_USDS: latestRoundData()
+            API3_USDS-->>USDS: USDS-USD price
         end
 
         Note over USDS: Filter: Exclude zero and values deviating >1% from median<br/>Average: Sum of valid values / count

--- a/documentation/price.md
+++ b/documentation/price.md
@@ -59,39 +59,39 @@ This allows `ERC7726OracleCloneable`, `MorphoOracleFactory`, and `ChainlinkOracl
 
 ## Assets
 
-| Asset | Address                                                                                | Price Feeds                                                                                                                                                                                                                                                                                                                                                                                                                                               | Strategy                                                                                                   | Store MA | Use MA | MA Duration       |
-| ----- | -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | -------- | ------ | ----------------- |
-| USDS  | [0xdC0...84F](https://etherscan.io/address/0xdC035D45d973E3EC169d2276DDab16f1e407384F) | [Chainlink USDS-USD](https://etherscan.io/address/0xfF30586cD0F29eD462364C7e81375FC0C71219b1), [Chainlink DAI-USD](https://etherscan.io/address/0xAed0c38402a5d19df6E4c03F4E2DceD6e29c1ee9), API3 USDS-USD                                                                                                                                                                                                                                                | `getAveragePriceExcludingDeviations()` with 1% price-feed deviation and revert on insufficient price feeds | No       | No     | 0                 |
-| sUSDS | [0xa39...fbD](https://etherscan.io/address/0xa3931d71877C0E7a3148CB7Eb4463524FEc27fbD) | ERC4626 Submodule                                                                                                                                                                                                                                                                                                                                                                                                                                         | None                                                                                                       | No       | No     | 0                 |
-| wETH  | [0xc02...cc2](https://etherscan.io/address/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2) | [Chainlink ETH-USD](https://etherscan.io/address/0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419), [RedStone ETH-USD](https://etherscan.io/address/0x67F6838e58859d612E4ddF04dA396d6DABB66Dc4), [API3 ETH-USD](https://etherscan.io/address/0x5b0cf2b36a65a6BB085D501B971e4c102B9Cd473), [ETH-BTC](https://etherscan.io/address/0xAc559F25B1619171CbC396a50854A3240b6A4e99)x[BTC-USD](https://etherscan.io/address/0xF4030086522a5bEEa4988F8cA5B36dbC97BeE88c) | `getAveragePriceExcludingDeviations()` with 5% price-feed deviation and revert on insufficient price feeds | No       | No     | 0                 |
-| OHM   | [0x64a...1d5](https://etherscan.io/address/0x64aa3364f17a4d01c6f1751fd97c2bd3d7e7f1d5) | [Uniswap V3 OHM/WETH](https://etherscan.io/address/0x88051b0eea095007d3bef21ab287be961f3d8598), [Uniswap V3 OHM/sUSDS](https://etherscan.io/address/0x0858e2b0f9d75f7300b38d64482ac2c8df06a755), [Chainlink OHM-ETH](https://etherscan.io/address/0x9a72298ae3886221820B1c878d12D872087D3a23)x[Chainlink ETH-USD](https://etherscan.io/address/0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419)                                                                | `getAveragePriceExcludingDeviations()` with 2% price-feed deviation and revert on insufficient price feeds | Yes      | No     | 2592000 (30 days) |
+| Asset | Address | Price Feeds | Strategy | Store MA | Use MA | MA Duration |
+| ----- | ------- | ----------- | -------- | -------- | ------ | ----------- |
+| USDS | [0xdC0...84F](https://etherscan.io/address/0xdC035D45d973E3EC169d2276DDab16f1e407384F) | [Chainlink USDS-USD](https://etherscan.io/address/0xfF30586cD0F29eD462364C7e81375FC0C71219b1), [Chainlink DAI-USD](https://etherscan.io/address/0xAed0c38402a5d19df6E4c03F4E2DceD6e29c1ee9), API3 USDS-USD | `getAveragePriceExcludingDeviations()` with 1% price-feed deviation and revert on insufficient price feeds | No | No | 0 |
+| sUSDS | [0xa39...fbD](https://etherscan.io/address/0xa3931d71877C0E7a3148CB7Eb4463524FEc27fbD) | ERC4626 Submodule | None | No | No | 0 |
+| wETH | [0xc02...cc2](https://etherscan.io/address/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2) | [Chainlink ETH-USD](https://etherscan.io/address/0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419), [RedStone ETH-USD](https://etherscan.io/address/0x67F6838e58859d612E4ddF04dA396d6DABB66Dc4), [API3 ETH-USD](https://etherscan.io/address/0x5b0cf2b36a65a6BB085D501B971e4c102B9Cd473), [ETH-BTC](https://etherscan.io/address/0xAc559F25B1619171CbC396a50854A3240b6A4e99)x[BTC-USD](https://etherscan.io/address/0xF4030086522a5bEEa4988F8cA5B36dbC97BeE88c) | `getAveragePriceExcludingDeviations()` with 5% price-feed deviation and revert on insufficient price feeds | No | No | 0 |
+| OHM | [0x64a...1d5](https://etherscan.io/address/0x64aa3364f17a4d01c6f1751fd97c2bd3d7e7f1d5) | [Uniswap V3 OHM/WETH](https://etherscan.io/address/0x88051b0eea095007d3bef21ab287be961f3d8598), [Uniswap V3 OHM/sUSDS](https://etherscan.io/address/0x0858e2b0f9d75f7300b38d64482ac2c8df06a755), [Chainlink OHM-ETH](https://etherscan.io/address/0x9a72298ae3886221820B1c878d12D872087D3a23)x[Chainlink ETH-USD](https://etherscan.io/address/0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419) | `getAveragePriceExcludingDeviations()` with 2% price-feed deviation and revert on insufficient price feeds | Yes | No | 2592000 (30 days) |
 
 ### Final Configuration Values
 
 The following values describe the target oracle configuration. Update `src/scripts/ops/batches/args/ConfigurePriceV1_2.json` with the live API3 USDS-USD reader proxy before deployment.
 
-| Asset | Strategy                               | Price-Feed Deviation | Revert on Insufficient Price Feeds | Expected Price          | Expected Tolerance |
-| ----- | -------------------------------------- | -------------------- | ---------------------------------- | ----------------------- | ------------------ |
-| USDS  | `getAveragePriceExcludingDeviations()` | 100 bps              | Yes                                | 1e18                    | 100 bps            |
-| sUSDS | None, uses ERC4626 feed only           | N/A                  | N/A                                | 1.095038992740982406e18 | 100 bps            |
-| wETH  | `getAveragePriceExcludingDeviations()` | 500 bps              | Yes                                | 2282.17e18              | 500 bps            |
-| OHM   | `getAveragePriceExcludingDeviations()` | 200 bps              | Yes                                | 19.5e18                 | 500 bps            |
+| Asset | Strategy | Price-Feed Deviation | Revert on Insufficient Price Feeds | Expected Price | Expected Tolerance |
+| ----- | -------- | -------------------- | ---------------------------------- | -------------- | ------------------ |
+| USDS | `getAveragePriceExcludingDeviations()` | 100 bps | Yes | 1e18 | 100 bps |
+| sUSDS | None, uses ERC4626 feed only | N/A | N/A | 1.095038992740982406e18 | 100 bps |
+| wETH | `getAveragePriceExcludingDeviations()` | 500 bps | Yes | 2282.17e18 | 500 bps |
+| OHM | `getAveragePriceExcludingDeviations()` | 200 bps | Yes | 19.5e18 | 500 bps |
 
-| Asset | Feed Path                 | Source                                   | Update Threshold      | Observation Window | Max Confidence |
-| ----- | ------------------------- | ---------------------------------------- | --------------------- | ------------------ | -------------- |
-| USDS  | Chainlink USDS-USD        | `chainlinkUsdsUsd`                       | 86,400 sec (24 hours) | N/A                | N/A            |
-| USDS  | Chainlink DAI-USD         | `chainlinkDaiUsd`                        | 86,400 sec (24 hours) | N/A                | N/A            |
-| USDS  | API3 USDS-USD             | `api3UsdsUsd`                            | 90,000 sec (25 hours) | N/A                | N/A            |
-| sUSDS | ERC4626 derived from USDS | `getPriceFromUnderlying(sUSDS)`          | N/A                   | N/A                | N/A            |
-| wETH  | Chainlink ETH-USD         | `chainlinkEthUsd`                        | 3,600 sec (1 hour)    | N/A                | N/A            |
-| wETH  | RedStone ETH-USD          | `redstoneEthUsd`                         | 86,400 sec (24 hours) | N/A                | N/A            |
-| wETH  | API3 ETH-USD              | `api3EthUsd`                             | 90,000 sec (25 hours) | N/A                | N/A            |
-| wETH  | Chainlink ETH-BTC leg     | `chainlinkEthBtc`                        | 86,400 sec (24 hours) | N/A                | N/A            |
-| wETH  | Chainlink BTC-USD leg     | `chainlinkBtcUsd`                        | 3,600 sec (1 hour)    | N/A                | N/A            |
-| OHM   | Uniswap V3 OHM/WETH       | `uniswapOhmWeth`                         | N/A                   | 1,500 sec (25 min) | N/A            |
-| OHM   | Uniswap V3 OHM/sUSDS      | `uniswapOhmSusds`                        | N/A                   | 1,500 sec (25 min) | N/A            |
-| OHM   | Chainlink OHM-ETH leg     | env `external.chainlink.ohmEthPriceFeed` | 86,400 sec (24 hours) | N/A                | N/A            |
-| OHM   | Chainlink ETH-USD leg     | `chainlinkEthUsd`                        | 3,600 sec (1 hour)    | N/A                | N/A            |
+| Asset | Feed Path | Source | Update Threshold | Observation Window | Max Confidence |
+| ----- | --------- | ------ | ---------------- | ------------------ | -------------- |
+| USDS | Chainlink USDS-USD | `chainlinkUsdsUsd` | 86,400 sec (24 hours) | N/A | N/A |
+| USDS | Chainlink DAI-USD | `chainlinkDaiUsd` | 86,400 sec (24 hours) | N/A | N/A |
+| USDS | API3 USDS-USD | `api3UsdsUsd` | 90,000 sec (25 hours) | N/A | N/A |
+| sUSDS | ERC4626 derived from USDS | `getPriceFromUnderlying(sUSDS)` | N/A | N/A | N/A |
+| wETH | Chainlink ETH-USD | `chainlinkEthUsd` | 3,600 sec (1 hour) | N/A | N/A |
+| wETH | RedStone ETH-USD | `redstoneEthUsd` | 86,400 sec (24 hours) | N/A | N/A |
+| wETH | API3 ETH-USD | `api3EthUsd` | 90,000 sec (25 hours) | N/A | N/A |
+| wETH | Chainlink ETH-BTC leg | `chainlinkEthBtc` | 86,400 sec (24 hours) | N/A | N/A |
+| wETH | Chainlink BTC-USD leg | `chainlinkBtcUsd` | 3,600 sec (1 hour) | N/A | N/A |
+| OHM | Uniswap V3 OHM/WETH | `uniswapOhmWeth` | N/A | 1,500 sec (25 min) | N/A |
+| OHM | Uniswap V3 OHM/sUSDS | `uniswapOhmSusds` | N/A | 1,500 sec (25 min) | N/A |
+| OHM | Chainlink OHM-ETH leg | env `external.chainlink.ohmEthPriceFeed` | 86,400 sec (24 hours) | N/A | N/A |
+| OHM | Chainlink ETH-USD leg | `chainlinkEthUsd` | 3,600 sec (1 hour) | N/A | N/A |
 
 - Ultimately, price resolution for all assets into USD will be reliant on a combination of Chainlink, RedStone, API3 and Chainlink-derived (ETH-BTC × BTC-USD) oracles.
 - Pyth feeds are not included in the target configuration because the protocol would need paid Hermes access to reliably operate the required feed updates. This would add an external subscription dependency for the PRICE module and make the oracle path reliant on a paid off-chain update service.
@@ -118,18 +118,18 @@ The following values describe the target oracle configuration. Update `src/scrip
 
 The **update threshold** is the maximum number of seconds that can elapse since the last price feed update before the price is considered stale. If a feed's last update is older than this threshold, the feed returns zero and is excluded from price calculation.
 
-| Asset | Feed                        | Update Threshold               |
-| ----- | --------------------------- | ------------------------------ |
-| USDS  | Chainlink USDS-USD          | 86,400 sec (24 hours)          |
-| USDS  | Chainlink DAI-USD           | 86,400 sec (24 hours)          |
-| USDS  | API3 USDS-USD               | 90,000 sec (25 hours)          |
-| wETH  | Chainlink ETH-USD           | 3,600 sec (1 hour)             |
-| wETH  | RedStone ETH-USD            | 86,400 sec (24 hours)          |
-| wETH  | API3 ETH-USD                | 90,000 sec (25 hours)          |
-| wETH  | Chainlink ETH-BTC leg       | 86,400 sec (24 hours)          |
-| wETH  | Chainlink BTC-USD leg       | 3,600 sec (1 hour)             |
-| OHM   | Chainlink OHM-ETH           | 86,400 sec (24 hours)          |
-| OHM   | Chainlink OHM-ETH × ETH-USD | 3,600 sec (1 hour) for ETH-USD |
+| Asset | Feed | Update Threshold |
+| ----- | ---- | ---------------- |
+| USDS | Chainlink USDS-USD | 86,400 sec (24 hours) |
+| USDS | Chainlink DAI-USD | 86,400 sec (24 hours) |
+| USDS | API3 USDS-USD | 90,000 sec (25 hours) |
+| wETH | Chainlink ETH-USD | 3,600 sec (1 hour) |
+| wETH | RedStone ETH-USD | 86,400 sec (24 hours) |
+| wETH | API3 ETH-USD | 90,000 sec (25 hours) |
+| wETH | Chainlink ETH-BTC leg | 86,400 sec (24 hours) |
+| wETH | Chainlink BTC-USD leg | 3,600 sec (1 hour) |
+| OHM | Chainlink OHM-ETH | 86,400 sec (24 hours) |
+| OHM | Chainlink OHM-ETH × ETH-USD | 3,600 sec (1 hour) for ETH-USD |
 
 > **IMPORTANT:** API3 feeds are consumed through Chainlink-interface compatible reader proxies. The configured update threshold is 25 hours for feeds with a 24-hour heartbeat. This gives a one-hour grace period for heartbeat updates that land slightly late, while still failing stale feeds promptly if an update is missed. API3 feed operation also requires regular payment to keep the reader proxy active and the feed updating.
 
@@ -141,10 +141,10 @@ The **observation window** is used only for Uniswap V3 price feeds to calculate 
 - The TWAP is calculated by averaging observations within the window
 - A longer window = more manipulation resistance but slower price updates
 
-| Asset | Feed                 | Observation Window |
-| ----- | -------------------- | ------------------ |
-| OHM   | Uniswap V3 OHM/WETH  | 1,500 sec (25 min) |
-| OHM   | Uniswap V3 OHM/sUSDS | 1,500 sec (25 min) |
+| Asset | Feed | Observation Window |
+| ----- | ---- | ------------------ |
+| OHM | Uniswap V3 OHM/WETH | 1,500 sec (25 min) |
+| OHM | Uniswap V3 OHM/sUSDS | 1,500 sec (25 min) |
 
 ### wETH Price Resolution
 

--- a/documentation/price.md
+++ b/documentation/price.md
@@ -61,21 +61,21 @@ This allows `ERC7726OracleCloneable`, `MorphoOracleFactory`, and `ChainlinkOracl
 
 | Asset | Address | Price Feeds | Strategy | Store MA | Use MA | MA Duration |
 | ----- | ------- | ----------- | -------- | -------- | ------ | ----------- |
-| USDS | [0xdC0...84F](https://etherscan.io/address/0xdC035D45d973E3EC169d2276DDab16f1e407384F) | [Chainlink USDS-USD](https://etherscan.io/address/0xfF30586cD0F29eD462364C7e81375FC0C71219b1), [Chainlink DAI-USD](https://etherscan.io/address/0xAed0c38402a5d19df6E4c03F4E2DceD6e29c1ee9), API3 USDS-USD | `getAveragePriceExcludingDeviations()` with 1% price-feed deviation and revert on insufficient price feeds | No | No | 0 |
+| USDS | [0xdC0...84F](https://etherscan.io/address/0xdC035D45d973E3EC169d2276DDab16f1e407384F) | [Chainlink USDS-USD](https://etherscan.io/address/0xfF30586cD0F29eD462364C7e81375FC0C71219b1), [Chainlink DAI-USD](https://etherscan.io/address/0xAed0c38402a5d19df6E4c03F4E2DceD6e29c1ee9), [API3 USDS-USD](https://etherscan.io/address/0x6C3C2A615Ea3c592487b3e06ecAF01D9a3181f47) | `getAveragePriceExcludingDeviations()` with 1% price-feed deviation and revert on insufficient price feeds | No | No | 0 |
 | sUSDS | [0xa39...fbD](https://etherscan.io/address/0xa3931d71877C0E7a3148CB7Eb4463524FEc27fbD) | ERC4626 Submodule | None | No | No | 0 |
 | wETH | [0xc02...cc2](https://etherscan.io/address/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2) | [Chainlink ETH-USD](https://etherscan.io/address/0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419), [RedStone ETH-USD](https://etherscan.io/address/0x67F6838e58859d612E4ddF04dA396d6DABB66Dc4), [API3 ETH-USD](https://etherscan.io/address/0x5b0cf2b36a65a6BB085D501B971e4c102B9Cd473), [ETH-BTC](https://etherscan.io/address/0xAc559F25B1619171CbC396a50854A3240b6A4e99)x[BTC-USD](https://etherscan.io/address/0xF4030086522a5bEEa4988F8cA5B36dbC97BeE88c) | `getAveragePriceExcludingDeviations()` with 5% price-feed deviation and revert on insufficient price feeds | No | No | 0 |
 | OHM | [0x64a...1d5](https://etherscan.io/address/0x64aa3364f17a4d01c6f1751fd97c2bd3d7e7f1d5) | [Uniswap V3 OHM/WETH](https://etherscan.io/address/0x88051b0eea095007d3bef21ab287be961f3d8598), [Uniswap V3 OHM/sUSDS](https://etherscan.io/address/0x0858e2b0f9d75f7300b38d64482ac2c8df06a755), [Chainlink OHM-ETH](https://etherscan.io/address/0x9a72298ae3886221820B1c878d12D872087D3a23)x[Chainlink ETH-USD](https://etherscan.io/address/0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419) | `getAveragePriceExcludingDeviations()` with 2% price-feed deviation and revert on insufficient price feeds | Yes | No | 2592000 (30 days) |
 
 ### Final Configuration Values
 
-The following values describe the target oracle configuration. Update `src/scripts/ops/batches/args/ConfigurePriceV1_2.json` with the live API3 USDS-USD reader proxy before deployment.
+The following values describe the target oracle configuration.
 
 | Asset | Strategy | Price-Feed Deviation | Revert on Insufficient Price Feeds | Expected Price | Expected Tolerance |
 | ----- | -------- | -------------------- | ---------------------------------- | -------------- | ------------------ |
 | USDS | `getAveragePriceExcludingDeviations()` | 100 bps | Yes | 1e18 | 100 bps |
 | sUSDS | None, uses ERC4626 feed only | N/A | N/A | 1.095038992740982406e18 | 100 bps |
 | wETH | `getAveragePriceExcludingDeviations()` | 500 bps | Yes | 2282.17e18 | 500 bps |
-| OHM | `getAveragePriceExcludingDeviations()` | 200 bps | Yes | 19.5e18 | 500 bps |
+| OHM | `getAveragePriceExcludingDeviations()` | 200 bps | Yes | 16.89e18 | 500 bps |
 
 | Asset | Feed Path | Source | Update Threshold | Observation Window | Max Confidence |
 | ----- | --------- | ------ | ---------------- | ------------------ | -------------- |

--- a/documentation/price_v1_upgrade.md
+++ b/documentation/price_v1_upgrade.md
@@ -69,11 +69,11 @@ Modify PriceConfigv2 to be enabled by default, and DAO MS has `price_admin` role
 
 ```bash
 ./shell/deployV3.sh \
-    --account \
-    src/scripts/deploy/savedDeployments/price_v1_2_deploy.json \
+    --account <wallet> \
+    --sequence src/scripts/deploy/savedDeployments/price_v1_2_deploy.json \
     --chain mainnet \
     --broadcast true \
-    --verify true < wallet > --sequence
+    --verify true
 ```
 
 This deploys:

--- a/documentation/price_v1_upgrade.md
+++ b/documentation/price_v1_upgrade.md
@@ -56,7 +56,6 @@ Modify PriceConfigv2 to be enabled by default, and DAO MS has `price_admin` role
 
 - `OlympusPricev1_2` - PRICE v1.2 module
 - `ChainlinkPriceFeeds` - Chainlink price feed submodule
-- `PythPriceFeeds` - Pyth price feed submodule
 - `UniswapV3Price` - Uniswap V3 price submodule
 - `ERC4626Price` - ERC4626 price submodule
 - `SimplePriceFeedStrategy` - Price strategy submodule
@@ -70,24 +69,24 @@ Modify PriceConfigv2 to be enabled by default, and DAO MS has `price_admin` role
 
 ```bash
 ./shell/deployV3.sh \
-  --account <wallet> \
-  --sequence src/scripts/deploy/savedDeployments/price_v1_2_deploy.json \
-  --chain mainnet \
-  --broadcast true \
-  --verify true
+    --account \
+    src/scripts/deploy/savedDeployments/price_v1_2_deploy.json \
+    --chain mainnet \
+    --broadcast true \
+    --verify true < wallet > --sequence
 ```
 
 This deploys:
 
 1. PRICE v1.2 module (`OlympusPricev1_2`)
-2. 5 submodules (ChainlinkPriceFeeds, PythPriceFeeds, UniswapV3Price, ERC4626Price, SimplePriceFeedStrategy)
+2. 4 submodules (ChainlinkPriceFeeds, UniswapV3Price, ERC4626Price, SimplePriceFeedStrategy)
 3. PriceConfigv2 policy (auto-enabled on installation)
 
 ### 3. MS Batch Script for PRICE Configuration
 
 **Batch script:** `src/scripts/ops/batches/ConfigurePriceV1_2.sol`
 
-This batch installs all 5 submodules and configures 4 assets (USDS, sUSDS, wETH, OHM) in a single transaction.
+This batch installs all 4 required submodules and configures 4 assets (USDS, sUSDS, wETH, OHM) in a single transaction.
 
 Create an args file with price feed addresses (JSON format with `.functions[].name` and `.functions[].args` structure).
 
@@ -103,10 +102,10 @@ Create an args file with price feed addresses (JSON format with `.functions[].na
 
 **Batch actions:**
 
-1. Install 5 submodules via `PriceConfigv2.installSubmodule()`
-2. Configure USDS (Chainlink USDS-USD + Chainlink DAI-USD + Pyth feeds, deviation-based strategy)
+1. Install 4 submodules via `PriceConfigv2.installSubmodule()`
+2. Configure USDS (Chainlink USDS-USD + Chainlink DAI-USD + API3 USDS-USD, deviation-based strategy)
 3. Configure sUSDS (ERC4626 wrapper, uses USDS price)
-4. Configure wETH (Chainlink + RedStone + Pyth feeds, deviation-based strategy)
+4. Configure wETH (Chainlink ETH-USD + RedStone ETH-USD + API3 ETH-USD + Chainlink ETH-BTC × BTC-USD, deviation-based strategy)
 5. Configure OHM (2x Uniswap V3 feeds + Chainlink OHM-ETH × ETH-USD, deviation-filtered average strategy, migrated 30-day moving average)
 
 **Automatic validation:** The batch script simulates a full 24-hour Heart cycle (3 beats) to validate PRICE configuration before proposing the batch.
@@ -139,14 +138,14 @@ No OCG approval required — only `price_admin` role.
 
 ## File Reference
 
-| File | Purpose |
-| ---- | ------- |
-| `shell/deployV3.sh` | Deployment shell script |
-| `src/scripts/deploy/DeployV3.s.sol` | Deployment script |
-| `src/scripts/deploy/savedDeployments/price_v1_2_deploy.json` | Deployment sequence |
-| `shell/safeBatchV2.sh` | Batch execution shell script |
-| `src/scripts/ops/batches/ConfigurePriceV1_2.sol` | PRICE configuration batch |
-| `src/policies/price/PriceConfig.v2.sol` | Configuration policy |
-| `src/modules/PRICE/OlympusPrice.v1_2.sol` | PRICE v1.2 module |
+| File                                                         | Purpose                      |
+| ------------------------------------------------------------ | ---------------------------- |
+| `shell/deployV3.sh`                                          | Deployment shell script      |
+| `src/scripts/deploy/DeployV3.s.sol`                          | Deployment script            |
+| `src/scripts/deploy/savedDeployments/price_v1_2_deploy.json` | Deployment sequence          |
+| `shell/safeBatchV2.sh`                                       | Batch execution shell script |
+| `src/scripts/ops/batches/ConfigurePriceV1_2.sol`             | PRICE configuration batch    |
+| `src/policies/price/PriceConfig.v2.sol`                      | Configuration policy         |
+| `src/modules/PRICE/OlympusPrice.v1_2.sol`                    | PRICE v1.2 module            |
 
 For oracle-related files, see **[Oracle Factories and Policies](oracle_factories.md)**.

--- a/snapshots/OlympusPricev1_2ForkTest.json
+++ b/snapshots/OlympusPricev1_2ForkTest.json
@@ -1,6 +1,6 @@
 {
-    "getPrice_OHM": "682583",
-    "heartbeat": "837525",
-    "heartbeat_emissionManager": "1561346",
-    "heartbeat_yrf": "1221954"
+    "getPrice_OHM": "762694",
+    "heartbeat": "831773",
+    "heartbeat_emissionManager": "1562225",
+    "heartbeat_yrf": "1204077"
 }

--- a/src/proposals/OracleProposal.sol
+++ b/src/proposals/OracleProposal.sol
@@ -36,7 +36,7 @@ contract OracleProposal is GovernorBravoProposal {
     address internal constant CHAINLINK_OHM_ETH = 0x9a72298ae3886221820B1c878d12D872087D3a23;
     address internal constant CHAINLINK_USDS_USD = 0xfF30586cD0F29eD462364C7e81375FC0C71219b1;
     address internal constant API3_ETH_USD = 0x5b0cf2b36a65a6BB085D501B971e4c102B9Cd473;
-    address internal constant API3_USDS_USD = address(0);
+    address internal constant API3_USDS_USD = 0x6C3C2A615Ea3c592487b3e06ecAF01D9a3181f47;
     address internal constant REDSTONE_ETH_USD = 0x67F6838e58859d612E4ddF04dA396d6DABB66Dc4;
 
     // Returns the id of the proposal.
@@ -243,9 +243,7 @@ contract OracleProposal is GovernorBravoProposal {
         _mockChainlinkFeedAt(CHAINLINK_OHM_ETH, executionTimestamp);
         _mockChainlinkFeedAt(CHAINLINK_USDS_USD, executionTimestamp);
         _mockChainlinkFeedAt(API3_ETH_USD, executionTimestamp);
-        if (API3_USDS_USD != address(0)) {
-            _mockChainlinkFeedAt(API3_USDS_USD, executionTimestamp);
-        }
+        _mockChainlinkFeedAt(API3_USDS_USD, executionTimestamp);
         _mockChainlinkFeedAt(REDSTONE_ETH_USD, executionTimestamp);
     }
 

--- a/src/proposals/OracleProposal.sol
+++ b/src/proposals/OracleProposal.sol
@@ -51,66 +51,67 @@ contract OracleProposal is GovernorBravoProposal {
 
     // Provides a detailed description of the proposal.
     function description() public pure override returns (string memory) {
-        return string.concat(
-            "# Enable Oracle Policies and OHM/USDS Oracles\n",
-            "\n",
-            "## Summary\n",
-            "\n",
-            "This proposal enables the oracle policies and deploys OHM/USDS oracles.\n",
-            "\n",
-            "## Oracle Policies\n",
-            "\n",
-            "This proposal enables three oracle factories:\n",
-            "\n",
-            "### 1. ERC7726OracleFactory\n\n",
-            "- **Purpose**: Factory for deploying ERC7726-compatible oracle clones\n",
-            "- **Function**: Creates ERC7726-compatible cached-price oracles from PRICE data\n",
-            "- **Use Cases**: General lending integrations requiring ERC7726 quote interfaces\n",
-            "\n",
-            "### 2. ChainlinkOracleFactory\n\n",
-            "- **Purpose**: Factory for deploying gas-efficient Chainlink oracle clones\n",
-            "- **Function**: Creates ERC7726-compliant oracles using PRICE as the price source\n",
-            "- **Use Cases**: Protocols requiring Chainlink-compatible oracles\n",
-            "\n",
-            "### 3. MorphoOracleFactory\n\n",
-            "- **Purpose**: Factory for deploying Morpho-compatible oracle clones\n",
-            "- **Function**: Creates oracles with Morpho-specific price scaling (36 decimals)\n",
-            "- **Use Cases**: Morpho lending protocol integration\n",
-            "\n",
-            "## Actions\n",
-            "\n",
-            "This proposal will execute the following actions:\n",
-            "\n",
-            "1. **Grant `admin` role to Timelock** (if needed)\n",
-            "2. **Grant `oracle_manager` role to DAO MS and Timelock** (if needed)\n",
-            "3. **Enable PriceCache policy** (if needed)\n",
-            "4. **Enable ERC7726OracleFactory policy**\n",
-            "5. **Enable ChainlinkOracleFactory policy**\n",
-            "6. **Enable MorphoOracleFactory policy**\n",
-            "7. **Deploy ERC7726 oracle** (via ERC7726OracleFactory)\n",
-            "8. **Deploy OHM/USDS Chainlink oracle** (via ChainlinkOracleFactory)\n",
-            "9. **Deploy OHM/USDS Morpho oracle** (via MorphoOracleFactory)\n",
-            "\n",
-            "## Technical Details\n",
-            "\n",
-            "### Oracle Factory Benefits\n",
-            "\n",
-            "- **Gas Efficiency**: Uses ClonesWithImmutableArgs for minimal deployment cost\n",
-            "- **Security**: Oracles inherit access control from PRICE and factory policies\n",
-            "- **Flexibility**: New oracles can be deployed by `oracle_manager` role holders without additional governance\n",
-            "\n",
-            "## Risks and Considerations\n",
-            "\n",
-            "- **Oracle Availability**: Enabled oracle policies depend on PRICE functioning correctly\n",
-            "- **Price Feed Dependencies**: Oracle accuracy depends on underlying PRICE feeds\n",
-            "\n",
-            "## Resources\n",
-            "\n",
-            "- [Audit Report](https://storage.googleapis.com/olympusdao-landing-page-reports/audits/2026-05_Olympus_Price_Feed_Updates_Report.pdf)\n",
-            "- [Implementation PR](https://github.com/OlympusDAO/olympus-v3/pull/187)\n",
-            "- [PRICE Documentation](https://github.com/OlympusDAO/olympus-v3/blob/4248bd6d45e160f7d369c1d44f126d8cef0b7f57/documentation/price.md)\n",
-            "- [Oracle Documentation](https://github.com/OlympusDAO/olympus-v3/blob/4248bd6d45e160f7d369c1d44f126d8cef0b7f57/documentation/oracle_factories.md)\n"
-        );
+        return
+            string.concat(
+                "# Enable Oracle Policies and OHM/USDS Oracles\n",
+                "\n",
+                "## Summary\n",
+                "\n",
+                "This proposal enables the oracle policies and deploys OHM/USDS oracles.\n",
+                "\n",
+                "## Oracle Policies\n",
+                "\n",
+                "This proposal enables three oracle factories:\n",
+                "\n",
+                "### 1. ERC7726OracleFactory\n\n",
+                "- **Purpose**: Factory for deploying ERC7726-compatible oracle clones\n",
+                "- **Function**: Creates ERC7726-compatible cached-price oracles from PRICE data\n",
+                "- **Use Cases**: General lending integrations requiring ERC7726 quote interfaces\n",
+                "\n",
+                "### 2. ChainlinkOracleFactory\n\n",
+                "- **Purpose**: Factory for deploying gas-efficient Chainlink oracle clones\n",
+                "- **Function**: Creates ERC7726-compliant oracles using PRICE as the price source\n",
+                "- **Use Cases**: Protocols requiring Chainlink-compatible oracles\n",
+                "\n",
+                "### 3. MorphoOracleFactory\n\n",
+                "- **Purpose**: Factory for deploying Morpho-compatible oracle clones\n",
+                "- **Function**: Creates oracles with Morpho-specific price scaling (36 decimals)\n",
+                "- **Use Cases**: Morpho lending protocol integration\n",
+                "\n",
+                "## Actions\n",
+                "\n",
+                "This proposal will execute the following actions:\n",
+                "\n",
+                "1. **Grant `admin` role to Timelock** (if needed)\n",
+                "2. **Grant `oracle_manager` role to DAO MS and Timelock** (if needed)\n",
+                "3. **Enable PriceCache policy** (if needed)\n",
+                "4. **Enable ERC7726OracleFactory policy**\n",
+                "5. **Enable ChainlinkOracleFactory policy**\n",
+                "6. **Enable MorphoOracleFactory policy**\n",
+                "7. **Deploy ERC7726 oracle** (via ERC7726OracleFactory)\n",
+                "8. **Deploy OHM/USDS Chainlink oracle** (via ChainlinkOracleFactory)\n",
+                "9. **Deploy OHM/USDS Morpho oracle** (via MorphoOracleFactory)\n",
+                "\n",
+                "## Technical Details\n",
+                "\n",
+                "### Oracle Factory Benefits\n",
+                "\n",
+                "- **Gas Efficiency**: Uses ClonesWithImmutableArgs for minimal deployment cost\n",
+                "- **Security**: Oracles inherit access control from PRICE and factory policies\n",
+                "- **Flexibility**: New oracles can be deployed by `oracle_manager` role holders without additional governance\n",
+                "\n",
+                "## Risks and Considerations\n",
+                "\n",
+                "- **Oracle Availability**: Enabled oracle policies depend on PRICE functioning correctly\n",
+                "- **Price Feed Dependencies**: Oracle accuracy depends on underlying PRICE feeds\n",
+                "\n",
+                "## Resources\n",
+                "\n",
+                "- [Audit Report](https://storage.googleapis.com/olympusdao-landing-page-reports/audits/2026-05_Olympus_Price_Feed_Updates_Report.pdf)\n",
+                "- [Implementation PR](https://github.com/OlympusDAO/olympus-v3/pull/187)\n",
+                "- [PRICE Documentation](https://github.com/OlympusDAO/olympus-v3/blob/4248bd6d45e160f7d369c1d44f126d8cef0b7f57/documentation/price.md)\n",
+                "- [Oracle Documentation](https://github.com/OlympusDAO/olympus-v3/blob/4248bd6d45e160f7d369c1d44f126d8cef0b7f57/documentation/oracle_factories.md)\n"
+            );
     }
 
     // Cache addresses in _deploy
@@ -128,7 +129,9 @@ contract OracleProposal is GovernorBravoProposal {
         address daoMS = addresses.getAddress("olympus-multisig-dao");
 
         address erc7726Factory = addresses.getAddress("olympus-policy-erc7726-oracle-factory-1_0");
-        address chainlinkFactory = addresses.getAddress("olympus-policy-chainlink-oracle-factory-1_0");
+        address chainlinkFactory = addresses.getAddress(
+            "olympus-policy-chainlink-oracle-factory-1_0"
+        );
         address morphoFactory = addresses.getAddress("olympus-policy-morpho-oracle-factory-1_0");
         address priceCache = addresses.getAddress("olympus-policy-price-cache-1_0");
 
@@ -165,7 +168,11 @@ contract OracleProposal is GovernorBravoProposal {
         if (!roles.hasRole(timelock, ORACLE_MANAGER_ROLE)) {
             _pushAction(
                 rolesAdmin,
-                abi.encodeWithSelector(RolesAdmin.grantRole.selector, ORACLE_MANAGER_ROLE, timelock),
+                abi.encodeWithSelector(
+                    RolesAdmin.grantRole.selector,
+                    ORACLE_MANAGER_ROLE,
+                    timelock
+                ),
                 "Grant oracle_manager role to Timelock"
             );
         } else {
@@ -174,36 +181,66 @@ contract OracleProposal is GovernorBravoProposal {
 
         // STEP 3: Enable PriceCache, if needed
         if (!IEnabler(priceCache).isEnabled()) {
-            _pushAction(priceCache, abi.encodeWithSelector(IEnabler.enable.selector, ""), "Enable PriceCache");
+            _pushAction(
+                priceCache,
+                abi.encodeWithSelector(IEnabler.enable.selector, ""),
+                "Enable PriceCache"
+            );
         } else {
             console2.log("PriceCache already enabled");
         }
 
         // STEP 4: Enable oracle policies
-        _pushAction(erc7726Factory, abi.encodeWithSelector(IEnabler.enable.selector, ""), "Enable ERC7726OracleFactory");
-
         _pushAction(
-            chainlinkFactory, abi.encodeWithSelector(IEnabler.enable.selector, ""), "Enable ChainlinkOracleFactory"
+            erc7726Factory,
+            abi.encodeWithSelector(IEnabler.enable.selector, ""),
+            "Enable ERC7726OracleFactory"
         );
 
-        _pushAction(morphoFactory, abi.encodeWithSelector(IEnabler.enable.selector, ""), "Enable MorphoOracleFactory");
+        _pushAction(
+            chainlinkFactory,
+            abi.encodeWithSelector(IEnabler.enable.selector, ""),
+            "Enable ChainlinkOracleFactory"
+        );
+
+        _pushAction(
+            morphoFactory,
+            abi.encodeWithSelector(IEnabler.enable.selector, ""),
+            "Enable MorphoOracleFactory"
+        );
 
         // STEP 5: Deploy oracles
         _pushAction(
             erc7726Factory,
-            abi.encodeWithSelector(IERC7726OracleFactory.createOracle.selector, DEFAULT_ORACLE_MAX_AGE, ""),
+            abi.encodeWithSelector(
+                IERC7726OracleFactory.createOracle.selector,
+                DEFAULT_ORACLE_MAX_AGE,
+                ""
+            ),
             "Deploy ERC7726 oracle"
         );
 
         _pushAction(
             chainlinkFactory,
-            abi.encodeWithSelector(IOracleFactory.createOracle.selector, ohm, usds, DEFAULT_ORACLE_MAX_AGE, ""),
+            abi.encodeWithSelector(
+                IOracleFactory.createOracle.selector,
+                ohm,
+                usds,
+                DEFAULT_ORACLE_MAX_AGE,
+                ""
+            ),
             "Deploy OHM/USDS Chainlink oracle"
         );
 
         _pushAction(
             morphoFactory,
-            abi.encodeWithSelector(IOracleFactory.createOracle.selector, ohm, usds, DEFAULT_ORACLE_MAX_AGE, ""),
+            abi.encodeWithSelector(
+                IOracleFactory.createOracle.selector,
+                ohm,
+                usds,
+                DEFAULT_ORACLE_MAX_AGE,
+                ""
+            ),
             "Deploy OHM/USDS Morpho oracle"
         );
     }
@@ -234,7 +271,8 @@ contract OracleProposal is GovernorBravoProposal {
     ///      These mocks are cleared immediately after simulation and do not affect the calldata
     ///      submitted to governance.
     function _mockPriceFeedsAtTimelockExecution(Addresses addresses) internal {
-        uint256 executionTimestamp = block.timestamp + ITimelock(addresses.getAddress("olympus-timelock")).delay();
+        uint256 executionTimestamp = block.timestamp +
+            ITimelock(addresses.getAddress("olympus-timelock")).delay();
 
         _mockChainlinkFeedAt(CHAINLINK_BTC_USD, executionTimestamp);
         _mockChainlinkFeedAt(CHAINLINK_DAI_USD, executionTimestamp);
@@ -248,7 +286,8 @@ contract OracleProposal is GovernorBravoProposal {
     }
 
     function _mockChainlinkFeedAt(address feed_, uint256 updatedAt_) internal {
-        (uint80 roundId, int256 answer,,, uint80 answeredInRound) = AggregatorV2V3Interface(feed_).latestRoundData();
+        (uint80 roundId, int256 answer, , , uint80 answeredInRound) = AggregatorV2V3Interface(feed_)
+            .latestRoundData();
 
         vm.mockCall(
             feed_,
@@ -265,7 +304,9 @@ contract OracleProposal is GovernorBravoProposal {
         address ohm = addresses.getAddress("olympus-legacy-ohm");
         address usds = addresses.getAddress("external-tokens-usds");
 
-        address chainlinkFactory = addresses.getAddress("olympus-policy-chainlink-oracle-factory-1_0");
+        address chainlinkFactory = addresses.getAddress(
+            "olympus-policy-chainlink-oracle-factory-1_0"
+        );
         address morphoFactory = addresses.getAddress("olympus-policy-morpho-oracle-factory-1_0");
         address erc7726Factory = addresses.getAddress("olympus-policy-erc7726-oracle-factory-1_0");
         address priceCache = addresses.getAddress("olympus-policy-price-cache-1_0");
@@ -278,8 +319,14 @@ contract OracleProposal is GovernorBravoProposal {
         require(roles.hasRole(timelock, ADMIN_ROLE), "Timelock does not have admin role");
 
         // Verify oracle_manager role granted
-        require(roles.hasRole(daoMS, ORACLE_MANAGER_ROLE), "DAO MS does not have oracle_manager role");
-        require(roles.hasRole(timelock, ORACLE_MANAGER_ROLE), "Timelock does not have oracle_manager role");
+        require(
+            roles.hasRole(daoMS, ORACLE_MANAGER_ROLE),
+            "DAO MS does not have oracle_manager role"
+        );
+        require(
+            roles.hasRole(timelock, ORACLE_MANAGER_ROLE),
+            "Timelock does not have oracle_manager role"
+        );
 
         // Verify price cache and oracle policies are enabled
         require(IEnabler(priceCache).isEnabled(), "PriceCache not enabled");
@@ -288,32 +335,55 @@ contract OracleProposal is GovernorBravoProposal {
         require(IEnabler(morphoFactory).isEnabled(), "MorphoOracleFactory not enabled");
 
         // Verify oracles were deployed
-        address erc7726Oracle = IERC7726OracleFactory(erc7726Factory).getOracle(DEFAULT_ORACLE_MAX_AGE);
+        address erc7726Oracle = IERC7726OracleFactory(erc7726Factory).getOracle(
+            DEFAULT_ORACLE_MAX_AGE
+        );
         require(erc7726Oracle != address(0), "ERC7726 oracle not deployed");
-        require(IERC7726OracleFactory(erc7726Factory).isOracleEnabled(erc7726Oracle), "ERC7726 oracle not enabled");
-
-        address chainlinkOracle = IOracleFactory(chainlinkFactory).getOracle(ohm, usds, DEFAULT_ORACLE_MAX_AGE);
-        require(chainlinkOracle != address(0), "OHM/USDS Chainlink oracle not deployed");
         require(
-            IOracleFactory(chainlinkFactory).isOracleEnabled(chainlinkOracle), "OHM/USDS Chainlink oracle not enabled"
+            IERC7726OracleFactory(erc7726Factory).isOracleEnabled(erc7726Oracle),
+            "ERC7726 oracle not enabled"
         );
 
-        address morphoOracle = IOracleFactory(morphoFactory).getOracle(ohm, usds, DEFAULT_ORACLE_MAX_AGE);
+        address chainlinkOracle = IOracleFactory(chainlinkFactory).getOracle(
+            ohm,
+            usds,
+            DEFAULT_ORACLE_MAX_AGE
+        );
+        require(chainlinkOracle != address(0), "OHM/USDS Chainlink oracle not deployed");
+        require(
+            IOracleFactory(chainlinkFactory).isOracleEnabled(chainlinkOracle),
+            "OHM/USDS Chainlink oracle not enabled"
+        );
+
+        address morphoOracle = IOracleFactory(morphoFactory).getOracle(
+            ohm,
+            usds,
+            DEFAULT_ORACLE_MAX_AGE
+        );
         require(morphoOracle != address(0), "OHM/USDS Morpho oracle not deployed");
-        require(IOracleFactory(morphoFactory).isOracleEnabled(morphoOracle), "OHM/USDS Morpho oracle not enabled");
+        require(
+            IOracleFactory(morphoFactory).isOracleEnabled(morphoOracle),
+            "OHM/USDS Morpho oracle not enabled"
+        );
     }
 
-    function _verifyFactoryConfiguration(address factory_, string memory name_, bool isERC7726_, address priceCache_)
-        internal
-        view
-    {
+    function _verifyFactoryConfiguration(
+        address factory_,
+        string memory name_,
+        bool isERC7726_,
+        address priceCache_
+    ) internal view {
         require(factory_.code.length != 0, string.concat(name_, " not deployed"));
-        require(address(Policy(factory_).kernel()) == address(_kernel), string.concat(name_, " wrong kernel"));
+        require(
+            address(Policy(factory_).kernel()) == address(_kernel),
+            string.concat(name_, " wrong kernel")
+        );
         require(_kernel.isPolicyActive(Policy(factory_)), string.concat(name_, " not activated"));
 
         address expectedSource = priceCache_;
-        address factorySource =
-            isERC7726_ ? IERC7726OracleFactory(factory_).getPriceCache() : IOracleFactory(factory_).getPriceCache();
+        address factorySource = isERC7726_
+            ? IERC7726OracleFactory(factory_).getPriceCache()
+            : IOracleFactory(factory_).getPriceCache();
 
         require(factorySource == expectedSource, string.concat(name_, " wrong price cache"));
     }

--- a/src/proposals/OracleProposal.sol
+++ b/src/proposals/OracleProposal.sol
@@ -12,7 +12,6 @@ import {ROLESv1} from "src/modules/ROLES/ROLES.v1.sol";
 import {RolesAdmin} from "src/policies/RolesAdmin.sol";
 import {ITimelock} from "src/external/governance/interfaces/ITimelock.sol";
 import {AggregatorV2V3Interface} from "src/interfaces/AggregatorV2V3Interface.sol";
-import {IPyth} from "src/interfaces/IPyth.sol";
 import {IEnabler} from "src/periphery/interfaces/IEnabler.sol";
 import {IOracleFactory} from "src/policies/interfaces/price/IOracleFactory.sol";
 import {IERC7726OracleFactory} from "src/policies/interfaces/price/IERC7726OracleFactory.sol";
@@ -36,16 +35,9 @@ contract OracleProposal is GovernorBravoProposal {
     address internal constant CHAINLINK_ETH_USD = 0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419;
     address internal constant CHAINLINK_OHM_ETH = 0x9a72298ae3886221820B1c878d12D872087D3a23;
     address internal constant CHAINLINK_USDS_USD = 0xfF30586cD0F29eD462364C7e81375FC0C71219b1;
-    address internal constant PYTH = 0x4305FB66699C3B2702D4d05CF36551390A4c69C6;
+    address internal constant API3_ETH_USD = 0x5b0cf2b36a65a6BB085D501B971e4c102B9Cd473;
+    address internal constant API3_USDS_USD = address(0);
     address internal constant REDSTONE_ETH_USD = 0x67F6838e58859d612E4ddF04dA396d6DABB66Dc4;
-
-    bytes32 internal constant PYTH_ETH_USD_ID =
-        0xff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace;
-    bytes32 internal constant PYTH_USDS_USD_ID =
-        0x77f0971af11cc8bac224917275c1bf55f2319ed5c654a1ca955c82fa2d297ea1;
-
-    uint256 internal constant PYTH_ETH_USD_UPDATE_THRESHOLD = 1 hours;
-    uint256 internal constant PYTH_USDS_USD_UPDATE_THRESHOLD = 1 days;
 
     // Returns the id of the proposal.
     function id() public pure override returns (uint256) {
@@ -59,67 +51,66 @@ contract OracleProposal is GovernorBravoProposal {
 
     // Provides a detailed description of the proposal.
     function description() public pure override returns (string memory) {
-        return
-            string.concat(
-                "# Enable Oracle Policies and OHM/USDS Oracles\n",
-                "\n",
-                "## Summary\n",
-                "\n",
-                "This proposal enables the oracle policies and deploys OHM/USDS oracles.\n",
-                "\n",
-                "## Oracle Policies\n",
-                "\n",
-                "This proposal enables three oracle factories:\n",
-                "\n",
-                "### 1. ERC7726OracleFactory\n\n",
-                "- **Purpose**: Factory for deploying ERC7726-compatible oracle clones\n",
-                "- **Function**: Creates ERC7726-compatible cached-price oracles from PRICE data\n",
-                "- **Use Cases**: General lending integrations requiring ERC7726 quote interfaces\n",
-                "\n",
-                "### 2. ChainlinkOracleFactory\n\n",
-                "- **Purpose**: Factory for deploying gas-efficient Chainlink oracle clones\n",
-                "- **Function**: Creates ERC7726-compliant oracles using PRICE as the price source\n",
-                "- **Use Cases**: Protocols requiring Chainlink-compatible oracles\n",
-                "\n",
-                "### 3. MorphoOracleFactory\n\n",
-                "- **Purpose**: Factory for deploying Morpho-compatible oracle clones\n",
-                "- **Function**: Creates oracles with Morpho-specific price scaling (36 decimals)\n",
-                "- **Use Cases**: Morpho lending protocol integration\n",
-                "\n",
-                "## Actions\n",
-                "\n",
-                "This proposal will execute the following actions:\n",
-                "\n",
-                "1. **Grant `admin` role to Timelock** (if needed)\n",
-                "2. **Grant `oracle_manager` role to DAO MS and Timelock** (if needed)\n",
-                "3. **Enable PriceCache policy** (if needed)\n",
-                "4. **Enable ERC7726OracleFactory policy**\n",
-                "5. **Enable ChainlinkOracleFactory policy**\n",
-                "6. **Enable MorphoOracleFactory policy**\n",
-                "7. **Deploy ERC7726 oracle** (via ERC7726OracleFactory)\n",
-                "8. **Deploy OHM/USDS Chainlink oracle** (via ChainlinkOracleFactory)\n",
-                "9. **Deploy OHM/USDS Morpho oracle** (via MorphoOracleFactory)\n",
-                "\n",
-                "## Technical Details\n",
-                "\n",
-                "### Oracle Factory Benefits\n",
-                "\n",
-                "- **Gas Efficiency**: Uses ClonesWithImmutableArgs for minimal deployment cost\n",
-                "- **Security**: Oracles inherit access control from PRICE and factory policies\n",
-                "- **Flexibility**: New oracles can be deployed by `oracle_manager` role holders without additional governance\n",
-                "\n",
-                "## Risks and Considerations\n",
-                "\n",
-                "- **Oracle Availability**: Enabled oracle policies depend on PRICE functioning correctly\n",
-                "- **Price Feed Dependencies**: Oracle accuracy depends on underlying PRICE feeds\n",
-                "\n",
-                "## Resources\n",
-                "\n",
-                "- [Audit Report](https://storage.googleapis.com/olympusdao-landing-page-reports/audits/2026-05_Olympus_Price_Feed_Updates_Report.pdf)\n",
-                "- [Implementation PR](https://github.com/OlympusDAO/olympus-v3/pull/187)\n",
-                "- [PRICE Documentation](https://github.com/OlympusDAO/olympus-v3/blob/4248bd6d45e160f7d369c1d44f126d8cef0b7f57/documentation/price.md)\n",
-                "- [Oracle Documentation](https://github.com/OlympusDAO/olympus-v3/blob/4248bd6d45e160f7d369c1d44f126d8cef0b7f57/documentation/oracle_factories.md)\n"
-            );
+        return string.concat(
+            "# Enable Oracle Policies and OHM/USDS Oracles\n",
+            "\n",
+            "## Summary\n",
+            "\n",
+            "This proposal enables the oracle policies and deploys OHM/USDS oracles.\n",
+            "\n",
+            "## Oracle Policies\n",
+            "\n",
+            "This proposal enables three oracle factories:\n",
+            "\n",
+            "### 1. ERC7726OracleFactory\n\n",
+            "- **Purpose**: Factory for deploying ERC7726-compatible oracle clones\n",
+            "- **Function**: Creates ERC7726-compatible cached-price oracles from PRICE data\n",
+            "- **Use Cases**: General lending integrations requiring ERC7726 quote interfaces\n",
+            "\n",
+            "### 2. ChainlinkOracleFactory\n\n",
+            "- **Purpose**: Factory for deploying gas-efficient Chainlink oracle clones\n",
+            "- **Function**: Creates ERC7726-compliant oracles using PRICE as the price source\n",
+            "- **Use Cases**: Protocols requiring Chainlink-compatible oracles\n",
+            "\n",
+            "### 3. MorphoOracleFactory\n\n",
+            "- **Purpose**: Factory for deploying Morpho-compatible oracle clones\n",
+            "- **Function**: Creates oracles with Morpho-specific price scaling (36 decimals)\n",
+            "- **Use Cases**: Morpho lending protocol integration\n",
+            "\n",
+            "## Actions\n",
+            "\n",
+            "This proposal will execute the following actions:\n",
+            "\n",
+            "1. **Grant `admin` role to Timelock** (if needed)\n",
+            "2. **Grant `oracle_manager` role to DAO MS and Timelock** (if needed)\n",
+            "3. **Enable PriceCache policy** (if needed)\n",
+            "4. **Enable ERC7726OracleFactory policy**\n",
+            "5. **Enable ChainlinkOracleFactory policy**\n",
+            "6. **Enable MorphoOracleFactory policy**\n",
+            "7. **Deploy ERC7726 oracle** (via ERC7726OracleFactory)\n",
+            "8. **Deploy OHM/USDS Chainlink oracle** (via ChainlinkOracleFactory)\n",
+            "9. **Deploy OHM/USDS Morpho oracle** (via MorphoOracleFactory)\n",
+            "\n",
+            "## Technical Details\n",
+            "\n",
+            "### Oracle Factory Benefits\n",
+            "\n",
+            "- **Gas Efficiency**: Uses ClonesWithImmutableArgs for minimal deployment cost\n",
+            "- **Security**: Oracles inherit access control from PRICE and factory policies\n",
+            "- **Flexibility**: New oracles can be deployed by `oracle_manager` role holders without additional governance\n",
+            "\n",
+            "## Risks and Considerations\n",
+            "\n",
+            "- **Oracle Availability**: Enabled oracle policies depend on PRICE functioning correctly\n",
+            "- **Price Feed Dependencies**: Oracle accuracy depends on underlying PRICE feeds\n",
+            "\n",
+            "## Resources\n",
+            "\n",
+            "- [Audit Report](https://storage.googleapis.com/olympusdao-landing-page-reports/audits/2026-05_Olympus_Price_Feed_Updates_Report.pdf)\n",
+            "- [Implementation PR](https://github.com/OlympusDAO/olympus-v3/pull/187)\n",
+            "- [PRICE Documentation](https://github.com/OlympusDAO/olympus-v3/blob/4248bd6d45e160f7d369c1d44f126d8cef0b7f57/documentation/price.md)\n",
+            "- [Oracle Documentation](https://github.com/OlympusDAO/olympus-v3/blob/4248bd6d45e160f7d369c1d44f126d8cef0b7f57/documentation/oracle_factories.md)\n"
+        );
     }
 
     // Cache addresses in _deploy
@@ -137,9 +128,7 @@ contract OracleProposal is GovernorBravoProposal {
         address daoMS = addresses.getAddress("olympus-multisig-dao");
 
         address erc7726Factory = addresses.getAddress("olympus-policy-erc7726-oracle-factory-1_0");
-        address chainlinkFactory = addresses.getAddress(
-            "olympus-policy-chainlink-oracle-factory-1_0"
-        );
+        address chainlinkFactory = addresses.getAddress("olympus-policy-chainlink-oracle-factory-1_0");
         address morphoFactory = addresses.getAddress("olympus-policy-morpho-oracle-factory-1_0");
         address priceCache = addresses.getAddress("olympus-policy-price-cache-1_0");
 
@@ -176,11 +165,7 @@ contract OracleProposal is GovernorBravoProposal {
         if (!roles.hasRole(timelock, ORACLE_MANAGER_ROLE)) {
             _pushAction(
                 rolesAdmin,
-                abi.encodeWithSelector(
-                    RolesAdmin.grantRole.selector,
-                    ORACLE_MANAGER_ROLE,
-                    timelock
-                ),
+                abi.encodeWithSelector(RolesAdmin.grantRole.selector, ORACLE_MANAGER_ROLE, timelock),
                 "Grant oracle_manager role to Timelock"
             );
         } else {
@@ -189,66 +174,36 @@ contract OracleProposal is GovernorBravoProposal {
 
         // STEP 3: Enable PriceCache, if needed
         if (!IEnabler(priceCache).isEnabled()) {
-            _pushAction(
-                priceCache,
-                abi.encodeWithSelector(IEnabler.enable.selector, ""),
-                "Enable PriceCache"
-            );
+            _pushAction(priceCache, abi.encodeWithSelector(IEnabler.enable.selector, ""), "Enable PriceCache");
         } else {
             console2.log("PriceCache already enabled");
         }
 
         // STEP 4: Enable oracle policies
-        _pushAction(
-            erc7726Factory,
-            abi.encodeWithSelector(IEnabler.enable.selector, ""),
-            "Enable ERC7726OracleFactory"
-        );
+        _pushAction(erc7726Factory, abi.encodeWithSelector(IEnabler.enable.selector, ""), "Enable ERC7726OracleFactory");
 
         _pushAction(
-            chainlinkFactory,
-            abi.encodeWithSelector(IEnabler.enable.selector, ""),
-            "Enable ChainlinkOracleFactory"
+            chainlinkFactory, abi.encodeWithSelector(IEnabler.enable.selector, ""), "Enable ChainlinkOracleFactory"
         );
 
-        _pushAction(
-            morphoFactory,
-            abi.encodeWithSelector(IEnabler.enable.selector, ""),
-            "Enable MorphoOracleFactory"
-        );
+        _pushAction(morphoFactory, abi.encodeWithSelector(IEnabler.enable.selector, ""), "Enable MorphoOracleFactory");
 
         // STEP 5: Deploy oracles
         _pushAction(
             erc7726Factory,
-            abi.encodeWithSelector(
-                IERC7726OracleFactory.createOracle.selector,
-                DEFAULT_ORACLE_MAX_AGE,
-                ""
-            ),
+            abi.encodeWithSelector(IERC7726OracleFactory.createOracle.selector, DEFAULT_ORACLE_MAX_AGE, ""),
             "Deploy ERC7726 oracle"
         );
 
         _pushAction(
             chainlinkFactory,
-            abi.encodeWithSelector(
-                IOracleFactory.createOracle.selector,
-                ohm,
-                usds,
-                DEFAULT_ORACLE_MAX_AGE,
-                ""
-            ),
+            abi.encodeWithSelector(IOracleFactory.createOracle.selector, ohm, usds, DEFAULT_ORACLE_MAX_AGE, ""),
             "Deploy OHM/USDS Chainlink oracle"
         );
 
         _pushAction(
             morphoFactory,
-            abi.encodeWithSelector(
-                IOracleFactory.createOracle.selector,
-                ohm,
-                usds,
-                DEFAULT_ORACLE_MAX_AGE,
-                ""
-            ),
+            abi.encodeWithSelector(IOracleFactory.createOracle.selector, ohm, usds, DEFAULT_ORACLE_MAX_AGE, ""),
             "Deploy OHM/USDS Morpho oracle"
         );
     }
@@ -269,7 +224,7 @@ contract OracleProposal is GovernorBravoProposal {
 
     /// @dev GovernorBravoProposal simulates execution after the timelock delay by warping the fork
     ///      forward. On a static fork, external oracle contracts do not receive the
-    ///      Chainlink/Pyth/RedStone updates that would occur during that real elapsed time, so PRICE
+    ///      Chainlink/API3/RedStone updates that would occur during that real elapsed time, so PRICE
     ///      can reject otherwise valid proposal actions with stale-feed errors.
     ///
     ///      The proposal actions depend on PRICE during simulation because deploying the
@@ -279,8 +234,7 @@ contract OracleProposal is GovernorBravoProposal {
     ///      These mocks are cleared immediately after simulation and do not affect the calldata
     ///      submitted to governance.
     function _mockPriceFeedsAtTimelockExecution(Addresses addresses) internal {
-        uint256 executionTimestamp = block.timestamp +
-            ITimelock(addresses.getAddress("olympus-timelock")).delay();
+        uint256 executionTimestamp = block.timestamp + ITimelock(addresses.getAddress("olympus-timelock")).delay();
 
         _mockChainlinkFeedAt(CHAINLINK_BTC_USD, executionTimestamp);
         _mockChainlinkFeedAt(CHAINLINK_DAI_USD, executionTimestamp);
@@ -288,47 +242,20 @@ contract OracleProposal is GovernorBravoProposal {
         _mockChainlinkFeedAt(CHAINLINK_ETH_USD, executionTimestamp);
         _mockChainlinkFeedAt(CHAINLINK_OHM_ETH, executionTimestamp);
         _mockChainlinkFeedAt(CHAINLINK_USDS_USD, executionTimestamp);
+        _mockChainlinkFeedAt(API3_ETH_USD, executionTimestamp);
+        if (API3_USDS_USD != address(0)) {
+            _mockChainlinkFeedAt(API3_USDS_USD, executionTimestamp);
+        }
         _mockChainlinkFeedAt(REDSTONE_ETH_USD, executionTimestamp);
-
-        _mockPythFeedAt(
-            PYTH,
-            PYTH_ETH_USD_ID,
-            PYTH_ETH_USD_UPDATE_THRESHOLD,
-            IPyth.Price({price: 233654247160, conf: 0, expo: -8, publishTime: executionTimestamp})
-        );
-        _mockPythFeedAt(
-            PYTH,
-            PYTH_USDS_USD_ID,
-            PYTH_USDS_USD_UPDATE_THRESHOLD,
-            IPyth.Price({price: 100000000, conf: 0, expo: -8, publishTime: executionTimestamp})
-        );
     }
 
     function _mockChainlinkFeedAt(address feed_, uint256 updatedAt_) internal {
-        (uint80 roundId, int256 answer, , , uint80 answeredInRound) = AggregatorV2V3Interface(feed_)
-            .latestRoundData();
+        (uint80 roundId, int256 answer,,, uint80 answeredInRound) = AggregatorV2V3Interface(feed_).latestRoundData();
 
         vm.mockCall(
             feed_,
             abi.encodeWithSignature("latestRoundData()"),
             abi.encode(roundId, answer, updatedAt_, updatedAt_, answeredInRound)
-        );
-    }
-
-    function _mockPythFeedAt(
-        address pyth_,
-        bytes32 priceFeedId_,
-        uint256 updateThreshold_,
-        IPyth.Price memory price_
-    ) internal {
-        vm.mockCall(
-            pyth_,
-            abi.encodeWithSelector(
-                IPyth.getPriceNoOlderThan.selector,
-                priceFeedId_,
-                updateThreshold_
-            ),
-            abi.encode(price_)
         );
     }
 
@@ -340,9 +267,7 @@ contract OracleProposal is GovernorBravoProposal {
         address ohm = addresses.getAddress("olympus-legacy-ohm");
         address usds = addresses.getAddress("external-tokens-usds");
 
-        address chainlinkFactory = addresses.getAddress(
-            "olympus-policy-chainlink-oracle-factory-1_0"
-        );
+        address chainlinkFactory = addresses.getAddress("olympus-policy-chainlink-oracle-factory-1_0");
         address morphoFactory = addresses.getAddress("olympus-policy-morpho-oracle-factory-1_0");
         address erc7726Factory = addresses.getAddress("olympus-policy-erc7726-oracle-factory-1_0");
         address priceCache = addresses.getAddress("olympus-policy-price-cache-1_0");
@@ -355,14 +280,8 @@ contract OracleProposal is GovernorBravoProposal {
         require(roles.hasRole(timelock, ADMIN_ROLE), "Timelock does not have admin role");
 
         // Verify oracle_manager role granted
-        require(
-            roles.hasRole(daoMS, ORACLE_MANAGER_ROLE),
-            "DAO MS does not have oracle_manager role"
-        );
-        require(
-            roles.hasRole(timelock, ORACLE_MANAGER_ROLE),
-            "Timelock does not have oracle_manager role"
-        );
+        require(roles.hasRole(daoMS, ORACLE_MANAGER_ROLE), "DAO MS does not have oracle_manager role");
+        require(roles.hasRole(timelock, ORACLE_MANAGER_ROLE), "Timelock does not have oracle_manager role");
 
         // Verify price cache and oracle policies are enabled
         require(IEnabler(priceCache).isEnabled(), "PriceCache not enabled");
@@ -371,55 +290,32 @@ contract OracleProposal is GovernorBravoProposal {
         require(IEnabler(morphoFactory).isEnabled(), "MorphoOracleFactory not enabled");
 
         // Verify oracles were deployed
-        address erc7726Oracle = IERC7726OracleFactory(erc7726Factory).getOracle(
-            DEFAULT_ORACLE_MAX_AGE
-        );
+        address erc7726Oracle = IERC7726OracleFactory(erc7726Factory).getOracle(DEFAULT_ORACLE_MAX_AGE);
         require(erc7726Oracle != address(0), "ERC7726 oracle not deployed");
-        require(
-            IERC7726OracleFactory(erc7726Factory).isOracleEnabled(erc7726Oracle),
-            "ERC7726 oracle not enabled"
-        );
+        require(IERC7726OracleFactory(erc7726Factory).isOracleEnabled(erc7726Oracle), "ERC7726 oracle not enabled");
 
-        address chainlinkOracle = IOracleFactory(chainlinkFactory).getOracle(
-            ohm,
-            usds,
-            DEFAULT_ORACLE_MAX_AGE
-        );
+        address chainlinkOracle = IOracleFactory(chainlinkFactory).getOracle(ohm, usds, DEFAULT_ORACLE_MAX_AGE);
         require(chainlinkOracle != address(0), "OHM/USDS Chainlink oracle not deployed");
         require(
-            IOracleFactory(chainlinkFactory).isOracleEnabled(chainlinkOracle),
-            "OHM/USDS Chainlink oracle not enabled"
+            IOracleFactory(chainlinkFactory).isOracleEnabled(chainlinkOracle), "OHM/USDS Chainlink oracle not enabled"
         );
 
-        address morphoOracle = IOracleFactory(morphoFactory).getOracle(
-            ohm,
-            usds,
-            DEFAULT_ORACLE_MAX_AGE
-        );
+        address morphoOracle = IOracleFactory(morphoFactory).getOracle(ohm, usds, DEFAULT_ORACLE_MAX_AGE);
         require(morphoOracle != address(0), "OHM/USDS Morpho oracle not deployed");
-        require(
-            IOracleFactory(morphoFactory).isOracleEnabled(morphoOracle),
-            "OHM/USDS Morpho oracle not enabled"
-        );
+        require(IOracleFactory(morphoFactory).isOracleEnabled(morphoOracle), "OHM/USDS Morpho oracle not enabled");
     }
 
-    function _verifyFactoryConfiguration(
-        address factory_,
-        string memory name_,
-        bool isERC7726_,
-        address priceCache_
-    ) internal view {
+    function _verifyFactoryConfiguration(address factory_, string memory name_, bool isERC7726_, address priceCache_)
+        internal
+        view
+    {
         require(factory_.code.length != 0, string.concat(name_, " not deployed"));
-        require(
-            address(Policy(factory_).kernel()) == address(_kernel),
-            string.concat(name_, " wrong kernel")
-        );
+        require(address(Policy(factory_).kernel()) == address(_kernel), string.concat(name_, " wrong kernel"));
         require(_kernel.isPolicyActive(Policy(factory_)), string.concat(name_, " not activated"));
 
         address expectedSource = priceCache_;
-        address factorySource = isERC7726_
-            ? IERC7726OracleFactory(factory_).getPriceCache()
-            : IOracleFactory(factory_).getPriceCache();
+        address factorySource =
+            isERC7726_ ? IERC7726OracleFactory(factory_).getPriceCache() : IOracleFactory(factory_).getPriceCache();
 
         require(factorySource == expectedSource, string.concat(name_, " wrong price cache"));
     }

--- a/src/scripts/deploy/savedDeployments/price_v1_2_deploy.json
+++ b/src/scripts/deploy/savedDeployments/price_v1_2_deploy.json
@@ -12,10 +12,6 @@
             "args": {}
         },
         {
-            "name": "PythPriceFeeds",
-            "args": {}
-        },
-        {
             "name": "UniswapV3Price",
             "args": {
                 "averageBlockTimeSeconds": 12

--- a/src/scripts/ops/batches/ConfigurePriceV1_2.sol
+++ b/src/scripts/ops/batches/ConfigurePriceV1_2.sol
@@ -25,7 +25,6 @@ import {PriceConfigv2} from "src/policies/price/PriceConfig.v2.sol";
 // PRICE Submodules
 import {ChainlinkPriceFeeds} from "src/modules/PRICE/submodules/feeds/ChainlinkPriceFeeds.sol";
 import {ERC4626Price} from "src/modules/PRICE/submodules/feeds/ERC4626Price.sol";
-import {PythPriceFeeds} from "src/modules/PRICE/submodules/feeds/PythPriceFeeds.sol";
 import {UniswapV3Price} from "src/modules/PRICE/submodules/feeds/UniswapV3Price.sol";
 import {SimplePriceFeedStrategy} from "src/modules/PRICE/submodules/strategies/SimplePriceFeedStrategy.sol";
 
@@ -39,12 +38,11 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
 
     // ========== STATE ========== //
 
-    /// @notice Addresses of assets and Pyth contract (loaded from args or env)
+    /// @notice Addresses of assets (loaded from args or env)
     address internal _usds;
     address internal _susds;
     address internal _weth;
     address internal _ohm;
-    address internal _pyth;
 
     /// @notice Configuration parameters (loaded from args)
     uint32 internal _uniswapOhmWethObservationWindow;
@@ -79,9 +77,6 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
         _weth = _envAddressNotZero("external.tokens.WETH");
         _ohm = _envAddressNotZero("olympus.legacy.OHM");
 
-        // Load Pyth contract address from args file (shared by all Pyth feeds)
-        _pyth = _readBatchArgAddress("configurePriceV1_2", "pyth");
-
         vm.label(kernel, "Kernel");
         vm.label(priceModule, "PRICE v1.2");
         vm.label(priceConfig, "PriceConfig v2");
@@ -89,18 +84,13 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
         vm.label(_susds, "sUSDS");
         vm.label(_weth, "WETH");
         vm.label(_ohm, "OHM");
-        vm.label(_pyth, "Pyth");
 
         // Load configuration parameters from args file
-        _uniswapOhmWethObservationWindow = _readBatchArgUint256(
-            "configurePriceV1_2",
-            "uniswapOhmWethObservationWindow"
-        ).encodeUInt32();
+        _uniswapOhmWethObservationWindow =
+            _readBatchArgUint256("configurePriceV1_2", "uniswapOhmWethObservationWindow").encodeUInt32();
 
-        _uniswapOhmSusdsObservationWindow = _readBatchArgUint256(
-            "configurePriceV1_2",
-            "uniswapOhmSusdsObservationWindow"
-        ).encodeUInt32();
+        _uniswapOhmSusdsObservationWindow =
+            _readBatchArgUint256("configurePriceV1_2", "uniswapOhmSusdsObservationWindow").encodeUInt32();
 
         console2.log("Kernel:", kernel);
         console2.log("PriceConfig:", priceConfig);
@@ -128,25 +118,11 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
 
         // Upgrade PRICE v1.2 module in the kernel
         console2.log("Upgrading PRICE module");
-        addToBatch(
-            kernel,
-            abi.encodeWithSelector(
-                Kernel.executeAction.selector,
-                Actions.UpgradeModule,
-                priceModule
-            )
-        );
+        addToBatch(kernel, abi.encodeWithSelector(Kernel.executeAction.selector, Actions.UpgradeModule, priceModule));
 
         // Activate PriceConfig V2 policy in the kernel
         console2.log("Activating PriceConfig V2 policy");
-        addToBatch(
-            kernel,
-            abi.encodeWithSelector(
-                Kernel.executeAction.selector,
-                Actions.ActivatePolicy,
-                priceConfig
-            )
-        );
+        addToBatch(kernel, abi.encodeWithSelector(Kernel.executeAction.selector, Actions.ActivatePolicy, priceConfig));
 
         // Install submodules first
         _installSubmodules(priceConfig);
@@ -172,53 +148,30 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
 
         // Load submodule addresses from env
         address chainlinkFeeds = _envAddressNotZero("olympus.submodules.PRICE.ChainlinkPriceFeeds");
-        address pythFeeds = _envAddressNotZero("olympus.submodules.PRICE.PythPriceFeeds");
         address uniswapV3Price = _envAddressNotZero("olympus.submodules.PRICE.UniswapV3Price");
         address erc4626Price = _envAddressNotZero("olympus.submodules.PRICE.ERC4626Price");
-        address simpleStrategy = _envAddressNotZero(
-            "olympus.submodules.PRICE.SimplePriceFeedStrategy"
-        );
+        address simpleStrategy = _envAddressNotZero("olympus.submodules.PRICE.SimplePriceFeedStrategy");
 
         vm.label(chainlinkFeeds, "PRICE.ChainlinkPriceFeeds");
-        vm.label(pythFeeds, "PRICE.PythPriceFeeds");
         vm.label(uniswapV3Price, "PRICE.UniswapV3Price");
         vm.label(erc4626Price, "PRICE.ERC4626Price");
         vm.label(simpleStrategy, "PRICE.SimplePriceFeedStrategy");
 
         // Install ChainlinkPriceFeeds
         console2.log("1. Installing ChainlinkPriceFeeds submodule");
-        addToBatch(
-            priceConfig_,
-            abi.encodeWithSelector(PriceConfigv2.installSubmodule.selector, chainlinkFeeds)
-        );
-
-        // Install PythPriceFeeds
-        console2.log("2. Installing PythPriceFeeds submodule");
-        addToBatch(
-            priceConfig_,
-            abi.encodeWithSelector(PriceConfigv2.installSubmodule.selector, pythFeeds)
-        );
+        addToBatch(priceConfig_, abi.encodeWithSelector(PriceConfigv2.installSubmodule.selector, chainlinkFeeds));
 
         // Install UniswapV3Price
-        console2.log("3. Installing UniswapV3Price submodule");
-        addToBatch(
-            priceConfig_,
-            abi.encodeWithSelector(PriceConfigv2.installSubmodule.selector, uniswapV3Price)
-        );
+        console2.log("2. Installing UniswapV3Price submodule");
+        addToBatch(priceConfig_, abi.encodeWithSelector(PriceConfigv2.installSubmodule.selector, uniswapV3Price));
 
         // Install ERC4626Price
-        console2.log("4. Installing ERC4626Price submodule");
-        addToBatch(
-            priceConfig_,
-            abi.encodeWithSelector(PriceConfigv2.installSubmodule.selector, erc4626Price)
-        );
+        console2.log("3. Installing ERC4626Price submodule");
+        addToBatch(priceConfig_, abi.encodeWithSelector(PriceConfigv2.installSubmodule.selector, erc4626Price));
 
         // Install SimplePriceFeedStrategy
-        console2.log("5. Installing SimplePriceFeedStrategy submodule");
-        addToBatch(
-            priceConfig_,
-            abi.encodeWithSelector(PriceConfigv2.installSubmodule.selector, simpleStrategy)
-        );
+        console2.log("4. Installing SimplePriceFeedStrategy submodule");
+        addToBatch(priceConfig_, abi.encodeWithSelector(PriceConfigv2.installSubmodule.selector, simpleStrategy));
 
         console2.log("All submodules installation batched");
     }
@@ -231,42 +184,29 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
         // Read price feed addresses from args file
         address chainlinkUsdsUsd = _readBatchArgAddress("configurePriceV1_2", "chainlinkUsdsUsd");
         address chainlinkDaiUsd = _readBatchArgAddress("configurePriceV1_2", "chainlinkDaiUsd");
+        address api3UsdsUsd = _readBatchArgAddress("configurePriceV1_2", "api3UsdsUsd");
 
         // Read deviation parameters from args file
-        uint16 usdsPriceFeedDeviationBps = SafeCast.encodeUInt16(
-            _readBatchArgUint256("configurePriceV1_2", "usdsPriceFeedDeviationBps")
-        );
-        bool usdsRevertOnInsufficientPriceFeeds = _readBatchArgBool(
-            "configurePriceV1_2",
-            "usdsRevertOnInsufficientPriceFeeds"
-        );
+        uint16 usdsPriceFeedDeviationBps =
+            SafeCast.encodeUInt16(_readBatchArgUint256("configurePriceV1_2", "usdsPriceFeedDeviationBps"));
+        bool usdsRevertOnInsufficientPriceFeeds =
+            _readBatchArgBool("configurePriceV1_2", "usdsRevertOnInsufficientPriceFeeds");
 
         // Read update thresholds from args file
-        uint48 chainlinkUsdsUsdUpdateThreshold = SafeCast.encodeUInt48(
-            _readBatchArgUint256("configurePriceV1_2", "chainlinkUsdsUsdUpdateThreshold")
-        );
-        uint48 chainlinkDaiUsdUpdateThreshold = SafeCast.encodeUInt48(
-            _readBatchArgUint256("configurePriceV1_2", "chainlinkDaiUsdUpdateThreshold")
-        );
-        uint48 pythUsdsUsdUpdateThreshold = SafeCast.encodeUInt48(
-            _readBatchArgUint256("configurePriceV1_2", "pythUsdsUsdUpdateThreshold")
-        );
-
-        // Read Pyth feed parameters from args file
-        bytes32 pythUsdsUsdId = _readBatchArgBytes32("configurePriceV1_2", "pythUsdsUsdFeedId");
-        uint256 pythUsdsUsdMaxConfidence = _readBatchArgUint256(
-            "configurePriceV1_2",
-            "pythUsdsUsdMaxConfidence"
-        );
+        uint48 chainlinkUsdsUsdUpdateThreshold =
+            SafeCast.encodeUInt48(_readBatchArgUint256("configurePriceV1_2", "chainlinkUsdsUsdUpdateThreshold"));
+        uint48 chainlinkDaiUsdUpdateThreshold =
+            SafeCast.encodeUInt48(_readBatchArgUint256("configurePriceV1_2", "chainlinkDaiUsdUpdateThreshold"));
+        uint48 api3UsdsUsdUpdateThreshold =
+            SafeCast.encodeUInt48(_readBatchArgUint256("configurePriceV1_2", "api3UsdsUsdUpdateThreshold"));
 
         vm.label(chainlinkUsdsUsd, "Chainlink USDS/USD");
         vm.label(chainlinkDaiUsd, "Chainlink DAI/USD");
+        vm.label(api3UsdsUsd, "API3 USDS/USD");
 
         console2.log("Chainlink USDS/USD:", chainlinkUsdsUsd);
         console2.log("Chainlink DAI/USD:", chainlinkDaiUsd);
-        console2.log("Pyth contract:", _pyth);
-        console2.log("Pyth USDS/USD ID:");
-        console2.logBytes32(pythUsdsUsdId);
+        console2.log("API3 USDS/USD:", api3UsdsUsd);
 
         // Create strategy component: getAveragePriceExcludingDeviations
         IPRICEv2.Component memory strategy = _encodeDeviationStrategy(
@@ -282,8 +222,7 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
             ChainlinkPriceFeeds.getOneFeedPrice.selector,
             abi.encode(
                 ChainlinkPriceFeeds.OneFeedParams({
-                    feed: AggregatorV2V3Interface(chainlinkUsdsUsd),
-                    updateThreshold: chainlinkUsdsUsdUpdateThreshold
+                    feed: AggregatorV2V3Interface(chainlinkUsdsUsd), updateThreshold: chainlinkUsdsUsdUpdateThreshold
                 })
             )
         );
@@ -292,32 +231,22 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
             ChainlinkPriceFeeds.getOneFeedPrice.selector,
             abi.encode(
                 ChainlinkPriceFeeds.OneFeedParams({
-                    feed: AggregatorV2V3Interface(chainlinkDaiUsd),
-                    updateThreshold: chainlinkDaiUsdUpdateThreshold
+                    feed: AggregatorV2V3Interface(chainlinkDaiUsd), updateThreshold: chainlinkDaiUsdUpdateThreshold
                 })
             )
         );
         feeds[2] = _encodeFeed(
-            toSubKeycode("PRICE.PYTH"),
-            PythPriceFeeds.getOneFeedPrice.selector,
+            toSubKeycode("PRICE.CHAINLINK"), // API3 uses Chainlink interface
+            ChainlinkPriceFeeds.getOneFeedPrice.selector,
             abi.encode(
-                PythPriceFeeds.OneFeedParams({
-                    pyth: _pyth,
-                    priceFeedId: pythUsdsUsdId,
-                    updateThreshold: pythUsdsUsdUpdateThreshold,
-                    maxConfidence: pythUsdsUsdMaxConfidence
+                ChainlinkPriceFeeds.OneFeedParams({
+                    feed: AggregatorV2V3Interface(api3UsdsUsd), updateThreshold: api3UsdsUsdUpdateThreshold
                 })
             )
         );
 
         // Add asset via PriceConfig
-        _addAsset(
-            priceConfig_,
-            _usds,
-            strategy,
-            feeds,
-            _readFeedExpectations(feeds.length, "usds")
-        );
+        _addAsset(priceConfig_, _usds, strategy, feeds, _readFeedExpectations(feeds.length, "usds"));
 
         console2.log("USDS asset configured");
     }
@@ -328,11 +257,8 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
         console2.log("\n=== Configuring sUSDS Asset ===");
 
         // Empty strategy (single feed, no aggregation needed)
-        IPRICEv2.Component memory strategy = IPRICEv2.Component({
-            target: toSubKeycode(""),
-            selector: bytes4(0),
-            params: abi.encode("")
-        });
+        IPRICEv2.Component memory strategy =
+            IPRICEv2.Component({target: toSubKeycode(""), selector: bytes4(0), params: abi.encode("")});
 
         // Single ERC4626 feed - derives price from the underlying asset (USDS)
         IPRICEv2.Component[] memory feeds = new IPRICEv2.Component[](1);
@@ -343,13 +269,7 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
         });
 
         // Add asset via PriceConfig
-        _addAsset(
-            priceConfig_,
-            _susds,
-            strategy,
-            feeds,
-            _readFeedExpectations(feeds.length, "susds")
-        );
+        _addAsset(priceConfig_, _susds, strategy, feeds, _readFeedExpectations(feeds.length, "susds"));
 
         console2.log("sUSDS asset configured");
     }
@@ -362,35 +282,25 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
         // Read price feed addresses from args file
         address chainlinkEthUsd = _readBatchArgAddress("configurePriceV1_2", "chainlinkEthUsd");
         address redstoneEthUsd = _readBatchArgAddress("configurePriceV1_2", "redstoneEthUsd");
-        bytes32 pythEthUsdId = _readBatchArgBytes32("configurePriceV1_2", "pythEthUsdFeedId");
+        address api3EthUsd = _readBatchArgAddress("configurePriceV1_2", "api3EthUsd");
         address chainlinkBtcUsd = _readBatchArgAddress("configurePriceV1_2", "chainlinkBtcUsd");
         address chainlinkEthBtc = _readBatchArgAddress("configurePriceV1_2", "chainlinkEthBtc");
 
-        // Read max confidence for Pyth ETH feed from args file
-        uint256 pythEthUsdMaxConfidence = _readBatchArgUint256(
-            "configurePriceV1_2",
-            "pythEthUsdMaxConfidence"
-        );
-
         // Read deviation parameters from args file
-        uint16 wethPriceFeedDeviationBps = SafeCast.encodeUInt16(
-            _readBatchArgUint256("configurePriceV1_2", "wethPriceFeedDeviationBps")
-        );
-        bool wethRevertOnInsufficientPriceFeeds = _readBatchArgBool(
-            "configurePriceV1_2",
-            "wethRevertOnInsufficientPriceFeeds"
-        );
+        uint16 wethPriceFeedDeviationBps =
+            SafeCast.encodeUInt16(_readBatchArgUint256("configurePriceV1_2", "wethPriceFeedDeviationBps"));
+        bool wethRevertOnInsufficientPriceFeeds =
+            _readBatchArgBool("configurePriceV1_2", "wethRevertOnInsufficientPriceFeeds");
 
         vm.label(chainlinkEthUsd, "Chainlink ETH/USD");
         vm.label(redstoneEthUsd, "RedStone ETH/USD");
+        vm.label(api3EthUsd, "API3 ETH/USD");
         vm.label(chainlinkBtcUsd, "Chainlink BTC/USD");
         vm.label(chainlinkEthBtc, "Chainlink ETH/BTC");
 
         console2.log("Chainlink ETH/USD:", chainlinkEthUsd);
         console2.log("RedStone ETH/USD:", redstoneEthUsd);
-        console2.log("Pyth contract:", _pyth);
-        console2.log("Pyth ETH/USD ID:");
-        console2.logBytes32(pythEthUsdId);
+        console2.log("API3 ETH/USD:", api3EthUsd);
         console2.log("Chainlink BTC/USD:", chainlinkBtcUsd);
         console2.log("Chainlink ETH/BTC:", chainlinkEthBtc);
         console2.log(
@@ -402,8 +312,7 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
             _readBatchArgUint256("configurePriceV1_2", "redstoneEthUsdUpdateThreshold")
         );
         console2.log(
-            "Pyth ETH/USD update threshold:",
-            _readBatchArgUint256("configurePriceV1_2", "pythEthUsdUpdateThreshold")
+            "API3 ETH/USD update threshold:", _readBatchArgUint256("configurePriceV1_2", "api3EthUsdUpdateThreshold")
         );
 
         // Create strategy component: getAveragePriceExcludingDeviations
@@ -443,16 +352,14 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
             )
         );
         feeds[2] = _encodeFeed(
-            toSubKeycode("PRICE.PYTH"),
-            PythPriceFeeds.getOneFeedPrice.selector,
+            toSubKeycode("PRICE.CHAINLINK"), // API3 uses Chainlink interface
+            ChainlinkPriceFeeds.getOneFeedPrice.selector,
             abi.encode(
-                PythPriceFeeds.OneFeedParams({
-                    pyth: _pyth,
-                    priceFeedId: pythEthUsdId,
+                ChainlinkPriceFeeds.OneFeedParams({
+                    feed: AggregatorV2V3Interface(api3EthUsd),
                     updateThreshold: SafeCast.encodeUInt48(
-                        _readBatchArgUint256("configurePriceV1_2", "pythEthUsdUpdateThreshold")
-                    ),
-                    maxConfidence: pythEthUsdMaxConfidence
+                        _readBatchArgUint256("configurePriceV1_2", "api3EthUsdUpdateThreshold")
+                    )
                 })
             )
         );
@@ -476,13 +383,7 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
         );
 
         // Add asset via PriceConfig
-        _addAsset(
-            priceConfig_,
-            _weth,
-            strategy,
-            feeds,
-            _readFeedExpectations(feeds.length, "weth")
-        );
+        _addAsset(priceConfig_, _weth, strategy, feeds, _readFeedExpectations(feeds.length, "weth"));
 
         console2.log("wETH asset configured");
     }
@@ -497,13 +398,9 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
         address uniswapOhmSusds = _readBatchArgAddress("configurePriceV1_2", "uniswapOhmSusds");
 
         // Read deviation parameters from args file
-        uint16 ohmDeviationBps = SafeCast.encodeUInt16(
-            _readBatchArgUint256("configurePriceV1_2", "ohmDeviationBps")
-        );
-        bool ohmRevertOnInsufficientPriceFeeds = _readBatchArgBool(
-            "configurePriceV1_2",
-            "ohmRevertOnInsufficientPriceFeeds"
-        );
+        uint16 ohmDeviationBps = SafeCast.encodeUInt16(_readBatchArgUint256("configurePriceV1_2", "ohmDeviationBps"));
+        bool ohmRevertOnInsufficientPriceFeeds =
+            _readBatchArgBool("configurePriceV1_2", "ohmRevertOnInsufficientPriceFeeds");
 
         console2.log("Uniswap OHM/WETH:", uniswapOhmWeth);
         console2.log("Uniswap OHM/sUSDS:", uniswapOhmSusds);
@@ -516,18 +413,12 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
         );
         IPRICEv2.Component[] memory feeds = _getOhmFeeds();
 
-        IPriceConfigv2.PriceFeedExpectation[] memory feedExpectations = _readFeedExpectations(
-            feeds.length,
-            "ohm"
-        );
+        IPriceConfigv2.PriceFeedExpectation[] memory feedExpectations = _readFeedExpectations(feeds.length, "ohm");
         console2.log("OHM initial price:", feedExpectations[0].expectedPrice);
 
         // Set last observation time to current time
-        (
-            uint32 ohmMovingAverageDuration,
-            uint48 ohmLastObservationTime,
-            uint256[] memory ohmObservations
-        ) = _getMigratedOhmObservations(oldPrice_);
+        (uint32 ohmMovingAverageDuration, uint48 ohmLastObservationTime, uint256[] memory ohmObservations) =
+            _getMigratedOhmObservations(oldPrice_);
 
         // Add asset via PriceConfig with moving average configuration
         _addAssetWithMA(
@@ -565,12 +456,10 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
         address chainlinkOhmEth = _envAddressNotZero("external.chainlink.ohmEthPriceFeed");
         address chainlinkEthUsd = _readBatchArgAddress("configurePriceV1_2", "chainlinkEthUsd");
 
-        uint48 chainlinkOhmEthUpdateThreshold = SafeCast.encodeUInt48(
-            _readBatchArgUint256("configurePriceV1_2", "chainlinkOhmEthUpdateThreshold")
-        );
-        uint48 chainlinkEthUsdUpdateThreshold = SafeCast.encodeUInt48(
-            _readBatchArgUint256("configurePriceV1_2", "chainlinkEthUsdUpdateThreshold")
-        );
+        uint48 chainlinkOhmEthUpdateThreshold =
+            SafeCast.encodeUInt48(_readBatchArgUint256("configurePriceV1_2", "chainlinkOhmEthUpdateThreshold"));
+        uint48 chainlinkEthUsdUpdateThreshold =
+            SafeCast.encodeUInt48(_readBatchArgUint256("configurePriceV1_2", "chainlinkEthUsdUpdateThreshold"));
 
         vm.label(uniswapOhmWeth, "Uniswap OHM/WETH");
         vm.label(uniswapOhmSusds, "Uniswap OHM/sUSDS");
@@ -589,8 +478,7 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
             UniswapV3Price.getTokenTWAP.selector,
             abi.encode(
                 UniswapV3Price.UniswapV3Params({
-                    pool: IUniswapV3Pool(uniswapOhmWeth),
-                    observationWindowSeconds: _uniswapOhmWethObservationWindow
+                    pool: IUniswapV3Pool(uniswapOhmWeth), observationWindowSeconds: _uniswapOhmWethObservationWindow
                 })
             )
         );
@@ -599,8 +487,7 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
             UniswapV3Price.getTokenTWAP.selector,
             abi.encode(
                 UniswapV3Price.UniswapV3Params({
-                    pool: IUniswapV3Pool(uniswapOhmSusds),
-                    observationWindowSeconds: _uniswapOhmSusdsObservationWindow
+                    pool: IUniswapV3Pool(uniswapOhmSusds), observationWindowSeconds: _uniswapOhmSusdsObservationWindow
                 })
             )
         );
@@ -618,22 +505,15 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
         );
     }
 
-    function _getMigratedOhmObservations(
-        PRICEv1 oldPrice_
-    )
+    function _getMigratedOhmObservations(PRICEv1 oldPrice_)
         internal
         view
-        returns (
-            uint32 ohmMovingAverageDuration_,
-            uint48 ohmLastObservationTime_,
-            uint256[] memory ohmObservations_
-        )
+        returns (uint32 ohmMovingAverageDuration_, uint48 ohmLastObservationTime_, uint256[] memory ohmObservations_)
     {
         ohmMovingAverageDuration_ = uint32(oldPrice_.movingAverageDuration());
 
         uint32 oldNumObservations = oldPrice_.numObservations();
-        uint256 expectedNumObservations = uint256(ohmMovingAverageDuration_) /
-            uint256(oldPrice_.observationFrequency());
+        uint256 expectedNumObservations = uint256(ohmMovingAverageDuration_) / uint256(oldPrice_.observationFrequency());
 
         if (expectedNumObservations != uint256(oldNumObservations)) {
             revert("OHM observation count mismatch");
@@ -725,19 +605,14 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
     /// @param length_ Number of configured feeds for the asset
     /// @param assetPrefix_ Lowercase asset prefix used in the args file
     /// @return expectations_ Expected price/tolerance entries for each feed
-    function _readFeedExpectations(
-        uint256 length_,
-        string memory assetPrefix_
-    ) internal view returns (IPriceConfigv2.PriceFeedExpectation[] memory expectations_) {
-        uint256 expectedPrice = _readBatchArgUint256(
-            "configurePriceV1_2",
-            string.concat(assetPrefix_, "ExpectedPrice")
-        );
+    function _readFeedExpectations(uint256 length_, string memory assetPrefix_)
+        internal
+        view
+        returns (IPriceConfigv2.PriceFeedExpectation[] memory expectations_)
+    {
+        uint256 expectedPrice = _readBatchArgUint256("configurePriceV1_2", string.concat(assetPrefix_, "ExpectedPrice"));
         uint16 toleranceBps = SafeCast.encodeUInt16(
-            _readBatchArgUint256(
-                "configurePriceV1_2",
-                string.concat(assetPrefix_, "ExpectedToleranceBps")
-            )
+            _readBatchArgUint256("configurePriceV1_2", string.concat(assetPrefix_, "ExpectedToleranceBps"))
         );
 
         expectations_ = _makeFeedExpectations(length_, expectedPrice, toleranceBps);
@@ -749,10 +624,7 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
         address asset_,
         string memory assetPrefix_
     ) internal view {
-        uint256 expectedPrice = _readBatchArgUint256(
-            "configurePriceV1_2",
-            string.concat(assetPrefix_, "ExpectedPrice")
-        );
+        uint256 expectedPrice = _readBatchArgUint256("configurePriceV1_2", string.concat(assetPrefix_, "ExpectedPrice"));
         uint256 actualPrice = price_.getPrice(asset_);
 
         console2.log(string.concat(symbol_, " expected price: ", _format18Decimals(expectedPrice)));
@@ -760,8 +632,7 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
     }
 
     function _format18Decimals(uint256 value_) internal pure returns (string memory) {
-        return
-            string.concat(vm.toString(value_ / PRICE_SCALE), ".", _leftPad18(value_ % PRICE_SCALE));
+        return string.concat(vm.toString(value_ / PRICE_SCALE), ".", _leftPad18(value_ % PRICE_SCALE));
     }
 
     function _leftPad18(uint256 value_) internal pure returns (string memory) {
@@ -785,17 +656,15 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
     /// @param expectedPrice_ Expected feed price in PRICE decimals
     /// @param toleranceBps_ Allowed deviation from expected price in basis points
     /// @return expectations_ Expected price/tolerance entries for each feed
-    function _makeFeedExpectations(
-        uint256 length_,
-        uint256 expectedPrice_,
-        uint16 toleranceBps_
-    ) internal pure returns (IPriceConfigv2.PriceFeedExpectation[] memory expectations_) {
+    function _makeFeedExpectations(uint256 length_, uint256 expectedPrice_, uint16 toleranceBps_)
+        internal
+        pure
+        returns (IPriceConfigv2.PriceFeedExpectation[] memory expectations_)
+    {
         expectations_ = new IPriceConfigv2.PriceFeedExpectation[](length_);
         for (uint256 i; i < length_; i++) {
-            expectations_[i] = IPriceConfigv2.PriceFeedExpectation({
-                expectedPrice: expectedPrice_,
-                toleranceBps: toleranceBps_
-            });
+            expectations_[i] =
+                IPriceConfigv2.PriceFeedExpectation({expectedPrice: expectedPrice_, toleranceBps: toleranceBps_});
         }
     }
 
@@ -806,18 +675,17 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
     /// @param deviationBps_ Deviation in basis points
     /// @param revertOnInsufficientCount_ Strict mode flag
     /// @return strategy_ The encoded strategy component
-    function _encodeDeviationStrategy(
-        bytes4 selector_,
-        uint16 deviationBps_,
-        bool revertOnInsufficientCount_
-    ) internal pure returns (IPRICEv2.Component memory strategy_) {
+    function _encodeDeviationStrategy(bytes4 selector_, uint16 deviationBps_, bool revertOnInsufficientCount_)
+        internal
+        pure
+        returns (IPRICEv2.Component memory strategy_)
+    {
         strategy_ = IPRICEv2.Component({
             target: toSubKeycode("PRICE.SIMPLESTRATEGY"),
             selector: selector_,
             params: abi.encode(
                 ISimplePriceFeedStrategy.DeviationParams({
-                    deviationBps: deviationBps_,
-                    revertOnInsufficientCount: revertOnInsufficientCount_
+                    deviationBps: deviationBps_, revertOnInsufficientCount: revertOnInsufficientCount_
                 })
             )
         });
@@ -826,9 +694,11 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
     /// @notice Encode an average strategy component
     /// @param revertOnInsufficientCount_ Strict mode flag
     /// @return strategy_ The encoded strategy component
-    function _encodeAverageStrategy(
-        bool revertOnInsufficientCount_
-    ) internal pure returns (IPRICEv2.Component memory strategy_) {
+    function _encodeAverageStrategy(bool revertOnInsufficientCount_)
+        internal
+        pure
+        returns (IPRICEv2.Component memory strategy_)
+    {
         strategy_ = IPRICEv2.Component({
             target: toSubKeycode("PRICE.SIMPLESTRATEGY"),
             selector: SimplePriceFeedStrategy.getAveragePrice.selector,
@@ -841,11 +711,11 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
     /// @param selector_ Function selector
     /// @param params_ Encoded parameters
     /// @return feed_ The encoded feed component
-    function _encodeFeed(
-        SubKeycode target_,
-        bytes4 selector_,
-        bytes memory params_
-    ) internal pure returns (IPRICEv2.Component memory feed_) {
+    function _encodeFeed(SubKeycode target_, bytes4 selector_, bytes memory params_)
+        internal
+        pure
+        returns (IPRICEv2.Component memory feed_)
+    {
         feed_ = IPRICEv2.Component({target: target_, selector: selector_, params: params_});
     }
 }

--- a/src/scripts/ops/batches/ConfigurePriceV1_2.sol
+++ b/src/scripts/ops/batches/ConfigurePriceV1_2.sol
@@ -86,11 +86,15 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
         vm.label(_ohm, "OHM");
 
         // Load configuration parameters from args file
-        _uniswapOhmWethObservationWindow =
-            _readBatchArgUint256("configurePriceV1_2", "uniswapOhmWethObservationWindow").encodeUInt32();
+        _uniswapOhmWethObservationWindow = _readBatchArgUint256(
+            "configurePriceV1_2",
+            "uniswapOhmWethObservationWindow"
+        ).encodeUInt32();
 
-        _uniswapOhmSusdsObservationWindow =
-            _readBatchArgUint256("configurePriceV1_2", "uniswapOhmSusdsObservationWindow").encodeUInt32();
+        _uniswapOhmSusdsObservationWindow = _readBatchArgUint256(
+            "configurePriceV1_2",
+            "uniswapOhmSusdsObservationWindow"
+        ).encodeUInt32();
 
         console2.log("Kernel:", kernel);
         console2.log("PriceConfig:", priceConfig);
@@ -118,11 +122,25 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
 
         // Upgrade PRICE v1.2 module in the kernel
         console2.log("Upgrading PRICE module");
-        addToBatch(kernel, abi.encodeWithSelector(Kernel.executeAction.selector, Actions.UpgradeModule, priceModule));
+        addToBatch(
+            kernel,
+            abi.encodeWithSelector(
+                Kernel.executeAction.selector,
+                Actions.UpgradeModule,
+                priceModule
+            )
+        );
 
         // Activate PriceConfig V2 policy in the kernel
         console2.log("Activating PriceConfig V2 policy");
-        addToBatch(kernel, abi.encodeWithSelector(Kernel.executeAction.selector, Actions.ActivatePolicy, priceConfig));
+        addToBatch(
+            kernel,
+            abi.encodeWithSelector(
+                Kernel.executeAction.selector,
+                Actions.ActivatePolicy,
+                priceConfig
+            )
+        );
 
         // Install submodules first
         _installSubmodules(priceConfig);
@@ -150,7 +168,9 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
         address chainlinkFeeds = _envAddressNotZero("olympus.submodules.PRICE.ChainlinkPriceFeeds");
         address uniswapV3Price = _envAddressNotZero("olympus.submodules.PRICE.UniswapV3Price");
         address erc4626Price = _envAddressNotZero("olympus.submodules.PRICE.ERC4626Price");
-        address simpleStrategy = _envAddressNotZero("olympus.submodules.PRICE.SimplePriceFeedStrategy");
+        address simpleStrategy = _envAddressNotZero(
+            "olympus.submodules.PRICE.SimplePriceFeedStrategy"
+        );
 
         vm.label(chainlinkFeeds, "PRICE.ChainlinkPriceFeeds");
         vm.label(uniswapV3Price, "PRICE.UniswapV3Price");
@@ -159,19 +179,31 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
 
         // Install ChainlinkPriceFeeds
         console2.log("1. Installing ChainlinkPriceFeeds submodule");
-        addToBatch(priceConfig_, abi.encodeWithSelector(PriceConfigv2.installSubmodule.selector, chainlinkFeeds));
+        addToBatch(
+            priceConfig_,
+            abi.encodeWithSelector(PriceConfigv2.installSubmodule.selector, chainlinkFeeds)
+        );
 
         // Install UniswapV3Price
         console2.log("2. Installing UniswapV3Price submodule");
-        addToBatch(priceConfig_, abi.encodeWithSelector(PriceConfigv2.installSubmodule.selector, uniswapV3Price));
+        addToBatch(
+            priceConfig_,
+            abi.encodeWithSelector(PriceConfigv2.installSubmodule.selector, uniswapV3Price)
+        );
 
         // Install ERC4626Price
         console2.log("3. Installing ERC4626Price submodule");
-        addToBatch(priceConfig_, abi.encodeWithSelector(PriceConfigv2.installSubmodule.selector, erc4626Price));
+        addToBatch(
+            priceConfig_,
+            abi.encodeWithSelector(PriceConfigv2.installSubmodule.selector, erc4626Price)
+        );
 
         // Install SimplePriceFeedStrategy
         console2.log("4. Installing SimplePriceFeedStrategy submodule");
-        addToBatch(priceConfig_, abi.encodeWithSelector(PriceConfigv2.installSubmodule.selector, simpleStrategy));
+        addToBatch(
+            priceConfig_,
+            abi.encodeWithSelector(PriceConfigv2.installSubmodule.selector, simpleStrategy)
+        );
 
         console2.log("All submodules installation batched");
     }
@@ -187,18 +219,24 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
         address api3UsdsUsd = _readBatchArgAddress("configurePriceV1_2", "api3UsdsUsd");
 
         // Read deviation parameters from args file
-        uint16 usdsPriceFeedDeviationBps =
-            SafeCast.encodeUInt16(_readBatchArgUint256("configurePriceV1_2", "usdsPriceFeedDeviationBps"));
-        bool usdsRevertOnInsufficientPriceFeeds =
-            _readBatchArgBool("configurePriceV1_2", "usdsRevertOnInsufficientPriceFeeds");
+        uint16 usdsPriceFeedDeviationBps = SafeCast.encodeUInt16(
+            _readBatchArgUint256("configurePriceV1_2", "usdsPriceFeedDeviationBps")
+        );
+        bool usdsRevertOnInsufficientPriceFeeds = _readBatchArgBool(
+            "configurePriceV1_2",
+            "usdsRevertOnInsufficientPriceFeeds"
+        );
 
         // Read update thresholds from args file
-        uint48 chainlinkUsdsUsdUpdateThreshold =
-            SafeCast.encodeUInt48(_readBatchArgUint256("configurePriceV1_2", "chainlinkUsdsUsdUpdateThreshold"));
-        uint48 chainlinkDaiUsdUpdateThreshold =
-            SafeCast.encodeUInt48(_readBatchArgUint256("configurePriceV1_2", "chainlinkDaiUsdUpdateThreshold"));
-        uint48 api3UsdsUsdUpdateThreshold =
-            SafeCast.encodeUInt48(_readBatchArgUint256("configurePriceV1_2", "api3UsdsUsdUpdateThreshold"));
+        uint48 chainlinkUsdsUsdUpdateThreshold = SafeCast.encodeUInt48(
+            _readBatchArgUint256("configurePriceV1_2", "chainlinkUsdsUsdUpdateThreshold")
+        );
+        uint48 chainlinkDaiUsdUpdateThreshold = SafeCast.encodeUInt48(
+            _readBatchArgUint256("configurePriceV1_2", "chainlinkDaiUsdUpdateThreshold")
+        );
+        uint48 api3UsdsUsdUpdateThreshold = SafeCast.encodeUInt48(
+            _readBatchArgUint256("configurePriceV1_2", "api3UsdsUsdUpdateThreshold")
+        );
 
         vm.label(chainlinkUsdsUsd, "Chainlink USDS/USD");
         vm.label(chainlinkDaiUsd, "Chainlink DAI/USD");
@@ -222,7 +260,8 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
             ChainlinkPriceFeeds.getOneFeedPrice.selector,
             abi.encode(
                 ChainlinkPriceFeeds.OneFeedParams({
-                    feed: AggregatorV2V3Interface(chainlinkUsdsUsd), updateThreshold: chainlinkUsdsUsdUpdateThreshold
+                    feed: AggregatorV2V3Interface(chainlinkUsdsUsd),
+                    updateThreshold: chainlinkUsdsUsdUpdateThreshold
                 })
             )
         );
@@ -231,7 +270,8 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
             ChainlinkPriceFeeds.getOneFeedPrice.selector,
             abi.encode(
                 ChainlinkPriceFeeds.OneFeedParams({
-                    feed: AggregatorV2V3Interface(chainlinkDaiUsd), updateThreshold: chainlinkDaiUsdUpdateThreshold
+                    feed: AggregatorV2V3Interface(chainlinkDaiUsd),
+                    updateThreshold: chainlinkDaiUsdUpdateThreshold
                 })
             )
         );
@@ -240,13 +280,20 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
             ChainlinkPriceFeeds.getOneFeedPrice.selector,
             abi.encode(
                 ChainlinkPriceFeeds.OneFeedParams({
-                    feed: AggregatorV2V3Interface(api3UsdsUsd), updateThreshold: api3UsdsUsdUpdateThreshold
+                    feed: AggregatorV2V3Interface(api3UsdsUsd),
+                    updateThreshold: api3UsdsUsdUpdateThreshold
                 })
             )
         );
 
         // Add asset via PriceConfig
-        _addAsset(priceConfig_, _usds, strategy, feeds, _readFeedExpectations(feeds.length, "usds"));
+        _addAsset(
+            priceConfig_,
+            _usds,
+            strategy,
+            feeds,
+            _readFeedExpectations(feeds.length, "usds")
+        );
 
         console2.log("USDS asset configured");
     }
@@ -257,8 +304,11 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
         console2.log("\n=== Configuring sUSDS Asset ===");
 
         // Empty strategy (single feed, no aggregation needed)
-        IPRICEv2.Component memory strategy =
-            IPRICEv2.Component({target: toSubKeycode(""), selector: bytes4(0), params: abi.encode("")});
+        IPRICEv2.Component memory strategy = IPRICEv2.Component({
+            target: toSubKeycode(""),
+            selector: bytes4(0),
+            params: abi.encode("")
+        });
 
         // Single ERC4626 feed - derives price from the underlying asset (USDS)
         IPRICEv2.Component[] memory feeds = new IPRICEv2.Component[](1);
@@ -269,7 +319,13 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
         });
 
         // Add asset via PriceConfig
-        _addAsset(priceConfig_, _susds, strategy, feeds, _readFeedExpectations(feeds.length, "susds"));
+        _addAsset(
+            priceConfig_,
+            _susds,
+            strategy,
+            feeds,
+            _readFeedExpectations(feeds.length, "susds")
+        );
 
         console2.log("sUSDS asset configured");
     }
@@ -287,10 +343,13 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
         address chainlinkEthBtc = _readBatchArgAddress("configurePriceV1_2", "chainlinkEthBtc");
 
         // Read deviation parameters from args file
-        uint16 wethPriceFeedDeviationBps =
-            SafeCast.encodeUInt16(_readBatchArgUint256("configurePriceV1_2", "wethPriceFeedDeviationBps"));
-        bool wethRevertOnInsufficientPriceFeeds =
-            _readBatchArgBool("configurePriceV1_2", "wethRevertOnInsufficientPriceFeeds");
+        uint16 wethPriceFeedDeviationBps = SafeCast.encodeUInt16(
+            _readBatchArgUint256("configurePriceV1_2", "wethPriceFeedDeviationBps")
+        );
+        bool wethRevertOnInsufficientPriceFeeds = _readBatchArgBool(
+            "configurePriceV1_2",
+            "wethRevertOnInsufficientPriceFeeds"
+        );
 
         vm.label(chainlinkEthUsd, "Chainlink ETH/USD");
         vm.label(redstoneEthUsd, "RedStone ETH/USD");
@@ -312,7 +371,8 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
             _readBatchArgUint256("configurePriceV1_2", "redstoneEthUsdUpdateThreshold")
         );
         console2.log(
-            "API3 ETH/USD update threshold:", _readBatchArgUint256("configurePriceV1_2", "api3EthUsdUpdateThreshold")
+            "API3 ETH/USD update threshold:",
+            _readBatchArgUint256("configurePriceV1_2", "api3EthUsdUpdateThreshold")
         );
 
         // Create strategy component: getAveragePriceExcludingDeviations
@@ -383,7 +443,13 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
         );
 
         // Add asset via PriceConfig
-        _addAsset(priceConfig_, _weth, strategy, feeds, _readFeedExpectations(feeds.length, "weth"));
+        _addAsset(
+            priceConfig_,
+            _weth,
+            strategy,
+            feeds,
+            _readFeedExpectations(feeds.length, "weth")
+        );
 
         console2.log("wETH asset configured");
     }
@@ -398,9 +464,13 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
         address uniswapOhmSusds = _readBatchArgAddress("configurePriceV1_2", "uniswapOhmSusds");
 
         // Read deviation parameters from args file
-        uint16 ohmDeviationBps = SafeCast.encodeUInt16(_readBatchArgUint256("configurePriceV1_2", "ohmDeviationBps"));
-        bool ohmRevertOnInsufficientPriceFeeds =
-            _readBatchArgBool("configurePriceV1_2", "ohmRevertOnInsufficientPriceFeeds");
+        uint16 ohmDeviationBps = SafeCast.encodeUInt16(
+            _readBatchArgUint256("configurePriceV1_2", "ohmDeviationBps")
+        );
+        bool ohmRevertOnInsufficientPriceFeeds = _readBatchArgBool(
+            "configurePriceV1_2",
+            "ohmRevertOnInsufficientPriceFeeds"
+        );
 
         console2.log("Uniswap OHM/WETH:", uniswapOhmWeth);
         console2.log("Uniswap OHM/sUSDS:", uniswapOhmSusds);
@@ -413,12 +483,18 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
         );
         IPRICEv2.Component[] memory feeds = _getOhmFeeds();
 
-        IPriceConfigv2.PriceFeedExpectation[] memory feedExpectations = _readFeedExpectations(feeds.length, "ohm");
+        IPriceConfigv2.PriceFeedExpectation[] memory feedExpectations = _readFeedExpectations(
+            feeds.length,
+            "ohm"
+        );
         console2.log("OHM initial price:", feedExpectations[0].expectedPrice);
 
         // Set last observation time to current time
-        (uint32 ohmMovingAverageDuration, uint48 ohmLastObservationTime, uint256[] memory ohmObservations) =
-            _getMigratedOhmObservations(oldPrice_);
+        (
+            uint32 ohmMovingAverageDuration,
+            uint48 ohmLastObservationTime,
+            uint256[] memory ohmObservations
+        ) = _getMigratedOhmObservations(oldPrice_);
 
         // Add asset via PriceConfig with moving average configuration
         _addAssetWithMA(
@@ -456,10 +532,12 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
         address chainlinkOhmEth = _envAddressNotZero("external.chainlink.ohmEthPriceFeed");
         address chainlinkEthUsd = _readBatchArgAddress("configurePriceV1_2", "chainlinkEthUsd");
 
-        uint48 chainlinkOhmEthUpdateThreshold =
-            SafeCast.encodeUInt48(_readBatchArgUint256("configurePriceV1_2", "chainlinkOhmEthUpdateThreshold"));
-        uint48 chainlinkEthUsdUpdateThreshold =
-            SafeCast.encodeUInt48(_readBatchArgUint256("configurePriceV1_2", "chainlinkEthUsdUpdateThreshold"));
+        uint48 chainlinkOhmEthUpdateThreshold = SafeCast.encodeUInt48(
+            _readBatchArgUint256("configurePriceV1_2", "chainlinkOhmEthUpdateThreshold")
+        );
+        uint48 chainlinkEthUsdUpdateThreshold = SafeCast.encodeUInt48(
+            _readBatchArgUint256("configurePriceV1_2", "chainlinkEthUsdUpdateThreshold")
+        );
 
         vm.label(uniswapOhmWeth, "Uniswap OHM/WETH");
         vm.label(uniswapOhmSusds, "Uniswap OHM/sUSDS");
@@ -478,7 +556,8 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
             UniswapV3Price.getTokenTWAP.selector,
             abi.encode(
                 UniswapV3Price.UniswapV3Params({
-                    pool: IUniswapV3Pool(uniswapOhmWeth), observationWindowSeconds: _uniswapOhmWethObservationWindow
+                    pool: IUniswapV3Pool(uniswapOhmWeth),
+                    observationWindowSeconds: _uniswapOhmWethObservationWindow
                 })
             )
         );
@@ -487,7 +566,8 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
             UniswapV3Price.getTokenTWAP.selector,
             abi.encode(
                 UniswapV3Price.UniswapV3Params({
-                    pool: IUniswapV3Pool(uniswapOhmSusds), observationWindowSeconds: _uniswapOhmSusdsObservationWindow
+                    pool: IUniswapV3Pool(uniswapOhmSusds),
+                    observationWindowSeconds: _uniswapOhmSusdsObservationWindow
                 })
             )
         );
@@ -505,15 +585,22 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
         );
     }
 
-    function _getMigratedOhmObservations(PRICEv1 oldPrice_)
+    function _getMigratedOhmObservations(
+        PRICEv1 oldPrice_
+    )
         internal
         view
-        returns (uint32 ohmMovingAverageDuration_, uint48 ohmLastObservationTime_, uint256[] memory ohmObservations_)
+        returns (
+            uint32 ohmMovingAverageDuration_,
+            uint48 ohmLastObservationTime_,
+            uint256[] memory ohmObservations_
+        )
     {
         ohmMovingAverageDuration_ = uint32(oldPrice_.movingAverageDuration());
 
         uint32 oldNumObservations = oldPrice_.numObservations();
-        uint256 expectedNumObservations = uint256(ohmMovingAverageDuration_) / uint256(oldPrice_.observationFrequency());
+        uint256 expectedNumObservations = uint256(ohmMovingAverageDuration_) /
+            uint256(oldPrice_.observationFrequency());
 
         if (expectedNumObservations != uint256(oldNumObservations)) {
             revert("OHM observation count mismatch");
@@ -605,14 +692,19 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
     /// @param length_ Number of configured feeds for the asset
     /// @param assetPrefix_ Lowercase asset prefix used in the args file
     /// @return expectations_ Expected price/tolerance entries for each feed
-    function _readFeedExpectations(uint256 length_, string memory assetPrefix_)
-        internal
-        view
-        returns (IPriceConfigv2.PriceFeedExpectation[] memory expectations_)
-    {
-        uint256 expectedPrice = _readBatchArgUint256("configurePriceV1_2", string.concat(assetPrefix_, "ExpectedPrice"));
+    function _readFeedExpectations(
+        uint256 length_,
+        string memory assetPrefix_
+    ) internal view returns (IPriceConfigv2.PriceFeedExpectation[] memory expectations_) {
+        uint256 expectedPrice = _readBatchArgUint256(
+            "configurePriceV1_2",
+            string.concat(assetPrefix_, "ExpectedPrice")
+        );
         uint16 toleranceBps = SafeCast.encodeUInt16(
-            _readBatchArgUint256("configurePriceV1_2", string.concat(assetPrefix_, "ExpectedToleranceBps"))
+            _readBatchArgUint256(
+                "configurePriceV1_2",
+                string.concat(assetPrefix_, "ExpectedToleranceBps")
+            )
         );
 
         expectations_ = _makeFeedExpectations(length_, expectedPrice, toleranceBps);
@@ -624,7 +716,10 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
         address asset_,
         string memory assetPrefix_
     ) internal view {
-        uint256 expectedPrice = _readBatchArgUint256("configurePriceV1_2", string.concat(assetPrefix_, "ExpectedPrice"));
+        uint256 expectedPrice = _readBatchArgUint256(
+            "configurePriceV1_2",
+            string.concat(assetPrefix_, "ExpectedPrice")
+        );
         uint256 actualPrice = price_.getPrice(asset_);
 
         console2.log(string.concat(symbol_, " expected price: ", _format18Decimals(expectedPrice)));
@@ -632,7 +727,8 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
     }
 
     function _format18Decimals(uint256 value_) internal pure returns (string memory) {
-        return string.concat(vm.toString(value_ / PRICE_SCALE), ".", _leftPad18(value_ % PRICE_SCALE));
+        return
+            string.concat(vm.toString(value_ / PRICE_SCALE), ".", _leftPad18(value_ % PRICE_SCALE));
     }
 
     function _leftPad18(uint256 value_) internal pure returns (string memory) {
@@ -656,15 +752,17 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
     /// @param expectedPrice_ Expected feed price in PRICE decimals
     /// @param toleranceBps_ Allowed deviation from expected price in basis points
     /// @return expectations_ Expected price/tolerance entries for each feed
-    function _makeFeedExpectations(uint256 length_, uint256 expectedPrice_, uint16 toleranceBps_)
-        internal
-        pure
-        returns (IPriceConfigv2.PriceFeedExpectation[] memory expectations_)
-    {
+    function _makeFeedExpectations(
+        uint256 length_,
+        uint256 expectedPrice_,
+        uint16 toleranceBps_
+    ) internal pure returns (IPriceConfigv2.PriceFeedExpectation[] memory expectations_) {
         expectations_ = new IPriceConfigv2.PriceFeedExpectation[](length_);
         for (uint256 i; i < length_; i++) {
-            expectations_[i] =
-                IPriceConfigv2.PriceFeedExpectation({expectedPrice: expectedPrice_, toleranceBps: toleranceBps_});
+            expectations_[i] = IPriceConfigv2.PriceFeedExpectation({
+                expectedPrice: expectedPrice_,
+                toleranceBps: toleranceBps_
+            });
         }
     }
 
@@ -675,17 +773,18 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
     /// @param deviationBps_ Deviation in basis points
     /// @param revertOnInsufficientCount_ Strict mode flag
     /// @return strategy_ The encoded strategy component
-    function _encodeDeviationStrategy(bytes4 selector_, uint16 deviationBps_, bool revertOnInsufficientCount_)
-        internal
-        pure
-        returns (IPRICEv2.Component memory strategy_)
-    {
+    function _encodeDeviationStrategy(
+        bytes4 selector_,
+        uint16 deviationBps_,
+        bool revertOnInsufficientCount_
+    ) internal pure returns (IPRICEv2.Component memory strategy_) {
         strategy_ = IPRICEv2.Component({
             target: toSubKeycode("PRICE.SIMPLESTRATEGY"),
             selector: selector_,
             params: abi.encode(
                 ISimplePriceFeedStrategy.DeviationParams({
-                    deviationBps: deviationBps_, revertOnInsufficientCount: revertOnInsufficientCount_
+                    deviationBps: deviationBps_,
+                    revertOnInsufficientCount: revertOnInsufficientCount_
                 })
             )
         });
@@ -694,11 +793,9 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
     /// @notice Encode an average strategy component
     /// @param revertOnInsufficientCount_ Strict mode flag
     /// @return strategy_ The encoded strategy component
-    function _encodeAverageStrategy(bool revertOnInsufficientCount_)
-        internal
-        pure
-        returns (IPRICEv2.Component memory strategy_)
-    {
+    function _encodeAverageStrategy(
+        bool revertOnInsufficientCount_
+    ) internal pure returns (IPRICEv2.Component memory strategy_) {
         strategy_ = IPRICEv2.Component({
             target: toSubKeycode("PRICE.SIMPLESTRATEGY"),
             selector: SimplePriceFeedStrategy.getAveragePrice.selector,
@@ -711,11 +808,11 @@ contract ConfigurePriceV1_2 is BatchScriptV2 {
     /// @param selector_ Function selector
     /// @param params_ Encoded parameters
     /// @return feed_ The encoded feed component
-    function _encodeFeed(SubKeycode target_, bytes4 selector_, bytes memory params_)
-        internal
-        pure
-        returns (IPRICEv2.Component memory feed_)
-    {
+    function _encodeFeed(
+        SubKeycode target_,
+        bytes4 selector_,
+        bytes memory params_
+    ) internal pure returns (IPRICEv2.Component memory feed_) {
         feed_ = IPRICEv2.Component({target: target_, selector: selector_, params: params_});
     }
 }

--- a/src/scripts/ops/batches/args/ConfigurePriceV1_2.json
+++ b/src/scripts/ops/batches/args/ConfigurePriceV1_2.json
@@ -2,6 +2,10 @@
     "functions": [
         {
             "args": {
+                "api3EthUsd": "0x5b0cf2b36a65a6BB085D501B971e4c102B9Cd473",
+                "api3EthUsdUpdateThreshold": 90000,
+                "api3UsdsUsd": "0x0000000000000000000000000000000000000000",
+                "api3UsdsUsdUpdateThreshold": 90000,
                 "chainlinkBtcUsd": "0xF4030086522a5bEEa4988F8cA5B36dbC97BeE88c",
                 "chainlinkBtcUsdUpdateThreshold": 3600,
                 "chainlinkDaiUsd": "0xAed0c38402a5d19df6E4c03F4E2DceD6e29c1ee9",
@@ -17,13 +21,6 @@
                 "ohmExpectedPrice": "19500000000000000000",
                 "ohmExpectedToleranceBps": 500,
                 "ohmRevertOnInsufficientPriceFeeds": true,
-                "pyth": "0x4305FB66699C3B2702D4d05CF36551390A4c69C6",
-                "pythEthUsdFeedId": "0xff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace",
-                "pythEthUsdMaxConfidence": 10000000000000000000,
-                "pythEthUsdUpdateThreshold": 3600,
-                "pythUsdsUsdFeedId": "0x77f0971af11cc8bac224917275c1bf55f2319ed5c654a1ca955c82fa2d297ea1",
-                "pythUsdsUsdMaxConfidence": 10000000000000000,
-                "pythUsdsUsdUpdateThreshold": 86400,
                 "redstoneEthUsd": "0x67F6838e58859d612E4ddF04dA396d6DABB66Dc4",
                 "redstoneEthUsdUpdateThreshold": 86400,
                 "susdsExpectedPrice": "1095038992740982406",

--- a/src/scripts/ops/batches/args/ConfigurePriceV1_2.json
+++ b/src/scripts/ops/batches/args/ConfigurePriceV1_2.json
@@ -4,7 +4,7 @@
             "args": {
                 "api3EthUsd": "0x5b0cf2b36a65a6BB085D501B971e4c102B9Cd473",
                 "api3EthUsdUpdateThreshold": 90000,
-                "api3UsdsUsd": "0x0000000000000000000000000000000000000000",
+                "api3UsdsUsd": "0x6C3C2A615Ea3c592487b3e06ecAF01D9a3181f47",
                 "api3UsdsUsdUpdateThreshold": 90000,
                 "chainlinkBtcUsd": "0xF4030086522a5bEEa4988F8cA5B36dbC97BeE88c",
                 "chainlinkBtcUsdUpdateThreshold": 3600,
@@ -18,7 +18,7 @@
                 "chainlinkUsdsUsd": "0xfF30586cD0F29eD462364C7e81375FC0C71219b1",
                 "chainlinkUsdsUsdUpdateThreshold": 86400,
                 "ohmDeviationBps": 200,
-                "ohmExpectedPrice": "19500000000000000000",
+                "ohmExpectedPrice": "16890000000000000000",
                 "ohmExpectedToleranceBps": 500,
                 "ohmRevertOnInsufficientPriceFeeds": true,
                 "redstoneEthUsd": "0x67F6838e58859d612E4ddF04dA396d6DABB66Dc4",

--- a/src/test/modules/PRICE/OlympusPricev1_2Fork.t.sol
+++ b/src/test/modules/PRICE/OlympusPricev1_2Fork.t.sol
@@ -50,7 +50,8 @@ contract OlympusPricev1_2ForkTest is Test {
     address public constant ROLES_ADMIN = 0xb216d714d91eeC4F7120a732c11428857C659eC8;
     address public constant EMISSION_MANAGER = 0xA61b846D5D8b757e3d541E0e4F80390E28f0B6Ff;
     address public constant YIELD_REPO = 0x271e35a8555a62F6bA76508E85dfD76D580B0692;
-    address public constant CONVERTIBLE_DEPOSIT_AUCTIONEER = 0xF35193DA8C10e44aF10853Ba5a3a1a6F7529E39a;
+    address public constant CONVERTIBLE_DEPOSIT_AUCTIONEER =
+        0xF35193DA8C10e44aF10853Ba5a3a1a6F7529E39a;
     address public constant TIMELOCK = 0x953EA3223d2dd3c1A91E9D6cca1bf7Af162C9c39;
     address public constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
     address public constant DAO_MS = 0x245cc372C84B3645Bf0Ffe6538620B04a217988B;
@@ -125,18 +126,22 @@ contract OlympusPricev1_2ForkTest is Test {
         uint256 initialPrice
     );
 
-    function _makeFeedExpectations(uint256 length_, uint256 minPrice_, uint256 maxPrice_)
-        internal
-        pure
-        returns (IPriceConfigv2.PriceFeedExpectation[] memory expectations_)
-    {
+    function _makeFeedExpectations(
+        uint256 length_,
+        uint256 minPrice_,
+        uint256 maxPrice_
+    ) internal pure returns (IPriceConfigv2.PriceFeedExpectation[] memory expectations_) {
         uint256 expectedPrice = (minPrice_ + maxPrice_) / 2;
-        uint16 toleranceBps = SafeCast.encodeUInt16(maxPrice_.mulDivUp(BPS_MAX, expectedPrice) - BPS_MAX);
+        uint16 toleranceBps = SafeCast.encodeUInt16(
+            maxPrice_.mulDivUp(BPS_MAX, expectedPrice) - BPS_MAX
+        );
 
         expectations_ = new IPriceConfigv2.PriceFeedExpectation[](length_);
         for (uint256 i; i < length_; i++) {
-            expectations_[i] =
-                IPriceConfigv2.PriceFeedExpectation({expectedPrice: expectedPrice, toleranceBps: toleranceBps});
+            expectations_[i] = IPriceConfigv2.PriceFeedExpectation({
+                expectedPrice: expectedPrice,
+                toleranceBps: toleranceBps
+            });
         }
     }
 
@@ -180,8 +185,11 @@ contract OlympusPricev1_2ForkTest is Test {
 
         // Deploy submodules
         chainlinkPrice = new ChainlinkPriceFeeds(price);
-        UniswapV3Price uniswapV3Price =
-            new UniswapV3Price(price, _UNISWAP_V3_AVERAGE_BLOCK_TIME_SECONDS, UNISWAP_V3_FACTORY);
+        UniswapV3Price uniswapV3Price = new UniswapV3Price(
+            price,
+            _UNISWAP_V3_AVERAGE_BLOCK_TIME_SECONDS,
+            UNISWAP_V3_FACTORY
+        );
         ERC4626Price erc4626Price = new ERC4626Price(price);
         strategy = new SimplePriceFeedStrategy(price);
 
@@ -282,18 +290,24 @@ contract OlympusPricev1_2ForkTest is Test {
 
         // Feed 0: Uniswap OHM/WETH
         UniswapV3Price.UniswapV3Params memory ohmWethParams = UniswapV3Price.UniswapV3Params({
-            pool: IUniswapV3Pool(UNISWAP_OHM_WETH), observationWindowSeconds: OHM_WETH_OBSERVATION_WINDOW
+            pool: IUniswapV3Pool(UNISWAP_OHM_WETH),
+            observationWindowSeconds: OHM_WETH_OBSERVATION_WINDOW
         });
         feeds[0] = IPRICEv2.Component(
-            toSubKeycode("PRICE.UNIV3"), UniswapV3Price.getTokenTWAP.selector, abi.encode(ohmWethParams)
+            toSubKeycode("PRICE.UNIV3"),
+            UniswapV3Price.getTokenTWAP.selector,
+            abi.encode(ohmWethParams)
         );
 
         // Feed 1: Uniswap OHM/sUSDS
         UniswapV3Price.UniswapV3Params memory ohmSusdsParams = UniswapV3Price.UniswapV3Params({
-            pool: IUniswapV3Pool(UNISWAP_OHM_SUSDS), observationWindowSeconds: OHM_SUSDS_OBSERVATION_WINDOW
+            pool: IUniswapV3Pool(UNISWAP_OHM_SUSDS),
+            observationWindowSeconds: OHM_SUSDS_OBSERVATION_WINDOW
         });
         feeds[1] = IPRICEv2.Component(
-            toSubKeycode("PRICE.UNIV3"), UniswapV3Price.getTokenTWAP.selector, abi.encode(ohmSusdsParams)
+            toSubKeycode("PRICE.UNIV3"),
+            UniswapV3Price.getTokenTWAP.selector,
+            abi.encode(ohmSusdsParams)
         );
 
         // Feed 2: Chainlink OHM/ETH x ETH/USD
@@ -319,8 +333,11 @@ contract OlympusPricev1_2ForkTest is Test {
         IPRICEv2.Component memory ohmStrategy_,
         IPRICEv2.Component[] memory feeds_
     ) internal {
-        (uint32 movingAverageDuration, uint48 lastObservationTime, uint256[] memory observations) =
-            _getMigratedOhmObservations();
+        (
+            uint32 movingAverageDuration,
+            uint48 lastObservationTime,
+            uint256[] memory observations
+        ) = _getMigratedOhmObservations();
 
         // Add OHM asset via PriceConfig with moving average configuration
         priceConfig.addAsset(
@@ -339,10 +356,18 @@ contract OlympusPricev1_2ForkTest is Test {
     function _getMigratedOhmObservations()
         internal
         view
-        returns (uint32 movingAverageDuration_, uint48 lastObservationTime_, uint256[] memory observations_)
+        returns (
+            uint32 movingAverageDuration_,
+            uint48 lastObservationTime_,
+            uint256[] memory observations_
+        )
     {
         uint48 oldObservationFrequency = oldPrice.observationFrequency();
-        assertEq(price.observationFrequency(), oldObservationFrequency, "Observation frequency should match PRICE v1");
+        assertEq(
+            price.observationFrequency(),
+            oldObservationFrequency,
+            "Observation frequency should match PRICE v1"
+        );
 
         uint32 oldNumObservations = oldPrice.numObservations();
         movingAverageDuration_ = uint32(oldPrice.movingAverageDuration());
@@ -350,7 +375,8 @@ contract OlympusPricev1_2ForkTest is Test {
 
         // Use the live PRICE v1 observation count rather than a hard-coded seed. With an 8-hour
         // observation frequency and a 30-day moving average, this migrates 90 raw observations.
-        uint256 expectedNumObservations = uint256(movingAverageDuration_) / uint256(oldObservationFrequency);
+        uint256 expectedNumObservations = uint256(movingAverageDuration_) /
+            uint256(oldObservationFrequency);
         assertEq(
             uint256(oldNumObservations),
             expectedNumObservations,
@@ -392,8 +418,8 @@ contract OlympusPricev1_2ForkTest is Test {
         IPRICEv2.Component[] memory feeds = new IPRICEv2.Component[](4);
 
         // Feed 0: Chainlink ETH/USD
-        ChainlinkPriceFeeds.OneFeedParams memory chainlinkEthUsdParams =
-            ChainlinkPriceFeeds.OneFeedParams(AggregatorV2V3Interface(CHAINLINK_ETH_USD), WETH_UPDATE_THRESHOLD);
+        ChainlinkPriceFeeds.OneFeedParams memory chainlinkEthUsdParams = ChainlinkPriceFeeds
+            .OneFeedParams(AggregatorV2V3Interface(CHAINLINK_ETH_USD), WETH_UPDATE_THRESHOLD);
         feeds[0] = IPRICEv2.Component(
             toSubKeycode("PRICE.CHAINLINK"),
             ChainlinkPriceFeeds.getOneFeedPrice.selector,
@@ -402,8 +428,8 @@ contract OlympusPricev1_2ForkTest is Test {
 
         // Feed 1: RedStone ETH/USD (uses Chainlink interface)
         // Note: RedStone is accessed via Chainlink interface in production
-        ChainlinkPriceFeeds.OneFeedParams memory redstoneEthUsdParams =
-            ChainlinkPriceFeeds.OneFeedParams(AggregatorV2V3Interface(REDSTONE_ETH_USD), WETH_UPDATE_THRESHOLD);
+        ChainlinkPriceFeeds.OneFeedParams memory redstoneEthUsdParams = ChainlinkPriceFeeds
+            .OneFeedParams(AggregatorV2V3Interface(REDSTONE_ETH_USD), WETH_UPDATE_THRESHOLD);
         feeds[1] = IPRICEv2.Component(
             toSubKeycode("PRICE.CHAINLINK"),
             ChainlinkPriceFeeds.getOneFeedPrice.selector,
@@ -411,19 +437,22 @@ contract OlympusPricev1_2ForkTest is Test {
         );
 
         // Feed 2: API3 ETH/USD (uses Chainlink interface)
-        ChainlinkPriceFeeds.OneFeedParams memory api3EthUsdParams =
-            ChainlinkPriceFeeds.OneFeedParams(AggregatorV2V3Interface(API3_ETH_USD), WETH_UPDATE_THRESHOLD);
+        ChainlinkPriceFeeds.OneFeedParams memory api3EthUsdParams = ChainlinkPriceFeeds
+            .OneFeedParams(AggregatorV2V3Interface(API3_ETH_USD), WETH_UPDATE_THRESHOLD);
         feeds[2] = IPRICEv2.Component(
-            toSubKeycode("PRICE.CHAINLINK"), ChainlinkPriceFeeds.getOneFeedPrice.selector, abi.encode(api3EthUsdParams)
+            toSubKeycode("PRICE.CHAINLINK"),
+            ChainlinkPriceFeeds.getOneFeedPrice.selector,
+            abi.encode(api3EthUsdParams)
         );
 
         // Feed 3: Derived ETH-USD from ETH-BTC × BTC-USD
-        ChainlinkPriceFeeds.TwoFeedParams memory derivedEthUsdParams = ChainlinkPriceFeeds.TwoFeedParams({
-            firstFeed: AggregatorV2V3Interface(CHAINLINK_ETH_BTC),
-            firstUpdateThreshold: WETH_ETH_BTC_UPDATE_THRESHOLD,
-            secondFeed: AggregatorV2V3Interface(CHAINLINK_BTC_USD),
-            secondUpdateThreshold: WETH_BTC_USD_UPDATE_THRESHOLD
-        });
+        ChainlinkPriceFeeds.TwoFeedParams memory derivedEthUsdParams = ChainlinkPriceFeeds
+            .TwoFeedParams({
+                firstFeed: AggregatorV2V3Interface(CHAINLINK_ETH_BTC),
+                firstUpdateThreshold: WETH_ETH_BTC_UPDATE_THRESHOLD,
+                secondFeed: AggregatorV2V3Interface(CHAINLINK_BTC_USD),
+                secondUpdateThreshold: WETH_BTC_USD_UPDATE_THRESHOLD
+            });
         feeds[3] = IPRICEv2.Component(
             toSubKeycode("PRICE.CHAINLINK"),
             ChainlinkPriceFeeds.getTwoFeedPriceMul.selector,
@@ -470,8 +499,8 @@ contract OlympusPricev1_2ForkTest is Test {
         IPRICEv2.Component[] memory feeds = new IPRICEv2.Component[](3);
 
         // Feed 0: Chainlink USDS/USD
-        ChainlinkPriceFeeds.OneFeedParams memory chainlinkUsdsUsdParams =
-            ChainlinkPriceFeeds.OneFeedParams(AggregatorV2V3Interface(CHAINLINK_USDS_USD), USDS_UPDATE_THRESHOLD);
+        ChainlinkPriceFeeds.OneFeedParams memory chainlinkUsdsUsdParams = ChainlinkPriceFeeds
+            .OneFeedParams(AggregatorV2V3Interface(CHAINLINK_USDS_USD), USDS_UPDATE_THRESHOLD);
         feeds[0] = IPRICEv2.Component(
             toSubKeycode("PRICE.CHAINLINK"),
             ChainlinkPriceFeeds.getOneFeedPrice.selector,
@@ -479,8 +508,8 @@ contract OlympusPricev1_2ForkTest is Test {
         );
 
         // Feed 1: Chainlink DAI/USD
-        ChainlinkPriceFeeds.OneFeedParams memory chainlinkDaiUsdParams =
-            ChainlinkPriceFeeds.OneFeedParams(AggregatorV2V3Interface(CHAINLINK_DAI_USD), USDS_UPDATE_THRESHOLD);
+        ChainlinkPriceFeeds.OneFeedParams memory chainlinkDaiUsdParams = ChainlinkPriceFeeds
+            .OneFeedParams(AggregatorV2V3Interface(CHAINLINK_DAI_USD), USDS_UPDATE_THRESHOLD);
         feeds[1] = IPRICEv2.Component(
             toSubKeycode("PRICE.CHAINLINK"),
             ChainlinkPriceFeeds.getOneFeedPrice.selector,
@@ -490,10 +519,12 @@ contract OlympusPricev1_2ForkTest is Test {
         // Feed 2: API3 USDS/USD (uses Chainlink interface). The production address is
         // still a zero-address placeholder, so this fork test uses a local feed until
         // the live API3 reader proxy is available.
-        ChainlinkPriceFeeds.OneFeedParams memory api3UsdsUsdParams =
-            ChainlinkPriceFeeds.OneFeedParams(AggregatorV2V3Interface(API3_USDS_USD), USDS_UPDATE_THRESHOLD);
+        ChainlinkPriceFeeds.OneFeedParams memory api3UsdsUsdParams = ChainlinkPriceFeeds
+            .OneFeedParams(AggregatorV2V3Interface(API3_USDS_USD), USDS_UPDATE_THRESHOLD);
         feeds[2] = IPRICEv2.Component(
-            toSubKeycode("PRICE.CHAINLINK"), ChainlinkPriceFeeds.getOneFeedPrice.selector, abi.encode(api3UsdsUsdParams)
+            toSubKeycode("PRICE.CHAINLINK"),
+            ChainlinkPriceFeeds.getOneFeedPrice.selector,
+            abi.encode(api3UsdsUsdParams)
         );
 
         // Add USDS asset via PriceConfig
@@ -518,8 +549,11 @@ contract OlympusPricev1_2ForkTest is Test {
         vm.startPrank(DAO_MS); // DAO_MS has price_admin permissions
 
         // Empty strategy (single feed, no aggregation needed)
-        IPRICEv2.Component memory susdsStrategy =
-            IPRICEv2.Component({target: toSubKeycode(""), selector: bytes4(0), params: abi.encode("")});
+        IPRICEv2.Component memory susdsStrategy = IPRICEv2.Component({
+            target: toSubKeycode(""),
+            selector: bytes4(0),
+            params: abi.encode("")
+        });
 
         // Single ERC4626 feed - derives price from the underlying asset (USDS)
         IPRICEv2.Component[] memory feeds = new IPRICEv2.Component[](1);
@@ -546,10 +580,12 @@ contract OlympusPricev1_2ForkTest is Test {
     }
 
     /// @notice Validates that a price is within a reasonable range
-    function _assertPriceInRange(uint256 price_, uint256 minPrice_, uint256 maxPrice_, string memory assetName_)
-        internal
-        pure
-    {
+    function _assertPriceInRange(
+        uint256 price_,
+        uint256 minPrice_,
+        uint256 maxPrice_,
+        string memory assetName_
+    ) internal pure {
         assertGe(price_, minPrice_, string.concat(assetName_, " price below minimum"));
         assertLe(price_, maxPrice_, string.concat(assetName_, " price above maximum"));
     }
@@ -576,15 +612,21 @@ contract OlympusPricev1_2ForkTest is Test {
     function test_priceValidation_ohmUsesDeviationFilteredAverage() public view {
         IPRICEv2.Asset memory ohmAsset = price.getAssetData(OHM);
         IPRICEv2.Component memory ohmStrategy = abi.decode(ohmAsset.strategy, (IPRICEv2.Component));
-        ISimplePriceFeedStrategy.DeviationParams memory params =
-            abi.decode(ohmStrategy.params, (ISimplePriceFeedStrategy.DeviationParams));
+        ISimplePriceFeedStrategy.DeviationParams memory params = abi.decode(
+            ohmStrategy.params,
+            (ISimplePriceFeedStrategy.DeviationParams)
+        );
 
         assertEq(
             ohmStrategy.selector,
             SimplePriceFeedStrategy.getAveragePriceExcludingDeviations.selector,
             "OHM should use deviation-filtered average"
         );
-        assertEq(params.deviationBps, OHM_DEVIATION_BPS, "OHM deviation threshold should match config");
+        assertEq(
+            params.deviationBps,
+            OHM_DEVIATION_BPS,
+            "OHM deviation threshold should match config"
+        );
         assertTrue(params.revertOnInsufficientCount, "OHM strategy should use strict mode");
     }
 
@@ -639,9 +681,21 @@ contract OlympusPricev1_2ForkTest is Test {
         bytes4 getPriceWithVariantSelector = bytes4(keccak256("getPrice(address,(uint8,bytes1))"));
         bytes4 getPriceSelector = bytes4(keccak256("getPrice(address)"));
 
-        vm.mockCall(address(price), abi.encodeWithSelector(getPriceSelector, OHM), abi.encode(price_));
-        vm.mockCall(address(price), abi.encodeWithSelector(IPRICEv1.getCurrentPrice.selector), abi.encode(price_));
-        vm.mockCall(address(price), abi.encodeWithSelector(IPRICEv1.getLastPrice.selector), abi.encode(price_));
+        vm.mockCall(
+            address(price),
+            abi.encodeWithSelector(getPriceSelector, OHM),
+            abi.encode(price_)
+        );
+        vm.mockCall(
+            address(price),
+            abi.encodeWithSelector(IPRICEv1.getCurrentPrice.selector),
+            abi.encode(price_)
+        );
+        vm.mockCall(
+            address(price),
+            abi.encodeWithSelector(IPRICEv1.getLastPrice.selector),
+            abi.encode(price_)
+        );
         vm.mockCall(
             address(price),
             abi.encodeWithSelector(getPriceWithVariantSelector, OHM, IPRICEv2.Variant.CURRENT),
@@ -741,7 +795,11 @@ contract OlympusPricev1_2ForkTest is Test {
 
         // Verify PRICE moving average was updated
         uint48 lastObsTimeAfter = price.lastObservationTime();
-        assertEq(lastObsTimeAfter, SafeCast.encodeUInt48(block.timestamp), "Last observation time should be updated");
+        assertEq(
+            lastObsTimeAfter,
+            SafeCast.encodeUInt48(block.timestamp),
+            "Last observation time should be updated"
+        );
         assertGt(lastObsTimeAfter, lastObsTimeBefore, "Last observation time should be updated");
 
         // Verify moving average was updated
@@ -762,7 +820,6 @@ contract OlympusPricev1_2ForkTest is Test {
         givenOhmPrice(17e18) // Below 50% premium
         warpToNextHeartbeat
         beat // Epoch 0
-
     {
         // Verify that the CD auction target is 0 (disabled)
         assertEq(cdAuctioneer.getAuctionParameters().target, 0, "CD auction target should be 0");
@@ -781,7 +838,6 @@ contract OlympusPricev1_2ForkTest is Test {
         givenOhmPrice(24e18) // Above 50% premium
         warpToNextHeartbeat
         beat // Epoch 0
-
     {
         // Calculate the expected min price
         uint256 expectedMinPrice = emissionManager.getMinPriceFor(24e18);
@@ -820,7 +876,13 @@ contract OlympusPricev1_2ForkTest is Test {
         // Ignore the market ID, as it depends on the number of bond markets created on
         // mainnet before the fork block. The token pair and initial price are deterministic.
         vm.expectEmit(false, true, true, true);
-        emit MarketCreated(0, address(OHM), address(emissionManager.reserve()), uint48(0), expectedInitialPrice);
+        emit MarketCreated(
+            0,
+            address(OHM),
+            address(emissionManager.reserve()),
+            uint48(0),
+            expectedInitialPrice
+        );
 
         // Beat
         // Epoch 0, auction results next index is 0
@@ -829,7 +891,11 @@ contract OlympusPricev1_2ForkTest is Test {
         vm.stopSnapshotGas();
 
         // Verify
-        assertGt(emissionManager.activeMarketId(), activeMarketIdBefore, "Active market ID should increase");
+        assertGt(
+            emissionManager.activeMarketId(),
+            activeMarketIdBefore,
+            "Active market ID should increase"
+        );
     }
 
     // when the heartbeat launches a YRF market
@@ -853,7 +919,11 @@ contract OlympusPricev1_2ForkTest is Test {
         // Expect event
         vm.expectEmit(true, true, true, true);
         emit MarketCreated(
-            expectedMarketId, address(emissionManager.reserve()), address(OHM), uint48(0), expectedInitialPrice
+            expectedMarketId,
+            address(emissionManager.reserve()),
+            address(OHM),
+            uint48(0),
+            expectedInitialPrice
         );
 
         // Beat

--- a/src/test/modules/PRICE/OlympusPricev1_2Fork.t.sol
+++ b/src/test/modules/PRICE/OlympusPricev1_2Fork.t.sol
@@ -23,11 +23,11 @@ import {toSubKeycode} from "src/Submodules.sol";
 import {PRICEv1} from "src/modules/PRICE/PRICE.v1.sol";
 import {OlympusPricev1_2} from "src/modules/PRICE/OlympusPrice.v1_2.sol";
 import {ChainlinkPriceFeeds} from "src/modules/PRICE/submodules/feeds/ChainlinkPriceFeeds.sol";
-import {PythPriceFeeds} from "src/modules/PRICE/submodules/feeds/PythPriceFeeds.sol";
 import {SimplePriceFeedStrategy} from "src/modules/PRICE/submodules/strategies/SimplePriceFeedStrategy.sol";
 import {RolesAdmin} from "src/policies/RolesAdmin.sol";
 import {PriceConfigv2} from "src/policies/price/PriceConfig.v2.sol";
 import {IPriceConfigv2} from "src/policies/interfaces/IPriceConfigv2.sol";
+import {MockPriceFeed} from "src/test/mocks/MockPriceFeed.sol";
 
 import {EmissionManager} from "src/policies/EmissionManager.sol";
 import {YieldRepurchaseFacility} from "src/policies/YieldRepurchaseFacility.sol";
@@ -51,11 +51,9 @@ contract OlympusPricev1_2ForkTest is Test {
     address public constant ROLES_ADMIN = 0xb216d714d91eeC4F7120a732c11428857C659eC8;
     address public constant EMISSION_MANAGER = 0xA61b846D5D8b757e3d541E0e4F80390E28f0B6Ff;
     address public constant YIELD_REPO = 0x271e35a8555a62F6bA76508E85dfD76D580B0692;
-    address public constant CONVERTIBLE_DEPOSIT_AUCTIONEER =
-        0xF35193DA8C10e44aF10853Ba5a3a1a6F7529E39a;
+    address public constant CONVERTIBLE_DEPOSIT_AUCTIONEER = 0xF35193DA8C10e44aF10853Ba5a3a1a6F7529E39a;
     address public constant TIMELOCK = 0x953EA3223d2dd3c1A91E9D6cca1bf7Af162C9c39;
     address public constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
-    address public constant PYTH = 0x4305FB66699C3B2702D4d05CF36551390A4c69C6;
     address public constant DAO_MS = 0x245cc372C84B3645Bf0Ffe6538620B04a217988B;
     address public constant USDS = 0xdC035D45d973E3EC169d2276DDab16f1e407384F;
     address public constant SUSDS = 0xa3931d71877C0E7a3148CB7Eb4463524FEc27fbD;
@@ -66,21 +64,19 @@ contract OlympusPricev1_2ForkTest is Test {
     address public constant REDSTONE_ETH_USD = 0x67F6838e58859d612E4ddF04dA396d6DABB66Dc4;
     address public constant CHAINLINK_USDS_USD = 0xfF30586cD0F29eD462364C7e81375FC0C71219b1;
     address public constant CHAINLINK_DAI_USD = 0xAed0c38402a5d19df6E4c03F4E2DceD6e29c1ee9;
+    address public constant API3_ETH_USD = 0x5b0cf2b36a65a6BB085D501B971e4c102B9Cd473;
+    address public constant API3_USDS_USD = address(0);
     address public constant UNISWAP_OHM_WETH = 0x88051B0eea095007D3bEf21aB287Be961f3d8598;
     address public constant UNISWAP_OHM_SUSDS = 0x0858e2B0F9D75f7300B38D64482aC2C8DF06a755;
     address public constant UNISWAP_V3_FACTORY = 0x1F98431c8aD98523631AE4a59f267346ea31F984;
 
     uint256 internal constant OHM_USD_PRICE = 20e18;
-    bytes32 internal constant ETH_USD_FEED_ID =
-        0xff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace;
-    bytes32 internal constant PYTH_USDS_USD_FEED_ID =
-        0x77f0971af11cc8bac224917275c1bf55f2319ed5c654a1ca955c82fa2d297ea1;
 
     // Price validation bounds (18 decimals) - from production config
     uint256 internal constant USDS_MIN_PRICE = 0.99e18;
     uint256 internal constant USDS_MAX_PRICE = 1.01e18;
     uint256 internal constant SUSDS_MIN_PRICE = 1.06e18;
-    uint256 internal constant SUSDS_MAX_PRICE = 1.10e18;
+    uint256 internal constant SUSDS_MAX_PRICE = 1.1e18;
     uint256 internal constant ETH_MIN_PRICE = 1500e18;
     uint256 internal constant ETH_MAX_PRICE = 2100e18;
     uint256 internal constant OHM_MIN_PRICE = 17e18;
@@ -89,8 +85,6 @@ contract OlympusPricev1_2ForkTest is Test {
     uint256 internal constant WETH_DEVIATION_BPS = 500; // 5% deviation
     uint256 internal constant USDS_DEVIATION_BPS = 100; // 1% deviation
     uint256 internal constant OHM_DEVIATION_BPS = 200; // 2% deviation
-    uint256 internal constant PYTH_ETH_USD_MAX_CONFIDENCE = 10e18;
-    uint256 internal constant PYTH_USDS_USD_MAX_CONFIDENCE = 0.1e18;
     uint48 internal constant WETH_UPDATE_THRESHOLD = 2 * 86400; // 48 hours (differs from production to allow for warping)
     uint48 internal constant WETH_ETH_BTC_UPDATE_THRESHOLD = 2 * 86400; // 48 hours (differs from production to allow for warping)
     uint48 internal constant WETH_BTC_USD_UPDATE_THRESHOLD = 2 * 86400; // 48 hours (differs from production to allow for warping)
@@ -114,8 +108,8 @@ contract OlympusPricev1_2ForkTest is Test {
 
     // Submodules
     ChainlinkPriceFeeds public chainlinkPrice;
-    PythPriceFeeds public pythPrice;
     SimplePriceFeedStrategy public strategy;
+    AggregatorV2V3Interface internal _api3UsdsUsdFeed;
 
     // Permissioned addresses
     address public kernelExecutor;
@@ -128,23 +122,34 @@ contract OlympusPricev1_2ForkTest is Test {
         uint256 initialPrice
     );
 
-    function _makeFeedExpectations(
-        uint256 length_,
-        uint256 minPrice_,
-        uint256 maxPrice_
-    ) internal pure returns (IPriceConfigv2.PriceFeedExpectation[] memory expectations_) {
+    function _makeFeedExpectations(uint256 length_, uint256 minPrice_, uint256 maxPrice_)
+        internal
+        pure
+        returns (IPriceConfigv2.PriceFeedExpectation[] memory expectations_)
+    {
         uint256 expectedPrice = (minPrice_ + maxPrice_) / 2;
-        uint16 toleranceBps = SafeCast.encodeUInt16(
-            maxPrice_.mulDivUp(BPS_MAX, expectedPrice) - BPS_MAX
-        );
+        uint16 toleranceBps = SafeCast.encodeUInt16(maxPrice_.mulDivUp(BPS_MAX, expectedPrice) - BPS_MAX);
 
         expectations_ = new IPriceConfigv2.PriceFeedExpectation[](length_);
         for (uint256 i; i < length_; i++) {
-            expectations_[i] = IPriceConfigv2.PriceFeedExpectation({
-                expectedPrice: expectedPrice,
-                toleranceBps: toleranceBps
-            });
+            expectations_[i] =
+                IPriceConfigv2.PriceFeedExpectation({expectedPrice: expectedPrice, toleranceBps: toleranceBps});
         }
+    }
+
+    function _getApi3UsdsUsdFeed() internal returns (AggregatorV2V3Interface) {
+        if (API3_USDS_USD != address(0)) return AggregatorV2V3Interface(API3_USDS_USD);
+        if (address(_api3UsdsUsdFeed) != address(0)) return _api3UsdsUsdFeed;
+
+        MockPriceFeed api3UsdsUsdFeed = new MockPriceFeed();
+        api3UsdsUsdFeed.setDecimals(18);
+        api3UsdsUsdFeed.setLatestAnswer(1e18);
+        api3UsdsUsdFeed.setTimestamp(block.timestamp);
+        api3UsdsUsdFeed.setRoundId(1);
+        api3UsdsUsdFeed.setAnsweredInRound(1);
+
+        _api3UsdsUsdFeed = AggregatorV2V3Interface(address(api3UsdsUsdFeed));
+        return _api3UsdsUsdFeed;
     }
 
     function setUp() public {
@@ -181,12 +186,8 @@ contract OlympusPricev1_2ForkTest is Test {
 
         // Deploy submodules
         chainlinkPrice = new ChainlinkPriceFeeds(price);
-        pythPrice = new PythPriceFeeds(price);
-        UniswapV3Price uniswapV3Price = new UniswapV3Price(
-            price,
-            _UNISWAP_V3_AVERAGE_BLOCK_TIME_SECONDS,
-            UNISWAP_V3_FACTORY
-        );
+        UniswapV3Price uniswapV3Price =
+            new UniswapV3Price(price, _UNISWAP_V3_AVERAGE_BLOCK_TIME_SECONDS, UNISWAP_V3_FACTORY);
         ERC4626Price erc4626Price = new ERC4626Price(price);
         strategy = new SimplePriceFeedStrategy(price);
 
@@ -208,7 +209,6 @@ contract OlympusPricev1_2ForkTest is Test {
         // We assume that the DAO MS has the price_admin role
         vm.startPrank(DAO_MS);
         priceConfig.installSubmodule(address(chainlinkPrice));
-        priceConfig.installSubmodule(address(pythPrice));
         priceConfig.installSubmodule(address(uniswapV3Price));
         priceConfig.installSubmodule(address(erc4626Price));
         priceConfig.installSubmodule(address(strategy));
@@ -251,24 +251,18 @@ contract OlympusPricev1_2ForkTest is Test {
 
         // Feed 0: Uniswap OHM/WETH
         UniswapV3Price.UniswapV3Params memory ohmWethParams = UniswapV3Price.UniswapV3Params({
-            pool: IUniswapV3Pool(UNISWAP_OHM_WETH),
-            observationWindowSeconds: OHM_WETH_OBSERVATION_WINDOW
+            pool: IUniswapV3Pool(UNISWAP_OHM_WETH), observationWindowSeconds: OHM_WETH_OBSERVATION_WINDOW
         });
         feeds[0] = IPRICEv2.Component(
-            toSubKeycode("PRICE.UNIV3"),
-            UniswapV3Price.getTokenTWAP.selector,
-            abi.encode(ohmWethParams)
+            toSubKeycode("PRICE.UNIV3"), UniswapV3Price.getTokenTWAP.selector, abi.encode(ohmWethParams)
         );
 
         // Feed 1: Uniswap OHM/sUSDS
         UniswapV3Price.UniswapV3Params memory ohmSusdsParams = UniswapV3Price.UniswapV3Params({
-            pool: IUniswapV3Pool(UNISWAP_OHM_SUSDS),
-            observationWindowSeconds: OHM_SUSDS_OBSERVATION_WINDOW
+            pool: IUniswapV3Pool(UNISWAP_OHM_SUSDS), observationWindowSeconds: OHM_SUSDS_OBSERVATION_WINDOW
         });
         feeds[1] = IPRICEv2.Component(
-            toSubKeycode("PRICE.UNIV3"),
-            UniswapV3Price.getTokenTWAP.selector,
-            abi.encode(ohmSusdsParams)
+            toSubKeycode("PRICE.UNIV3"), UniswapV3Price.getTokenTWAP.selector, abi.encode(ohmSusdsParams)
         );
 
         // Feed 2: Chainlink OHM/ETH x ETH/USD
@@ -294,11 +288,8 @@ contract OlympusPricev1_2ForkTest is Test {
         IPRICEv2.Component memory ohmStrategy_,
         IPRICEv2.Component[] memory feeds_
     ) internal {
-        (
-            uint32 movingAverageDuration,
-            uint48 lastObservationTime,
-            uint256[] memory observations
-        ) = _getMigratedOhmObservations();
+        (uint32 movingAverageDuration, uint48 lastObservationTime, uint256[] memory observations) =
+            _getMigratedOhmObservations();
 
         // Add OHM asset via PriceConfig with moving average configuration
         priceConfig.addAsset(
@@ -317,18 +308,10 @@ contract OlympusPricev1_2ForkTest is Test {
     function _getMigratedOhmObservations()
         internal
         view
-        returns (
-            uint32 movingAverageDuration_,
-            uint48 lastObservationTime_,
-            uint256[] memory observations_
-        )
+        returns (uint32 movingAverageDuration_, uint48 lastObservationTime_, uint256[] memory observations_)
     {
         uint48 oldObservationFrequency = oldPrice.observationFrequency();
-        assertEq(
-            price.observationFrequency(),
-            oldObservationFrequency,
-            "Observation frequency should match PRICE v1"
-        );
+        assertEq(price.observationFrequency(), oldObservationFrequency, "Observation frequency should match PRICE v1");
 
         uint32 oldNumObservations = oldPrice.numObservations();
         movingAverageDuration_ = uint32(oldPrice.movingAverageDuration());
@@ -336,8 +319,7 @@ contract OlympusPricev1_2ForkTest is Test {
 
         // Use the live PRICE v1 observation count rather than a hard-coded seed. With an 8-hour
         // observation frequency and a 30-day moving average, this migrates 90 raw observations.
-        uint256 expectedNumObservations = uint256(movingAverageDuration_) /
-            uint256(oldObservationFrequency);
+        uint256 expectedNumObservations = uint256(movingAverageDuration_) / uint256(oldObservationFrequency);
         assertEq(
             uint256(oldNumObservations),
             expectedNumObservations,
@@ -358,7 +340,7 @@ contract OlympusPricev1_2ForkTest is Test {
 
     function _configureWethAsset() internal {
         // Configure WETH with production configuration: 4 feeds with deviation strategy
-        // Feeds: Chainlink ETH/USD, RedStone ETH/USD (via Chainlink interface), Pyth ETH/USD, Derived ETH/BTC×BTC/USD
+        // Feeds: Chainlink ETH/USD, RedStone ETH/USD, API3 ETH/USD, Derived ETH/BTC×BTC/USD
 
         vm.startPrank(DAO_MS); // DAO_MS has price_admin permissions
 
@@ -379,8 +361,8 @@ contract OlympusPricev1_2ForkTest is Test {
         IPRICEv2.Component[] memory feeds = new IPRICEv2.Component[](4);
 
         // Feed 0: Chainlink ETH/USD
-        ChainlinkPriceFeeds.OneFeedParams memory chainlinkEthUsdParams = ChainlinkPriceFeeds
-            .OneFeedParams(AggregatorV2V3Interface(CHAINLINK_ETH_USD), WETH_UPDATE_THRESHOLD);
+        ChainlinkPriceFeeds.OneFeedParams memory chainlinkEthUsdParams =
+            ChainlinkPriceFeeds.OneFeedParams(AggregatorV2V3Interface(CHAINLINK_ETH_USD), WETH_UPDATE_THRESHOLD);
         feeds[0] = IPRICEv2.Component(
             toSubKeycode("PRICE.CHAINLINK"),
             ChainlinkPriceFeeds.getOneFeedPrice.selector,
@@ -389,35 +371,28 @@ contract OlympusPricev1_2ForkTest is Test {
 
         // Feed 1: RedStone ETH/USD (uses Chainlink interface)
         // Note: RedStone is accessed via Chainlink interface in production
-        ChainlinkPriceFeeds.OneFeedParams memory redstoneEthUsdParams = ChainlinkPriceFeeds
-            .OneFeedParams(AggregatorV2V3Interface(REDSTONE_ETH_USD), WETH_UPDATE_THRESHOLD);
+        ChainlinkPriceFeeds.OneFeedParams memory redstoneEthUsdParams =
+            ChainlinkPriceFeeds.OneFeedParams(AggregatorV2V3Interface(REDSTONE_ETH_USD), WETH_UPDATE_THRESHOLD);
         feeds[1] = IPRICEv2.Component(
             toSubKeycode("PRICE.CHAINLINK"),
             ChainlinkPriceFeeds.getOneFeedPrice.selector,
             abi.encode(redstoneEthUsdParams)
         );
 
-        // Feed 2: Pyth ETH/USD
-        PythPriceFeeds.OneFeedParams memory pythEthUsdParams = PythPriceFeeds.OneFeedParams(
-            PYTH,
-            ETH_USD_FEED_ID,
-            WETH_UPDATE_THRESHOLD,
-            PYTH_ETH_USD_MAX_CONFIDENCE
-        );
+        // Feed 2: API3 ETH/USD (uses Chainlink interface)
+        ChainlinkPriceFeeds.OneFeedParams memory api3EthUsdParams =
+            ChainlinkPriceFeeds.OneFeedParams(AggregatorV2V3Interface(API3_ETH_USD), WETH_UPDATE_THRESHOLD);
         feeds[2] = IPRICEv2.Component(
-            toSubKeycode("PRICE.PYTH"),
-            PythPriceFeeds.getOneFeedPrice.selector,
-            abi.encode(pythEthUsdParams)
+            toSubKeycode("PRICE.CHAINLINK"), ChainlinkPriceFeeds.getOneFeedPrice.selector, abi.encode(api3EthUsdParams)
         );
 
         // Feed 3: Derived ETH-USD from ETH-BTC × BTC-USD
-        ChainlinkPriceFeeds.TwoFeedParams memory derivedEthUsdParams = ChainlinkPriceFeeds
-            .TwoFeedParams({
-                firstFeed: AggregatorV2V3Interface(CHAINLINK_ETH_BTC),
-                firstUpdateThreshold: WETH_ETH_BTC_UPDATE_THRESHOLD,
-                secondFeed: AggregatorV2V3Interface(CHAINLINK_BTC_USD),
-                secondUpdateThreshold: WETH_BTC_USD_UPDATE_THRESHOLD
-            });
+        ChainlinkPriceFeeds.TwoFeedParams memory derivedEthUsdParams = ChainlinkPriceFeeds.TwoFeedParams({
+            firstFeed: AggregatorV2V3Interface(CHAINLINK_ETH_BTC),
+            firstUpdateThreshold: WETH_ETH_BTC_UPDATE_THRESHOLD,
+            secondFeed: AggregatorV2V3Interface(CHAINLINK_BTC_USD),
+            secondUpdateThreshold: WETH_BTC_USD_UPDATE_THRESHOLD
+        });
         feeds[3] = IPRICEv2.Component(
             toSubKeycode("PRICE.CHAINLINK"),
             ChainlinkPriceFeeds.getTwoFeedPriceMul.selector,
@@ -443,7 +418,7 @@ contract OlympusPricev1_2ForkTest is Test {
 
     function _configureUsdsAsset() internal {
         // Configure USDS with production configuration: 3 feeds with deviation strategy
-        // Feeds: Chainlink USDS/USD, Chainlink DAI/USD, Pyth USDS/USD
+        // Feeds: Chainlink USDS/USD, Chainlink DAI/USD, API3 USDS/USD
 
         vm.startPrank(DAO_MS); // DAO_MS has price_admin permissions
 
@@ -464,8 +439,8 @@ contract OlympusPricev1_2ForkTest is Test {
         IPRICEv2.Component[] memory feeds = new IPRICEv2.Component[](3);
 
         // Feed 0: Chainlink USDS/USD
-        ChainlinkPriceFeeds.OneFeedParams memory chainlinkUsdsUsdParams = ChainlinkPriceFeeds
-            .OneFeedParams(AggregatorV2V3Interface(CHAINLINK_USDS_USD), USDS_UPDATE_THRESHOLD);
+        ChainlinkPriceFeeds.OneFeedParams memory chainlinkUsdsUsdParams =
+            ChainlinkPriceFeeds.OneFeedParams(AggregatorV2V3Interface(CHAINLINK_USDS_USD), USDS_UPDATE_THRESHOLD);
         feeds[0] = IPRICEv2.Component(
             toSubKeycode("PRICE.CHAINLINK"),
             ChainlinkPriceFeeds.getOneFeedPrice.selector,
@@ -473,25 +448,21 @@ contract OlympusPricev1_2ForkTest is Test {
         );
 
         // Feed 1: Chainlink DAI/USD
-        ChainlinkPriceFeeds.OneFeedParams memory chainlinkDaiUsdParams = ChainlinkPriceFeeds
-            .OneFeedParams(AggregatorV2V3Interface(CHAINLINK_DAI_USD), USDS_UPDATE_THRESHOLD);
+        ChainlinkPriceFeeds.OneFeedParams memory chainlinkDaiUsdParams =
+            ChainlinkPriceFeeds.OneFeedParams(AggregatorV2V3Interface(CHAINLINK_DAI_USD), USDS_UPDATE_THRESHOLD);
         feeds[1] = IPRICEv2.Component(
             toSubKeycode("PRICE.CHAINLINK"),
             ChainlinkPriceFeeds.getOneFeedPrice.selector,
             abi.encode(chainlinkDaiUsdParams)
         );
 
-        // Feed 2: Pyth USDS/USD
-        PythPriceFeeds.OneFeedParams memory pythUsdsUsdParams = PythPriceFeeds.OneFeedParams(
-            PYTH,
-            PYTH_USDS_USD_FEED_ID,
-            USDS_UPDATE_THRESHOLD,
-            PYTH_USDS_USD_MAX_CONFIDENCE
-        );
+        // Feed 2: API3 USDS/USD (uses Chainlink interface). The production address is
+        // still a zero-address placeholder, so this fork test uses a local feed until
+        // the live API3 reader proxy is available.
+        ChainlinkPriceFeeds.OneFeedParams memory api3UsdsUsdParams =
+            ChainlinkPriceFeeds.OneFeedParams(_getApi3UsdsUsdFeed(), USDS_UPDATE_THRESHOLD);
         feeds[2] = IPRICEv2.Component(
-            toSubKeycode("PRICE.PYTH"),
-            PythPriceFeeds.getOneFeedPrice.selector,
-            abi.encode(pythUsdsUsdParams)
+            toSubKeycode("PRICE.CHAINLINK"), ChainlinkPriceFeeds.getOneFeedPrice.selector, abi.encode(api3UsdsUsdParams)
         );
 
         // Add USDS asset via PriceConfig
@@ -516,11 +487,8 @@ contract OlympusPricev1_2ForkTest is Test {
         vm.startPrank(DAO_MS); // DAO_MS has price_admin permissions
 
         // Empty strategy (single feed, no aggregation needed)
-        IPRICEv2.Component memory susdsStrategy = IPRICEv2.Component({
-            target: toSubKeycode(""),
-            selector: bytes4(0),
-            params: abi.encode("")
-        });
+        IPRICEv2.Component memory susdsStrategy =
+            IPRICEv2.Component({target: toSubKeycode(""), selector: bytes4(0), params: abi.encode("")});
 
         // Single ERC4626 feed - derives price from the underlying asset (USDS)
         IPRICEv2.Component[] memory feeds = new IPRICEv2.Component[](1);
@@ -547,12 +515,10 @@ contract OlympusPricev1_2ForkTest is Test {
     }
 
     /// @notice Validates that a price is within a reasonable range
-    function _assertPriceInRange(
-        uint256 price_,
-        uint256 minPrice_,
-        uint256 maxPrice_,
-        string memory assetName_
-    ) internal pure {
+    function _assertPriceInRange(uint256 price_, uint256 minPrice_, uint256 maxPrice_, string memory assetName_)
+        internal
+        pure
+    {
         assertGe(price_, minPrice_, string.concat(assetName_, " price below minimum"));
         assertLe(price_, maxPrice_, string.concat(assetName_, " price above maximum"));
     }
@@ -579,21 +545,15 @@ contract OlympusPricev1_2ForkTest is Test {
     function test_priceValidation_ohmUsesDeviationFilteredAverage() public view {
         IPRICEv2.Asset memory ohmAsset = price.getAssetData(OHM);
         IPRICEv2.Component memory ohmStrategy = abi.decode(ohmAsset.strategy, (IPRICEv2.Component));
-        ISimplePriceFeedStrategy.DeviationParams memory params = abi.decode(
-            ohmStrategy.params,
-            (ISimplePriceFeedStrategy.DeviationParams)
-        );
+        ISimplePriceFeedStrategy.DeviationParams memory params =
+            abi.decode(ohmStrategy.params, (ISimplePriceFeedStrategy.DeviationParams));
 
         assertEq(
             ohmStrategy.selector,
             SimplePriceFeedStrategy.getAveragePriceExcludingDeviations.selector,
             "OHM should use deviation-filtered average"
         );
-        assertEq(
-            params.deviationBps,
-            OHM_DEVIATION_BPS,
-            "OHM deviation threshold should match config"
-        );
+        assertEq(params.deviationBps, OHM_DEVIATION_BPS, "OHM deviation threshold should match config");
         assertTrue(params.revertOnInsufficientCount, "OHM strategy should use strict mode");
     }
 
@@ -648,21 +608,9 @@ contract OlympusPricev1_2ForkTest is Test {
         bytes4 getPriceWithVariantSelector = bytes4(keccak256("getPrice(address,(uint8,bytes1))"));
         bytes4 getPriceSelector = bytes4(keccak256("getPrice(address)"));
 
-        vm.mockCall(
-            address(price),
-            abi.encodeWithSelector(getPriceSelector, OHM),
-            abi.encode(price_)
-        );
-        vm.mockCall(
-            address(price),
-            abi.encodeWithSelector(IPRICEv1.getCurrentPrice.selector),
-            abi.encode(price_)
-        );
-        vm.mockCall(
-            address(price),
-            abi.encodeWithSelector(IPRICEv1.getLastPrice.selector),
-            abi.encode(price_)
-        );
+        vm.mockCall(address(price), abi.encodeWithSelector(getPriceSelector, OHM), abi.encode(price_));
+        vm.mockCall(address(price), abi.encodeWithSelector(IPRICEv1.getCurrentPrice.selector), abi.encode(price_));
+        vm.mockCall(address(price), abi.encodeWithSelector(IPRICEv1.getLastPrice.selector), abi.encode(price_));
         vm.mockCall(
             address(price),
             abi.encodeWithSelector(getPriceWithVariantSelector, OHM, IPRICEv2.Variant.CURRENT),
@@ -762,11 +710,7 @@ contract OlympusPricev1_2ForkTest is Test {
 
         // Verify PRICE moving average was updated
         uint48 lastObsTimeAfter = price.lastObservationTime();
-        assertEq(
-            lastObsTimeAfter,
-            SafeCast.encodeUInt48(block.timestamp),
-            "Last observation time should be updated"
-        );
+        assertEq(lastObsTimeAfter, SafeCast.encodeUInt48(block.timestamp), "Last observation time should be updated");
         assertGt(lastObsTimeAfter, lastObsTimeBefore, "Last observation time should be updated");
 
         // Verify moving average was updated
@@ -787,6 +731,7 @@ contract OlympusPricev1_2ForkTest is Test {
         givenOhmPrice(17e18) // Below 50% premium
         warpToNextHeartbeat
         beat // Epoch 0
+
     {
         // Verify that the CD auction target is 0 (disabled)
         assertEq(cdAuctioneer.getAuctionParameters().target, 0, "CD auction target should be 0");
@@ -805,6 +750,7 @@ contract OlympusPricev1_2ForkTest is Test {
         givenOhmPrice(24e18) // Above 50% premium
         warpToNextHeartbeat
         beat // Epoch 0
+
     {
         // Calculate the expected min price
         uint256 expectedMinPrice = emissionManager.getMinPriceFor(24e18);
@@ -843,11 +789,7 @@ contract OlympusPricev1_2ForkTest is Test {
         // Expect event
         vm.expectEmit(true, true, true, true);
         emit MarketCreated(
-            expectedMarketId,
-            address(OHM),
-            address(emissionManager.reserve()),
-            uint48(0),
-            expectedInitialPrice
+            expectedMarketId, address(OHM), address(emissionManager.reserve()), uint48(0), expectedInitialPrice
         );
 
         // Beat
@@ -858,9 +800,7 @@ contract OlympusPricev1_2ForkTest is Test {
 
         // Verify
         assertEq(
-            emissionManager.activeMarketId(),
-            expectedMarketId,
-            "Active market ID should be the expected market ID"
+            emissionManager.activeMarketId(), expectedMarketId, "Active market ID should be the expected market ID"
         );
     }
 
@@ -885,11 +825,7 @@ contract OlympusPricev1_2ForkTest is Test {
         // Expect event
         vm.expectEmit(true, true, true, true);
         emit MarketCreated(
-            expectedMarketId,
-            address(emissionManager.reserve()),
-            address(OHM),
-            uint48(0),
-            expectedInitialPrice
+            expectedMarketId, address(emissionManager.reserve()), address(OHM), uint48(0), expectedInitialPrice
         );
 
         // Beat

--- a/src/test/modules/PRICE/OlympusPricev1_2Fork.t.sol
+++ b/src/test/modules/PRICE/OlympusPricev1_2Fork.t.sol
@@ -27,7 +27,6 @@ import {SimplePriceFeedStrategy} from "src/modules/PRICE/submodules/strategies/S
 import {RolesAdmin} from "src/policies/RolesAdmin.sol";
 import {PriceConfigv2} from "src/policies/price/PriceConfig.v2.sol";
 import {IPriceConfigv2} from "src/policies/interfaces/IPriceConfigv2.sol";
-import {MockPriceFeed} from "src/test/mocks/MockPriceFeed.sol";
 
 import {EmissionManager} from "src/policies/EmissionManager.sol";
 import {YieldRepurchaseFacility} from "src/policies/YieldRepurchaseFacility.sol";
@@ -42,9 +41,9 @@ contract OlympusPricev1_2ForkTest is Test {
     using FullMath for uint256;
 
     // Constants
-    /// @dev Fork block after CD deployment, specified so that YRF and EM are at particular epochs
-    /// @dev YRF epoch 4, EM epoch 1
-    uint256 internal constant FORK_BLOCK = 24582000 + 1;
+    /// @dev Fork block after API3 USDS/USD deployment.
+    uint256 internal constant FORK_BLOCK = 25279717 + 1;
+
     address public constant OHM = 0x64aa3364F17a4D01c6f1751Fd97C2BD3D7e7f1D5;
     address public constant KERNEL = 0x2286d7f9639e8158FaD1169e76d1FbC38247f54b;
     address public constant HEART = 0x5824850D8A6E46a473445a5AF214C7EbD46c5ECB;
@@ -65,12 +64,16 @@ contract OlympusPricev1_2ForkTest is Test {
     address public constant CHAINLINK_USDS_USD = 0xfF30586cD0F29eD462364C7e81375FC0C71219b1;
     address public constant CHAINLINK_DAI_USD = 0xAed0c38402a5d19df6E4c03F4E2DceD6e29c1ee9;
     address public constant API3_ETH_USD = 0x5b0cf2b36a65a6BB085D501B971e4c102B9Cd473;
-    address public constant API3_USDS_USD = address(0);
+    address public constant API3_USDS_USD = 0x6C3C2A615Ea3c592487b3e06ecAF01D9a3181f47;
     address public constant UNISWAP_OHM_WETH = 0x88051B0eea095007D3bEf21aB287Be961f3d8598;
     address public constant UNISWAP_OHM_SUSDS = 0x0858e2B0F9D75f7300B38D64482aC2C8DF06a755;
     address public constant UNISWAP_V3_FACTORY = 0x1F98431c8aD98523631AE4a59f267346ea31F984;
 
-    uint256 internal constant OHM_USD_PRICE = 20e18;
+    uint256 internal constant OHM_USD_PRICE = 16.89e18;
+    uint256 internal constant CDA_MINIMUM_BID = 100e18;
+    uint256 internal constant CDA_INITIAL_TICK_SIZE_BASE = 2e18;
+    uint24 internal constant CDA_INITIAL_TICK_STEP_MULTIPLIER = 10075;
+    uint256 internal constant EM_TICK_SIZE = 150e9;
 
     // Price validation bounds (18 decimals) - from production config
     uint256 internal constant USDS_MIN_PRICE = 0.99e18;
@@ -79,8 +82,8 @@ contract OlympusPricev1_2ForkTest is Test {
     uint256 internal constant SUSDS_MAX_PRICE = 1.1e18;
     uint256 internal constant ETH_MIN_PRICE = 1500e18;
     uint256 internal constant ETH_MAX_PRICE = 2100e18;
-    uint256 internal constant OHM_MIN_PRICE = 17e18;
-    uint256 internal constant OHM_MAX_PRICE = 22e18;
+    uint256 internal constant OHM_MIN_PRICE = 16.50e18;
+    uint256 internal constant OHM_MAX_PRICE = 17.00e18;
     uint256 internal constant BPS_MAX = 10_000;
     uint256 internal constant WETH_DEVIATION_BPS = 500; // 5% deviation
     uint256 internal constant USDS_DEVIATION_BPS = 100; // 1% deviation
@@ -137,21 +140,6 @@ contract OlympusPricev1_2ForkTest is Test {
         }
     }
 
-    function _getApi3UsdsUsdFeed() internal returns (AggregatorV2V3Interface) {
-        if (API3_USDS_USD != address(0)) return AggregatorV2V3Interface(API3_USDS_USD);
-        if (address(_api3UsdsUsdFeed) != address(0)) return _api3UsdsUsdFeed;
-
-        MockPriceFeed api3UsdsUsdFeed = new MockPriceFeed();
-        api3UsdsUsdFeed.setDecimals(18);
-        api3UsdsUsdFeed.setLatestAnswer(1e18);
-        api3UsdsUsdFeed.setTimestamp(block.timestamp);
-        api3UsdsUsdFeed.setRoundId(1);
-        api3UsdsUsdFeed.setAnsweredInRound(1);
-
-        _api3UsdsUsdFeed = AggregatorV2V3Interface(address(api3UsdsUsdFeed));
-        return _api3UsdsUsdFeed;
-    }
-
     function setUp() public {
         vm.createSelectFork("mainnet", FORK_BLOCK);
 
@@ -167,10 +155,15 @@ contract OlympusPricev1_2ForkTest is Test {
         cdAuctioneer = ConvertibleDepositAuctioneer(CONVERTIBLE_DEPOSIT_AUCTIONEER);
         yrf = YieldRepurchaseFacility(YIELD_REPO);
 
-        // Ensure that the EmissionManager's bond market capacity scalar is set to 1e18 (100%)
-        // This is disabled (0) at the time of the fork
-        vm.prank(TIMELOCK);
+        // Restore CD/EM sizing from ConvertibleDepositActivator. The live fork has since been
+        // updated with higher values that prevent this test from reaching its target scenario.
+        vm.startPrank(TIMELOCK);
+        cdAuctioneer.setMinimumBid(CDA_MINIMUM_BID);
+        cdAuctioneer.setTickSizeBase(CDA_INITIAL_TICK_SIZE_BASE);
+        cdAuctioneer.setTickStep(CDA_INITIAL_TICK_STEP_MULTIPLIER);
+        emissionManager.setTickSize(EM_TICK_SIZE);
         emissionManager.setBondMarketCapacityScalar(1e18);
+        vm.stopPrank();
 
         // Get observation frequency from old PRICE module
         uint32 observationFrequency = uint32(oldPrice.observationFrequency());
@@ -460,7 +453,7 @@ contract OlympusPricev1_2ForkTest is Test {
         // still a zero-address placeholder, so this fork test uses a local feed until
         // the live API3 reader proxy is available.
         ChainlinkPriceFeeds.OneFeedParams memory api3UsdsUsdParams =
-            ChainlinkPriceFeeds.OneFeedParams(_getApi3UsdsUsdFeed(), USDS_UPDATE_THRESHOLD);
+            ChainlinkPriceFeeds.OneFeedParams(AggregatorV2V3Interface(API3_USDS_USD), USDS_UPDATE_THRESHOLD);
         feeds[2] = IPRICEv2.Component(
             toSubKeycode("PRICE.CHAINLINK"), ChainlinkPriceFeeds.getOneFeedPrice.selector, abi.encode(api3UsdsUsdParams)
         );
@@ -784,13 +777,12 @@ contract OlympusPricev1_2ForkTest is Test {
         warpToNextHeartbeat
     {
         uint256 expectedInitialPrice = 24e36; // Bond market scaling
-        uint256 expectedMarketId = 730 + 1;
+        uint256 activeMarketIdBefore = emissionManager.activeMarketId();
 
-        // Expect event
-        vm.expectEmit(true, true, true, true);
-        emit MarketCreated(
-            expectedMarketId, address(OHM), address(emissionManager.reserve()), uint48(0), expectedInitialPrice
-        );
+        // Ignore the market ID, as it depends on the number of bond markets created on
+        // mainnet before the fork block. The token pair and initial price are deterministic.
+        vm.expectEmit(false, true, true, true);
+        emit MarketCreated(0, address(OHM), address(emissionManager.reserve()), uint48(0), expectedInitialPrice);
 
         // Beat
         // Epoch 0, auction results next index is 0
@@ -799,9 +791,7 @@ contract OlympusPricev1_2ForkTest is Test {
         vm.stopSnapshotGas();
 
         // Verify
-        assertEq(
-            emissionManager.activeMarketId(), expectedMarketId, "Active market ID should be the expected market ID"
-        );
+        assertGt(emissionManager.activeMarketId(), activeMarketIdBefore, "Active market ID should increase");
     }
 
     // when the heartbeat launches a YRF market
@@ -820,7 +810,7 @@ contract OlympusPricev1_2ForkTest is Test {
         // = 42955326460481099
         // Adjusted by 1e17 for bond market scaling
         uint256 expectedInitialPrice = 42955326460481099 * 1e17;
-        uint256 expectedMarketId = 728 + 1;
+        uint256 expectedMarketId = 825 + 1;
 
         // Expect event
         vm.expectEmit(true, true, true, true);

--- a/src/test/modules/PRICE/OlympusPricev1_2Fork.t.sol
+++ b/src/test/modules/PRICE/OlympusPricev1_2Fork.t.sol
@@ -79,10 +79,10 @@ contract OlympusPricev1_2ForkTest is Test {
     // Price validation bounds (18 decimals) - from production config
     uint256 internal constant USDS_MIN_PRICE = 0.99e18;
     uint256 internal constant USDS_MAX_PRICE = 1.01e18;
-    uint256 internal constant SUSDS_MIN_PRICE = 1.06e18;
-    uint256 internal constant SUSDS_MAX_PRICE = 1.1e18;
-    uint256 internal constant ETH_MIN_PRICE = 1500e18;
-    uint256 internal constant ETH_MAX_PRICE = 2100e18;
+    uint256 internal constant SUSDS_MIN_PRICE = 1.09e18;
+    uint256 internal constant SUSDS_MAX_PRICE = 1.11e18;
+    uint256 internal constant ETH_MIN_PRICE = 1650e18;
+    uint256 internal constant ETH_MAX_PRICE = 1700e18;
     uint256 internal constant OHM_MIN_PRICE = 16.50e18;
     uint256 internal constant OHM_MAX_PRICE = 17.00e18;
     uint256 internal constant BPS_MAX = 10_000;

--- a/src/test/modules/PRICE/OlympusPricev1_2Fork.t.sol
+++ b/src/test/modules/PRICE/OlympusPricev1_2Fork.t.sol
@@ -142,6 +142,7 @@ contract OlympusPricev1_2ForkTest is Test {
 
     function setUp() public {
         vm.createSelectFork("mainnet", FORK_BLOCK);
+        _labelMainnetAddresses();
 
         // Get system contracts
         kernel = Kernel(KERNEL);
@@ -184,6 +185,13 @@ contract OlympusPricev1_2ForkTest is Test {
         ERC4626Price erc4626Price = new ERC4626Price(price);
         strategy = new SimplePriceFeedStrategy(price);
 
+        vm.label(address(price), "PRICE v1.2");
+        vm.label(address(priceConfig), "PriceConfig v2");
+        vm.label(address(chainlinkPrice), "ChainlinkPriceFeeds");
+        vm.label(address(uniswapV3Price), "UniswapV3Price");
+        vm.label(address(erc4626Price), "ERC4626Price");
+        vm.label(address(strategy), "SimplePriceFeedStrategy");
+
         // ========== SAME-BATCH PRICE v1.2 UPGRADE ==========
         // All operations happen in the same transaction (via kernelExecutor),
         // ensuring no Heart heartbeat occurs between upgrade and configuration.
@@ -222,6 +230,36 @@ contract OlympusPricev1_2ForkTest is Test {
     }
 
     // ========== HELPER FUNCTIONS ========== //
+
+    function _labelMainnetAddresses() internal {
+        vm.label(OHM, "OHM");
+        vm.label(WETH, "WETH");
+        vm.label(USDS, "USDS");
+        vm.label(SUSDS, "sUSDS");
+
+        vm.label(KERNEL, "Kernel");
+        vm.label(HEART, "Heart");
+        vm.label(ROLES_ADMIN, "RolesAdmin");
+        vm.label(EMISSION_MANAGER, "EmissionManager");
+        vm.label(YIELD_REPO, "YieldRepurchaseFacility");
+        vm.label(CONVERTIBLE_DEPOSIT_AUCTIONEER, "ConvertibleDepositAuctioneer");
+        vm.label(TIMELOCK, "Timelock");
+        vm.label(DAO_MS, "DAO MS");
+
+        vm.label(CHAINLINK_ETH_USD, "Chainlink ETH/USD");
+        vm.label(CHAINLINK_BTC_USD, "Chainlink BTC/USD");
+        vm.label(CHAINLINK_ETH_BTC, "Chainlink ETH/BTC");
+        vm.label(CHAINLINK_OHM_ETH, "Chainlink OHM/ETH");
+        vm.label(CHAINLINK_USDS_USD, "Chainlink USDS/USD");
+        vm.label(CHAINLINK_DAI_USD, "Chainlink DAI/USD");
+        vm.label(REDSTONE_ETH_USD, "Redstone ETH/USD");
+        vm.label(API3_ETH_USD, "API3 ETH/USD");
+        vm.label(API3_USDS_USD, "API3 USDS/USD");
+
+        vm.label(UNISWAP_OHM_WETH, "Uniswap V3 OHM/WETH");
+        vm.label(UNISWAP_OHM_SUSDS, "Uniswap V3 OHM/sUSDS");
+        vm.label(UNISWAP_V3_FACTORY, "Uniswap V3 Factory");
+    }
 
     function _configureOhmAsset() internal {
         vm.startPrank(DAO_MS); // DAO_MS has price_admin permissions

--- a/src/test/modules/PRICE/OlympusPricev1_2Fork.t.sol
+++ b/src/test/modules/PRICE/OlympusPricev1_2Fork.t.sol
@@ -516,9 +516,7 @@ contract OlympusPricev1_2ForkTest is Test {
             abi.encode(chainlinkDaiUsdParams)
         );
 
-        // Feed 2: API3 USDS/USD (uses Chainlink interface). The production address is
-        // still a zero-address placeholder, so this fork test uses a local feed until
-        // the live API3 reader proxy is available.
+        // Feed 2: API3 USDS/USD (uses Chainlink interface).
         ChainlinkPriceFeeds.OneFeedParams memory api3UsdsUsdParams = ChainlinkPriceFeeds
             .OneFeedParams(AggregatorV2V3Interface(API3_USDS_USD), USDS_UPDATE_THRESHOLD);
         feeds[2] = IPRICEv2.Component(

--- a/src/test/proposals/OracleProposal.t.sol
+++ b/src/test/proposals/OracleProposal.t.sol
@@ -16,7 +16,6 @@ import {IPRICEv2} from "src/modules/PRICE/IPRICE.v2.sol";
 
 // PRICE Submodules
 import {ChainlinkPriceFeeds} from "src/modules/PRICE/submodules/feeds/ChainlinkPriceFeeds.sol";
-import {PythPriceFeeds} from "src/modules/PRICE/submodules/feeds/PythPriceFeeds.sol";
 import {UniswapV3Price} from "src/modules/PRICE/submodules/feeds/UniswapV3Price.sol";
 import {ERC4626Price} from "src/modules/PRICE/submodules/feeds/ERC4626Price.sol";
 import {SimplePriceFeedStrategy} from "src/modules/PRICE/submodules/strategies/SimplePriceFeedStrategy.sol";
@@ -70,17 +69,15 @@ contract OracleProposalTest is ProposalTest {
     uint256 internal constant OHM_EXPECTED_PRICE = 17.5e18;
     uint16 internal constant OHM_EXPECTATION_TOLERANCE_BPS = 1_000; // 10%
 
-    function _makeFeedExpectations(
-        uint256 length_,
-        uint256 expectedPrice_,
-        uint16 toleranceBps_
-    ) internal pure returns (IPriceConfigv2.PriceFeedExpectation[] memory expectations_) {
+    function _makeFeedExpectations(uint256 length_, uint256 expectedPrice_, uint16 toleranceBps_)
+        internal
+        pure
+        returns (IPriceConfigv2.PriceFeedExpectation[] memory expectations_)
+    {
         expectations_ = new IPriceConfigv2.PriceFeedExpectation[](length_);
         for (uint256 i; i < length_; i++) {
-            expectations_[i] = IPriceConfigv2.PriceFeedExpectation({
-                expectedPrice: expectedPrice_,
-                toleranceBps: toleranceBps_
-            });
+            expectations_[i] =
+                IPriceConfigv2.PriceFeedExpectation({expectedPrice: expectedPrice_, toleranceBps: toleranceBps_});
         }
     }
 
@@ -119,9 +116,7 @@ contract OracleProposalTest is ProposalTest {
         // 1. Deploy PRICE v1_2 module if not already installed
         address priceModule = address(kernel.getModuleForKeycode(toKeycode("PRICE")));
         (uint8 priceMajor, uint8 priceMinor) = Module(priceModule).VERSION();
-        bool needsPriceUpgrade = (priceModule == address(0)) ||
-            (priceMajor != 1) ||
-            (priceMinor < 2);
+        bool needsPriceUpgrade = (priceModule == address(0)) || (priceMajor != 1) || (priceMinor < 2);
 
         if (needsPriceUpgrade) {
             console2.log("Deploying PRICE v1.2 module");
@@ -139,10 +134,7 @@ contract OracleProposalTest is ProposalTest {
         } else {
             console2.log("PRICE v1.2 module already installed");
             // Validate that the addresses file has the correct address for the PRICE module
-            require(
-                addresses.getAddress("olympus-module-price-1_2") == priceModule,
-                "PRICE module address mismatch"
-            );
+            require(addresses.getAddress("olympus-module-price-1_2") == priceModule, "PRICE module address mismatch");
         }
 
         // Get the PRICE module address
@@ -150,7 +142,6 @@ contract OracleProposalTest is ProposalTest {
 
         // 2. Deploy PRICE submodules
         _deployChainlinkPriceFeedsIfNeeded(priceModule);
-        _deployPythPriceFeedsIfNeeded(priceModule);
         _deployUniswapV3PriceIfNeeded(priceModule);
         _deployErc4626PriceIfNeeded(priceModule);
         _deploySimplePriceFeedStrategyIfNeeded(priceModule);
@@ -210,31 +201,13 @@ contract OracleProposalTest is ProposalTest {
         vm.label(submodule, key);
     }
 
-    function _deployPythPriceFeedsIfNeeded(address priceModule_) internal {
-        string memory key = "olympus-submodule-price-pyth-price-feeds-1_0";
-        address submodule = _safeGetAddress(key);
-        if (submodule == address(0)) {
-            console2.log("Deploying PythPriceFeeds");
-            submodule = address(new PythPriceFeeds(Module(priceModule_)));
-            addresses.addAddress(key, submodule);
-        } else {
-            console2.log("PythPriceFeeds already deployed");
-        }
-
-        vm.label(submodule, key);
-    }
-
     function _deployUniswapV3PriceIfNeeded(address priceModule_) internal {
         string memory key = "olympus-submodule-price-uniswap-v3-1_0";
         address submodule = _safeGetAddress(key);
         if (submodule == address(0)) {
             console2.log("Deploying UniswapV3Price");
             submodule = address(
-                new UniswapV3Price(
-                    Module(priceModule_),
-                    _UNISWAP_V3_AVERAGE_BLOCK_TIME_SECONDS,
-                    _UNISWAP_V3_FACTORY
-                )
+                new UniswapV3Price(Module(priceModule_), _UNISWAP_V3_AVERAGE_BLOCK_TIME_SECONDS, _UNISWAP_V3_FACTORY)
             );
             addresses.addAddress(key, submodule);
         } else {
@@ -279,13 +252,7 @@ contract OracleProposalTest is ProposalTest {
         address policy = _safeGetAddress(key);
         if (policy == address(0)) {
             console2.log("Deploying PriceCache");
-            policy = address(
-                new PriceCache(
-                    Kernel(kernelAddr_),
-                    _UNIT_OF_ACCOUNT_DECIMALS,
-                    _UNIT_OF_ACCOUNT_SYMBOL
-                )
-            );
+            policy = address(new PriceCache(Kernel(kernelAddr_), _UNIT_OF_ACCOUNT_DECIMALS, _UNIT_OF_ACCOUNT_SYMBOL));
             addresses.addAddress(key, policy);
         } else {
             console2.log("PriceCache already deployed");
@@ -348,9 +315,7 @@ contract OracleProposalTest is ProposalTest {
     /// @notice Activate oracle policies if not already active
     function _activateOraclePoliciesIfNeeded() internal {
         address erc7726Factory = addresses.getAddress("olympus-policy-erc7726-oracle-factory-1_0");
-        address chainlinkFactory = addresses.getAddress(
-            "olympus-policy-chainlink-oracle-factory-1_0"
-        );
+        address chainlinkFactory = addresses.getAddress("olympus-policy-chainlink-oracle-factory-1_0");
         address morphoFactory = addresses.getAddress("olympus-policy-morpho-oracle-factory-1_0");
         Kernel kernelAddr = Kernel(addresses.getAddress("olympus-kernel"));
 
@@ -395,13 +360,9 @@ contract OracleProposalTest is ProposalTest {
 
         // Install submodules (skip if already installed)
         _installSubmoduleIfNeeded(priceConfig, "olympus-submodule-price-chainlink-price-feeds-1_0");
-        _installSubmoduleIfNeeded(priceConfig, "olympus-submodule-price-pyth-price-feeds-1_0");
         _installSubmoduleIfNeeded(priceConfig, "olympus-submodule-price-uniswap-v3-1_0");
         _installSubmoduleIfNeeded(priceConfig, "olympus-submodule-price-erc4626-1_0");
-        _installSubmoduleIfNeeded(
-            priceConfig,
-            "olympus-submodule-price-simple-price-feed-strategy-1_0"
-        );
+        _installSubmoduleIfNeeded(priceConfig, "olympus-submodule-price-simple-price-feed-strategy-1_0");
 
         // Configure USDS with a simple Chainlink feed
         _configureUSDS(priceConfig, usds);
@@ -422,11 +383,8 @@ contract OracleProposalTest is ProposalTest {
         vm.label(chainlinkUsdsUsd, "chainlinkUsdsUsd");
 
         // Create strategy component: empty (single price feed)
-        IPRICEv2.Component memory strategy = IPRICEv2.Component({
-            target: toSubKeycode(""),
-            selector: bytes4(0),
-            params: abi.encode("")
-        });
+        IPRICEv2.Component memory strategy =
+            IPRICEv2.Component({target: toSubKeycode(""), selector: bytes4(0), params: abi.encode("")});
 
         // Create feed component using Chainlink
         IPRICEv2.Component[] memory feeds = new IPRICEv2.Component[](1);
@@ -444,17 +402,18 @@ contract OracleProposalTest is ProposalTest {
         // Add USDS asset via PriceConfig
         address daoMS = addresses.getAddress("olympus-multisig-dao");
         vm.startPrank(daoMS);
-        PriceConfigv2(priceConfig_).addAsset(
-            usds_,
-            false, // storeMovingAverage
-            false, // useMovingAverage
-            uint32(0), // movingAverageDuration
-            uint48(0), // lastObservationTime
-            new uint256[](0), // observations
-            strategy,
-            feeds,
-            _makeFeedExpectations(feeds.length, USDS_EXPECTED_PRICE, USDS_EXPECTATION_TOLERANCE_BPS)
-        );
+        PriceConfigv2(priceConfig_)
+            .addAsset(
+                usds_,
+                false, // storeMovingAverage
+                false, // useMovingAverage
+                uint32(0), // movingAverageDuration
+                uint48(0), // lastObservationTime
+                new uint256[](0), // observations
+                strategy,
+                feeds,
+                _makeFeedExpectations(feeds.length, USDS_EXPECTED_PRICE, USDS_EXPECTATION_TOLERANCE_BPS)
+            );
         vm.stopPrank();
 
         console2.log("USDS asset configured");
@@ -465,11 +424,8 @@ contract OracleProposalTest is ProposalTest {
         console2.log("Configuring sUSDS asset");
 
         // Create strategy component: empty (single price feed)
-        IPRICEv2.Component memory strategy = IPRICEv2.Component({
-            target: toSubKeycode(""),
-            selector: bytes4(0),
-            params: abi.encode("")
-        });
+        IPRICEv2.Component memory strategy =
+            IPRICEv2.Component({target: toSubKeycode(""), selector: bytes4(0), params: abi.encode("")});
 
         // Create feed component using ERC4626
         IPRICEv2.Component[] memory feeds = new IPRICEv2.Component[](1);
@@ -482,21 +438,18 @@ contract OracleProposalTest is ProposalTest {
         // Add sUSDS asset via PriceConfig
         address daoMS = addresses.getAddress("olympus-multisig-dao");
         vm.startPrank(daoMS);
-        PriceConfigv2(priceConfig_).addAsset(
-            susds_,
-            false, // storeMovingAverage
-            false, // useMovingAverage
-            uint32(0), // movingAverageDuration
-            uint48(0), // lastObservationTime
-            new uint256[](0), // observations
-            strategy,
-            feeds,
-            _makeFeedExpectations(
-                feeds.length,
-                SUSDS_EXPECTED_PRICE,
-                SUSDS_EXPECTATION_TOLERANCE_BPS
-            )
-        );
+        PriceConfigv2(priceConfig_)
+            .addAsset(
+                susds_,
+                false, // storeMovingAverage
+                false, // useMovingAverage
+                uint32(0), // movingAverageDuration
+                uint48(0), // lastObservationTime
+                new uint256[](0), // observations
+                strategy,
+                feeds,
+                _makeFeedExpectations(feeds.length, SUSDS_EXPECTED_PRICE, SUSDS_EXPECTATION_TOLERANCE_BPS)
+            );
         vm.stopPrank();
 
         console2.log("sUSDS asset configured");
@@ -511,11 +464,8 @@ contract OracleProposalTest is ProposalTest {
         vm.label(address(ohmSusdsPool), "ohmSusdsPool");
 
         // Create strategy component: empty (single price feed)
-        IPRICEv2.Component memory strategy = IPRICEv2.Component({
-            target: toSubKeycode(""),
-            selector: bytes4(0),
-            params: abi.encode("")
-        });
+        IPRICEv2.Component memory strategy =
+            IPRICEv2.Component({target: toSubKeycode(""), selector: bytes4(0), params: abi.encode("")});
 
         // Create feed component for OHM/sUSDS pool
         IPRICEv2.Component[] memory feeds = new IPRICEv2.Component[](1);
@@ -524,8 +474,7 @@ contract OracleProposalTest is ProposalTest {
             selector: UniswapV3Price.getTokenTWAP.selector,
             params: abi.encode(
                 UniswapV3Price.UniswapV3Params({
-                    pool: ohmSusdsPool,
-                    observationWindowSeconds: OHM_OBSERVATION_WINDOW_SECONDS
+                    pool: ohmSusdsPool, observationWindowSeconds: OHM_OBSERVATION_WINDOW_SECONDS
                 })
             )
         });
@@ -533,17 +482,18 @@ contract OracleProposalTest is ProposalTest {
         // Add OHM asset via PriceConfig
         address daoMS = addresses.getAddress("olympus-multisig-dao");
         vm.startPrank(daoMS);
-        PriceConfigv2(priceConfig_).addAsset(
-            ohm_,
-            false, // storeMovingAverage
-            false, // useMovingAverage
-            uint32(0), // movingAverageDuration
-            uint48(0), // lastObservationTime
-            new uint256[](0), // observations
-            strategy,
-            feeds,
-            _makeFeedExpectations(feeds.length, OHM_EXPECTED_PRICE, OHM_EXPECTATION_TOLERANCE_BPS)
-        );
+        PriceConfigv2(priceConfig_)
+            .addAsset(
+                ohm_,
+                false, // storeMovingAverage
+                false, // useMovingAverage
+                uint32(0), // movingAverageDuration
+                uint48(0), // lastObservationTime
+                new uint256[](0), // observations
+                strategy,
+                feeds,
+                _makeFeedExpectations(feeds.length, OHM_EXPECTED_PRICE, OHM_EXPECTATION_TOLERANCE_BPS)
+            );
         vm.stopPrank();
 
         console2.log("OHM asset configured with OHM/sUSDS Uniswap V3 pool");
@@ -563,10 +513,7 @@ contract OracleProposalTest is ProposalTest {
         SubKeycode subKeycode = Submodule(submodule).SUBKEYCODE();
 
         // Check if submodule is already installed in PRICE module
-        if (
-            address(ModuleWithSubmodules(priceModule).getSubmoduleForKeycode(subKeycode)) !=
-            address(0)
-        ) {
+        if (address(ModuleWithSubmodules(priceModule).getSubmoduleForKeycode(subKeycode)) != address(0)) {
             console2.log("Submodule already installed in PRICE module:", key_);
             return;
         }
@@ -593,26 +540,17 @@ contract OracleProposalTest is ProposalTest {
         address ohm = addresses.getAddress("olympus-legacy-ohm");
         address usds = addresses.getAddress("external-tokens-usds");
 
-        address chainlinkFactory = addresses.getAddress(
-            "olympus-policy-chainlink-oracle-factory-1_0"
-        );
+        address chainlinkFactory = addresses.getAddress("olympus-policy-chainlink-oracle-factory-1_0");
         address morphoFactory = addresses.getAddress("olympus-policy-morpho-oracle-factory-1_0");
 
         // Verify roles
         assertTrue(roles.hasRole(timelock, ADMIN_ROLE), "Timelock does not have admin role");
-        assertTrue(
-            roles.hasRole(daoMS, ORACLE_MANAGER_ROLE),
-            "DAO MS does not have oracle_manager role"
-        );
-        assertTrue(
-            roles.hasRole(timelock, ORACLE_MANAGER_ROLE),
-            "Timelock does not have oracle_manager role"
-        );
+        assertTrue(roles.hasRole(daoMS, ORACLE_MANAGER_ROLE), "DAO MS does not have oracle_manager role");
+        assertTrue(roles.hasRole(timelock, ORACLE_MANAGER_ROLE), "Timelock does not have oracle_manager role");
 
         // Verify policies enabled
         assertTrue(
-            IEnabler(addresses.getAddress("olympus-policy-price-cache-1_0")).isEnabled(),
-            "PriceCache not enabled"
+            IEnabler(addresses.getAddress("olympus-policy-price-cache-1_0")).isEnabled(), "PriceCache not enabled"
         );
         assertTrue(
             IEnabler(addresses.getAddress("olympus-policy-erc7726-oracle-factory-1_0")).isEnabled(),
@@ -623,36 +561,17 @@ contract OracleProposalTest is ProposalTest {
 
         // Verify oracles deployed
         address erc7726Factory = addresses.getAddress("olympus-policy-erc7726-oracle-factory-1_0");
-        address erc7726Oracle = IERC7726OracleFactory(erc7726Factory).getOracle(
-            DEFAULT_ORACLE_MAX_AGE
-        );
+        address erc7726Oracle = IERC7726OracleFactory(erc7726Factory).getOracle(DEFAULT_ORACLE_MAX_AGE);
         assertTrue(erc7726Oracle != address(0), "ERC7726 oracle not deployed");
-        assertTrue(
-            IERC7726OracleFactory(erc7726Factory).isOracleEnabled(erc7726Oracle),
-            "ERC7726 oracle not enabled"
-        );
+        assertTrue(IERC7726OracleFactory(erc7726Factory).isOracleEnabled(erc7726Oracle), "ERC7726 oracle not enabled");
 
-        address chainlinkOracle = IOracleFactory(chainlinkFactory).getOracle(
-            ohm,
-            usds,
-            DEFAULT_ORACLE_MAX_AGE
-        );
+        address chainlinkOracle = IOracleFactory(chainlinkFactory).getOracle(ohm, usds, DEFAULT_ORACLE_MAX_AGE);
         assertTrue(chainlinkOracle != address(0), "OHM/USDS Chainlink oracle not deployed");
-        assertTrue(
-            IOracleFactory(chainlinkFactory).isOracleEnabled(chainlinkOracle),
-            "Chainlink oracle not enabled"
-        );
+        assertTrue(IOracleFactory(chainlinkFactory).isOracleEnabled(chainlinkOracle), "Chainlink oracle not enabled");
 
-        address morphoOracle = IOracleFactory(morphoFactory).getOracle(
-            ohm,
-            usds,
-            DEFAULT_ORACLE_MAX_AGE
-        );
+        address morphoOracle = IOracleFactory(morphoFactory).getOracle(ohm, usds, DEFAULT_ORACLE_MAX_AGE);
         assertTrue(morphoOracle != address(0), "OHM/USDS Morpho oracle not deployed");
-        assertTrue(
-            IOracleFactory(morphoFactory).isOracleEnabled(morphoOracle),
-            "Morpho oracle not enabled"
-        );
+        assertTrue(IOracleFactory(morphoFactory).isOracleEnabled(morphoOracle), "Morpho oracle not enabled");
     }
 
     /// @notice Validates that the ERC7726 oracle clone returns a valid OHM price
@@ -662,21 +581,14 @@ contract OracleProposalTest is ProposalTest {
         address erc7726Factory = addresses.getAddress("olympus-policy-erc7726-oracle-factory-1_0");
         address ohm = addresses.getAddress("olympus-legacy-ohm");
         address usds = addresses.getAddress("external-tokens-usds");
-        address erc7726Oracle = IERC7726OracleFactory(erc7726Factory).getOracle(
-            DEFAULT_ORACLE_MAX_AGE
-        );
+        address erc7726Oracle = IERC7726OracleFactory(erc7726Factory).getOracle(DEFAULT_ORACLE_MAX_AGE);
 
         // Validate ERC7726 clone can quote OHM in terms of USDS
         // Quote 1 OHM (9 decimals) in USDS (18 decimals)
         uint256 ohmInUsds = IERC7726Oracle(erc7726Oracle).getQuote(1e9, ohm, usds);
         console2.log("Asset price of OHM:", ohmInUsds);
         assertFalse(
-            Deviation.isDeviating(
-                ohmInUsds,
-                OHM_EXPECTED_PRICE,
-                OHM_EXPECTATION_TOLERANCE_BPS,
-                BPS_MAX
-            ),
+            Deviation.isDeviating(ohmInUsds, OHM_EXPECTED_PRICE, OHM_EXPECTATION_TOLERANCE_BPS, BPS_MAX),
             "OHM price outside tolerance"
         );
     }

--- a/src/test/proposals/OracleProposal.t.sol
+++ b/src/test/proposals/OracleProposal.t.sol
@@ -46,9 +46,8 @@ import {Deviation} from "src/libraries/Deviation.sol";
 contract OracleProposalTest is ProposalTest {
     Kernel public kernel;
 
-    // Block to fork from (after DAO MS deployment, before OCG proposal)
-    // TODO: Update to the block after the DAO MS deployment
-    uint48 public constant FORK_BLOCK = 24413007 + 1;
+    // Block to fork from after the API3 USDS/USD deployment.
+    uint48 public constant FORK_BLOCK = 25279717 + 1;
 
     uint48 internal constant DEFAULT_ORACLE_MAX_AGE = 1 hours;
     uint16 internal constant BPS_MAX = 10_000;

--- a/src/test/proposals/OracleProposal.t.sol
+++ b/src/test/proposals/OracleProposal.t.sol
@@ -68,15 +68,17 @@ contract OracleProposalTest is ProposalTest {
     uint256 internal constant OHM_EXPECTED_PRICE = 17.5e18;
     uint16 internal constant OHM_EXPECTATION_TOLERANCE_BPS = 1_000; // 10%
 
-    function _makeFeedExpectations(uint256 length_, uint256 expectedPrice_, uint16 toleranceBps_)
-        internal
-        pure
-        returns (IPriceConfigv2.PriceFeedExpectation[] memory expectations_)
-    {
+    function _makeFeedExpectations(
+        uint256 length_,
+        uint256 expectedPrice_,
+        uint16 toleranceBps_
+    ) internal pure returns (IPriceConfigv2.PriceFeedExpectation[] memory expectations_) {
         expectations_ = new IPriceConfigv2.PriceFeedExpectation[](length_);
         for (uint256 i; i < length_; i++) {
-            expectations_[i] =
-                IPriceConfigv2.PriceFeedExpectation({expectedPrice: expectedPrice_, toleranceBps: toleranceBps_});
+            expectations_[i] = IPriceConfigv2.PriceFeedExpectation({
+                expectedPrice: expectedPrice_,
+                toleranceBps: toleranceBps_
+            });
         }
     }
 
@@ -115,7 +117,9 @@ contract OracleProposalTest is ProposalTest {
         // 1. Deploy PRICE v1_2 module if not already installed
         address priceModule = address(kernel.getModuleForKeycode(toKeycode("PRICE")));
         (uint8 priceMajor, uint8 priceMinor) = Module(priceModule).VERSION();
-        bool needsPriceUpgrade = (priceModule == address(0)) || (priceMajor != 1) || (priceMinor < 2);
+        bool needsPriceUpgrade = (priceModule == address(0)) ||
+            (priceMajor != 1) ||
+            (priceMinor < 2);
 
         if (needsPriceUpgrade) {
             console2.log("Deploying PRICE v1.2 module");
@@ -133,7 +137,10 @@ contract OracleProposalTest is ProposalTest {
         } else {
             console2.log("PRICE v1.2 module already installed");
             // Validate that the addresses file has the correct address for the PRICE module
-            require(addresses.getAddress("olympus-module-price-1_2") == priceModule, "PRICE module address mismatch");
+            require(
+                addresses.getAddress("olympus-module-price-1_2") == priceModule,
+                "PRICE module address mismatch"
+            );
         }
 
         // Get the PRICE module address
@@ -206,7 +213,11 @@ contract OracleProposalTest is ProposalTest {
         if (submodule == address(0)) {
             console2.log("Deploying UniswapV3Price");
             submodule = address(
-                new UniswapV3Price(Module(priceModule_), _UNISWAP_V3_AVERAGE_BLOCK_TIME_SECONDS, _UNISWAP_V3_FACTORY)
+                new UniswapV3Price(
+                    Module(priceModule_),
+                    _UNISWAP_V3_AVERAGE_BLOCK_TIME_SECONDS,
+                    _UNISWAP_V3_FACTORY
+                )
             );
             addresses.addAddress(key, submodule);
         } else {
@@ -251,7 +262,13 @@ contract OracleProposalTest is ProposalTest {
         address policy = _safeGetAddress(key);
         if (policy == address(0)) {
             console2.log("Deploying PriceCache");
-            policy = address(new PriceCache(Kernel(kernelAddr_), _UNIT_OF_ACCOUNT_DECIMALS, _UNIT_OF_ACCOUNT_SYMBOL));
+            policy = address(
+                new PriceCache(
+                    Kernel(kernelAddr_),
+                    _UNIT_OF_ACCOUNT_DECIMALS,
+                    _UNIT_OF_ACCOUNT_SYMBOL
+                )
+            );
             addresses.addAddress(key, policy);
         } else {
             console2.log("PriceCache already deployed");
@@ -314,7 +331,9 @@ contract OracleProposalTest is ProposalTest {
     /// @notice Activate oracle policies if not already active
     function _activateOraclePoliciesIfNeeded() internal {
         address erc7726Factory = addresses.getAddress("olympus-policy-erc7726-oracle-factory-1_0");
-        address chainlinkFactory = addresses.getAddress("olympus-policy-chainlink-oracle-factory-1_0");
+        address chainlinkFactory = addresses.getAddress(
+            "olympus-policy-chainlink-oracle-factory-1_0"
+        );
         address morphoFactory = addresses.getAddress("olympus-policy-morpho-oracle-factory-1_0");
         Kernel kernelAddr = Kernel(addresses.getAddress("olympus-kernel"));
 
@@ -361,7 +380,10 @@ contract OracleProposalTest is ProposalTest {
         _installSubmoduleIfNeeded(priceConfig, "olympus-submodule-price-chainlink-price-feeds-1_0");
         _installSubmoduleIfNeeded(priceConfig, "olympus-submodule-price-uniswap-v3-1_0");
         _installSubmoduleIfNeeded(priceConfig, "olympus-submodule-price-erc4626-1_0");
-        _installSubmoduleIfNeeded(priceConfig, "olympus-submodule-price-simple-price-feed-strategy-1_0");
+        _installSubmoduleIfNeeded(
+            priceConfig,
+            "olympus-submodule-price-simple-price-feed-strategy-1_0"
+        );
 
         // Configure USDS with a simple Chainlink feed
         _configureUSDS(priceConfig, usds);
@@ -382,8 +404,11 @@ contract OracleProposalTest is ProposalTest {
         vm.label(chainlinkUsdsUsd, "chainlinkUsdsUsd");
 
         // Create strategy component: empty (single price feed)
-        IPRICEv2.Component memory strategy =
-            IPRICEv2.Component({target: toSubKeycode(""), selector: bytes4(0), params: abi.encode("")});
+        IPRICEv2.Component memory strategy = IPRICEv2.Component({
+            target: toSubKeycode(""),
+            selector: bytes4(0),
+            params: abi.encode("")
+        });
 
         // Create feed component using Chainlink
         IPRICEv2.Component[] memory feeds = new IPRICEv2.Component[](1);
@@ -401,18 +426,17 @@ contract OracleProposalTest is ProposalTest {
         // Add USDS asset via PriceConfig
         address daoMS = addresses.getAddress("olympus-multisig-dao");
         vm.startPrank(daoMS);
-        PriceConfigv2(priceConfig_)
-            .addAsset(
-                usds_,
-                false, // storeMovingAverage
-                false, // useMovingAverage
-                uint32(0), // movingAverageDuration
-                uint48(0), // lastObservationTime
-                new uint256[](0), // observations
-                strategy,
-                feeds,
-                _makeFeedExpectations(feeds.length, USDS_EXPECTED_PRICE, USDS_EXPECTATION_TOLERANCE_BPS)
-            );
+        PriceConfigv2(priceConfig_).addAsset(
+            usds_,
+            false, // storeMovingAverage
+            false, // useMovingAverage
+            uint32(0), // movingAverageDuration
+            uint48(0), // lastObservationTime
+            new uint256[](0), // observations
+            strategy,
+            feeds,
+            _makeFeedExpectations(feeds.length, USDS_EXPECTED_PRICE, USDS_EXPECTATION_TOLERANCE_BPS)
+        );
         vm.stopPrank();
 
         console2.log("USDS asset configured");
@@ -423,8 +447,11 @@ contract OracleProposalTest is ProposalTest {
         console2.log("Configuring sUSDS asset");
 
         // Create strategy component: empty (single price feed)
-        IPRICEv2.Component memory strategy =
-            IPRICEv2.Component({target: toSubKeycode(""), selector: bytes4(0), params: abi.encode("")});
+        IPRICEv2.Component memory strategy = IPRICEv2.Component({
+            target: toSubKeycode(""),
+            selector: bytes4(0),
+            params: abi.encode("")
+        });
 
         // Create feed component using ERC4626
         IPRICEv2.Component[] memory feeds = new IPRICEv2.Component[](1);
@@ -437,18 +464,21 @@ contract OracleProposalTest is ProposalTest {
         // Add sUSDS asset via PriceConfig
         address daoMS = addresses.getAddress("olympus-multisig-dao");
         vm.startPrank(daoMS);
-        PriceConfigv2(priceConfig_)
-            .addAsset(
-                susds_,
-                false, // storeMovingAverage
-                false, // useMovingAverage
-                uint32(0), // movingAverageDuration
-                uint48(0), // lastObservationTime
-                new uint256[](0), // observations
-                strategy,
-                feeds,
-                _makeFeedExpectations(feeds.length, SUSDS_EXPECTED_PRICE, SUSDS_EXPECTATION_TOLERANCE_BPS)
-            );
+        PriceConfigv2(priceConfig_).addAsset(
+            susds_,
+            false, // storeMovingAverage
+            false, // useMovingAverage
+            uint32(0), // movingAverageDuration
+            uint48(0), // lastObservationTime
+            new uint256[](0), // observations
+            strategy,
+            feeds,
+            _makeFeedExpectations(
+                feeds.length,
+                SUSDS_EXPECTED_PRICE,
+                SUSDS_EXPECTATION_TOLERANCE_BPS
+            )
+        );
         vm.stopPrank();
 
         console2.log("sUSDS asset configured");
@@ -463,8 +493,11 @@ contract OracleProposalTest is ProposalTest {
         vm.label(address(ohmSusdsPool), "ohmSusdsPool");
 
         // Create strategy component: empty (single price feed)
-        IPRICEv2.Component memory strategy =
-            IPRICEv2.Component({target: toSubKeycode(""), selector: bytes4(0), params: abi.encode("")});
+        IPRICEv2.Component memory strategy = IPRICEv2.Component({
+            target: toSubKeycode(""),
+            selector: bytes4(0),
+            params: abi.encode("")
+        });
 
         // Create feed component for OHM/sUSDS pool
         IPRICEv2.Component[] memory feeds = new IPRICEv2.Component[](1);
@@ -473,7 +506,8 @@ contract OracleProposalTest is ProposalTest {
             selector: UniswapV3Price.getTokenTWAP.selector,
             params: abi.encode(
                 UniswapV3Price.UniswapV3Params({
-                    pool: ohmSusdsPool, observationWindowSeconds: OHM_OBSERVATION_WINDOW_SECONDS
+                    pool: ohmSusdsPool,
+                    observationWindowSeconds: OHM_OBSERVATION_WINDOW_SECONDS
                 })
             )
         });
@@ -481,18 +515,17 @@ contract OracleProposalTest is ProposalTest {
         // Add OHM asset via PriceConfig
         address daoMS = addresses.getAddress("olympus-multisig-dao");
         vm.startPrank(daoMS);
-        PriceConfigv2(priceConfig_)
-            .addAsset(
-                ohm_,
-                false, // storeMovingAverage
-                false, // useMovingAverage
-                uint32(0), // movingAverageDuration
-                uint48(0), // lastObservationTime
-                new uint256[](0), // observations
-                strategy,
-                feeds,
-                _makeFeedExpectations(feeds.length, OHM_EXPECTED_PRICE, OHM_EXPECTATION_TOLERANCE_BPS)
-            );
+        PriceConfigv2(priceConfig_).addAsset(
+            ohm_,
+            false, // storeMovingAverage
+            false, // useMovingAverage
+            uint32(0), // movingAverageDuration
+            uint48(0), // lastObservationTime
+            new uint256[](0), // observations
+            strategy,
+            feeds,
+            _makeFeedExpectations(feeds.length, OHM_EXPECTED_PRICE, OHM_EXPECTATION_TOLERANCE_BPS)
+        );
         vm.stopPrank();
 
         console2.log("OHM asset configured with OHM/sUSDS Uniswap V3 pool");
@@ -512,7 +545,10 @@ contract OracleProposalTest is ProposalTest {
         SubKeycode subKeycode = Submodule(submodule).SUBKEYCODE();
 
         // Check if submodule is already installed in PRICE module
-        if (address(ModuleWithSubmodules(priceModule).getSubmoduleForKeycode(subKeycode)) != address(0)) {
+        if (
+            address(ModuleWithSubmodules(priceModule).getSubmoduleForKeycode(subKeycode)) !=
+            address(0)
+        ) {
             console2.log("Submodule already installed in PRICE module:", key_);
             return;
         }
@@ -539,17 +575,26 @@ contract OracleProposalTest is ProposalTest {
         address ohm = addresses.getAddress("olympus-legacy-ohm");
         address usds = addresses.getAddress("external-tokens-usds");
 
-        address chainlinkFactory = addresses.getAddress("olympus-policy-chainlink-oracle-factory-1_0");
+        address chainlinkFactory = addresses.getAddress(
+            "olympus-policy-chainlink-oracle-factory-1_0"
+        );
         address morphoFactory = addresses.getAddress("olympus-policy-morpho-oracle-factory-1_0");
 
         // Verify roles
         assertTrue(roles.hasRole(timelock, ADMIN_ROLE), "Timelock does not have admin role");
-        assertTrue(roles.hasRole(daoMS, ORACLE_MANAGER_ROLE), "DAO MS does not have oracle_manager role");
-        assertTrue(roles.hasRole(timelock, ORACLE_MANAGER_ROLE), "Timelock does not have oracle_manager role");
+        assertTrue(
+            roles.hasRole(daoMS, ORACLE_MANAGER_ROLE),
+            "DAO MS does not have oracle_manager role"
+        );
+        assertTrue(
+            roles.hasRole(timelock, ORACLE_MANAGER_ROLE),
+            "Timelock does not have oracle_manager role"
+        );
 
         // Verify policies enabled
         assertTrue(
-            IEnabler(addresses.getAddress("olympus-policy-price-cache-1_0")).isEnabled(), "PriceCache not enabled"
+            IEnabler(addresses.getAddress("olympus-policy-price-cache-1_0")).isEnabled(),
+            "PriceCache not enabled"
         );
         assertTrue(
             IEnabler(addresses.getAddress("olympus-policy-erc7726-oracle-factory-1_0")).isEnabled(),
@@ -560,17 +605,36 @@ contract OracleProposalTest is ProposalTest {
 
         // Verify oracles deployed
         address erc7726Factory = addresses.getAddress("olympus-policy-erc7726-oracle-factory-1_0");
-        address erc7726Oracle = IERC7726OracleFactory(erc7726Factory).getOracle(DEFAULT_ORACLE_MAX_AGE);
+        address erc7726Oracle = IERC7726OracleFactory(erc7726Factory).getOracle(
+            DEFAULT_ORACLE_MAX_AGE
+        );
         assertTrue(erc7726Oracle != address(0), "ERC7726 oracle not deployed");
-        assertTrue(IERC7726OracleFactory(erc7726Factory).isOracleEnabled(erc7726Oracle), "ERC7726 oracle not enabled");
+        assertTrue(
+            IERC7726OracleFactory(erc7726Factory).isOracleEnabled(erc7726Oracle),
+            "ERC7726 oracle not enabled"
+        );
 
-        address chainlinkOracle = IOracleFactory(chainlinkFactory).getOracle(ohm, usds, DEFAULT_ORACLE_MAX_AGE);
+        address chainlinkOracle = IOracleFactory(chainlinkFactory).getOracle(
+            ohm,
+            usds,
+            DEFAULT_ORACLE_MAX_AGE
+        );
         assertTrue(chainlinkOracle != address(0), "OHM/USDS Chainlink oracle not deployed");
-        assertTrue(IOracleFactory(chainlinkFactory).isOracleEnabled(chainlinkOracle), "Chainlink oracle not enabled");
+        assertTrue(
+            IOracleFactory(chainlinkFactory).isOracleEnabled(chainlinkOracle),
+            "Chainlink oracle not enabled"
+        );
 
-        address morphoOracle = IOracleFactory(morphoFactory).getOracle(ohm, usds, DEFAULT_ORACLE_MAX_AGE);
+        address morphoOracle = IOracleFactory(morphoFactory).getOracle(
+            ohm,
+            usds,
+            DEFAULT_ORACLE_MAX_AGE
+        );
         assertTrue(morphoOracle != address(0), "OHM/USDS Morpho oracle not deployed");
-        assertTrue(IOracleFactory(morphoFactory).isOracleEnabled(morphoOracle), "Morpho oracle not enabled");
+        assertTrue(
+            IOracleFactory(morphoFactory).isOracleEnabled(morphoOracle),
+            "Morpho oracle not enabled"
+        );
     }
 
     /// @notice Validates that the ERC7726 oracle clone returns a valid OHM price
@@ -580,14 +644,21 @@ contract OracleProposalTest is ProposalTest {
         address erc7726Factory = addresses.getAddress("olympus-policy-erc7726-oracle-factory-1_0");
         address ohm = addresses.getAddress("olympus-legacy-ohm");
         address usds = addresses.getAddress("external-tokens-usds");
-        address erc7726Oracle = IERC7726OracleFactory(erc7726Factory).getOracle(DEFAULT_ORACLE_MAX_AGE);
+        address erc7726Oracle = IERC7726OracleFactory(erc7726Factory).getOracle(
+            DEFAULT_ORACLE_MAX_AGE
+        );
 
         // Validate ERC7726 clone can quote OHM in terms of USDS
         // Quote 1 OHM (9 decimals) in USDS (18 decimals)
         uint256 ohmInUsds = IERC7726Oracle(erc7726Oracle).getQuote(1e9, ohm, usds);
         console2.log("Asset price of OHM:", ohmInUsds);
         assertFalse(
-            Deviation.isDeviating(ohmInUsds, OHM_EXPECTED_PRICE, OHM_EXPECTATION_TOLERANCE_BPS, BPS_MAX),
+            Deviation.isDeviating(
+                ohmInUsds,
+                OHM_EXPECTED_PRICE,
+                OHM_EXPECTATION_TOLERANCE_BPS,
+                BPS_MAX
+            ),
             "OHM price outside tolerance"
         );
     }


### PR DESCRIPTION
## Summary
- replace Pyth ETH/USD and USDS/USD configuration with API3 Chainlink-interface feeds
- remove Pyth from the PRICE v1.2 deploy/configuration path and docs
- update fork/proposal tests for the API3 USDS/USD deployment block and current fork-block price ranges

## Rationale
Pyth is no longer viable for this configuration because reliable updates require paid Hermes access. API3 provides Chainlink-interface compatible reader proxies for ETH/USD and USDS/USD, with 25-hour staleness thresholds to allow one hour of grace over a 24-hour heartbeat.

## Validation
- `forge test --match-contract OlympusPricev1_2ForkTest`
- `git diff --check`
- `pnpm exec prettier --check snapshots/OlympusPricev1_2ForkTest.json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated oracle configuration documentation to reflect switch from Pyth to API3 price feeds for asset pricing
  * Revised deployment instructions for the updated oracle setup workflow

* **Configuration**
  * Switched oracle feed providers to API3 for price data resolution
  * Updated feed update thresholds and price tolerance parameters accordingly

* **Tests**
  * Updated test suites to validate new oracle feed configuration and pricing mechanisms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->