### PR TITLE
chore(ci): upgrade pnpm to 11

### DIFF
--- a/.github/actions/bootstrap/action.yml
+++ b/.github/actions/bootstrap/action.yml
@@ -17,6 +17,8 @@ runs:
 
         - name: Install pnpm
           uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+          with:
+              version: 11.13.0
 
         - name: Install Foundry
           if: ${{ inputs.install-foundry == 'true' }}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "node": ">=24",
         "npm": "use-pnpm",
         "yarn": "use-pnpm",
-        "pnpm": ">=10.33.0"
+        "pnpm": ">=11.13.0"
     },
     "scripts": {
         "postinstall": "./shell/postinstall.sh",
@@ -64,5 +64,5 @@
         ],
         "jsonRecursiveSort": true
     },
-    "packageManager": "pnpm@10.33.0"
+    "packageManager": "pnpm@11.13.0"
 }


### PR DESCRIPTION
## Summary

Local development and CI now use the same pnpm 11.13.0 release. The existing lockfile remains stable under pnpm 11, so the upgrade does not introduce dependency graph churn.

## Validation

- `pnpm install --no-frozen-lockfile`
- `pnpm install --frozen-lockfile`
- `pnpm audit --audit-level moderate --json` (zero vulnerabilities)
- `pnpm build`
- `pnpm run lint`
- `pnpm run lint:check`
- Manual review against `develop` (no actionable findings)
- Full tests were waived for this package-manager-only change
- CodeRabbit was skipped by request

## Post-Deploy Monitoring & Validation

No additional operational monitoring required because this only changes development and CI package-manager selection. The expected healthy signal is successful dependency installation in CI; an install or version-resolution failure should block the workflow before protocol build or test steps run.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s required PNPM version to 11.13.0.
  * Standardized automated setup to use PNPM 11.13.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->