### PR TITLE
fix(deps): remediate pnpm audit findings

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,11 +5,12 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  brace-expansion@>=5.0.0 <5.0.6: ^5.0.6
+  brace-expansion@>=2.0.0 <2.1.2: ^2.1.2
+  brace-expansion@>=5.0.0 <5.0.7: ^5.0.7
   fast-uri@>=3.0.0 <=3.1.1: ^3.1.2
   cross-spawn@>=7.0.0 <7.0.5: ^7.0.5
   glob@>=11.0.0 <11.1.0: ^11.1.0
-  js-yaml@>=4.0.0 <4.2.0: ^4.2.0
+  js-yaml@>=4.0.0 <4.3.0: ^4.3.0
   lodash@<=4.17.23: ^4.18.0
   markdown-it@>=13.0.0 <14.2.0: ^14.2.0
   minimatch@>=10.0.0 <10.2.3: ^10.2.3
@@ -108,11 +109,11 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  brace-expansion@2.1.0:
-    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
+  brace-expansion@2.1.2:
+    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   c3-linearization@0.3.0:
@@ -274,8 +275,8 @@ packages:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
 
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   json-schema-traverse@1.0.0:
@@ -626,11 +627,11 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  brace-expansion@2.1.0:
+  brace-expansion@2.1.2:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -753,7 +754,7 @@ snapshots:
 
   is-stream@2.0.1: {}
 
-  js-yaml@4.2.0:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -787,7 +788,7 @@ snapshots:
       commander: 15.0.0
       deep-extend: 0.6.0
       ignore: 7.0.5
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       jsonc-parser: 3.3.1
       jsonpointer: 5.0.1
       markdown-it: 14.2.0
@@ -989,11 +990,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.1.0
+      brace-expansion: 2.1.2
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,12 +3,14 @@ preferFrozenLockfile: true
 engineStrict: true
 strictDepBuilds: true
 blockExoticSubdeps: true
+allowBuilds: {}
 overrides:
-    "brace-expansion@>=5.0.0 <5.0.6": "^5.0.6"
+    "brace-expansion@>=2.0.0 <2.1.2": "^2.1.2"
+    "brace-expansion@>=5.0.0 <5.0.7": "^5.0.7"
     "fast-uri@>=3.0.0 <=3.1.1": "^3.1.2"
     "cross-spawn@>=7.0.0 <7.0.5": "^7.0.5"
     "glob@>=11.0.0 <11.1.0": "^11.1.0"
-    "js-yaml@>=4.0.0 <4.2.0": "^4.2.0"
+    "js-yaml@>=4.0.0 <4.3.0": "^4.3.0"
     "lodash@<=4.17.23": "^4.18.0"
     "markdown-it@>=13.0.0 <14.2.0": "^14.2.0"
     "minimatch@>=10.0.0 <10.2.3": "^10.2.3"


### PR DESCRIPTION
## Summary

The dependency audit no longer reports the three high-severity `brace-expansion` and `js-yaml` vulnerabilities. Range-scoped overrides preserve compatibility for each affected dependency line, while an explicit empty `allowBuilds` map keeps pnpm 11's dependency-build policy default-deny.

## Validation

- `pnpm install --no-frozen-lockfile`
- `pnpm install --frozen-lockfile`
- `pnpm audit --audit-level moderate` — no known vulnerabilities
- `forge build`
- `pnpm run lint:check`
- `pnpm run test:unit` — 3,954 tests passed
- `coderabbit review --agent --base develop` — 0 findings across the two changed files

Fork tests were not run because this worktree has no `.env` or `ALCHEMY_API_KEY`. The metrics report command exited successfully, but its existing Surya graph phase logged a caught `TypeError`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version policies to improve compatibility and security.
  * Refined handling for selected transitive dependencies without changing user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->