### PR TITLE
fix(deps): remediate fast-uri and linkify-it advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,11 @@ settings:
 overrides:
   brace-expansion@>=2.0.0 <2.1.2: ^2.1.2
   brace-expansion@>=5.0.0 <5.0.7: ^5.0.7
-  fast-uri@>=3.0.0 <=3.1.1: ^3.1.2
+  fast-uri@>=3.0.0 <=3.1.3: ^3.1.4
   cross-spawn@>=7.0.0 <7.0.5: ^7.0.5
   glob@>=11.0.0 <11.1.0: ^11.1.0
   js-yaml@>=4.0.0 <4.3.0: ^4.3.0
+  linkify-it@<=5.0.1: ^5.0.2
   lodash@<=4.17.23: ^4.18.0
   markdown-it@>=13.0.0 <14.2.0: ^14.2.0
   minimatch@>=10.0.0 <10.2.3: ^10.2.3
@@ -200,8 +201,8 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -293,8 +294,8 @@ packages:
     resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
     hasBin: true
 
-  linkify-it@5.0.1:
-    resolution: {integrity: sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==}
+  linkify-it@5.0.2:
+    resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
 
   lru-cache@11.0.1:
     resolution: {integrity: sha512-CgeuL5uom6j/ZVrg7G/+1IXqRY8JXX4Hghfy5YE0EhoYQWvndP1kufu58cmZLNIDKnRhZrXfdS9urVWx98AipQ==}
@@ -605,7 +606,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -693,7 +694,7 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.4: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -768,7 +769,7 @@ snapshots:
     dependencies:
       commander: 8.3.0
 
-  linkify-it@5.0.1:
+  linkify-it@5.0.2:
     dependencies:
       uc.micro: 2.1.0
 
@@ -778,7 +779,7 @@ snapshots:
     dependencies:
       argparse: 2.0.1
       entities: 4.5.0
-      linkify-it: 5.0.1
+      linkify-it: 5.0.2
       mdurl: 2.0.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,6 @@
 minimumReleaseAge: 10080
+minimumReleaseAgeExclude:
+    - "fast-uri@3.1.4"
 preferFrozenLockfile: true
 engineStrict: true
 strictDepBuilds: true
@@ -7,10 +9,11 @@ allowBuilds: {}
 overrides:
     "brace-expansion@>=2.0.0 <2.1.2": "^2.1.2"
     "brace-expansion@>=5.0.0 <5.0.7": "^5.0.7"
-    "fast-uri@>=3.0.0 <=3.1.1": "^3.1.2"
+    "fast-uri@>=3.0.0 <=3.1.3": "^3.1.4"
     "cross-spawn@>=7.0.0 <7.0.5": "^7.0.5"
     "glob@>=11.0.0 <11.1.0": "^11.1.0"
     "js-yaml@>=4.0.0 <4.3.0": "^4.3.0"
+    "linkify-it@<=5.0.1": "^5.0.2"
     "lodash@<=4.17.23": "^4.18.0"
     "markdown-it@>=13.0.0 <14.2.0": "^14.2.0"
     "minimatch@>=10.0.0 <10.2.3": "^10.2.3"


### PR DESCRIPTION
## Summary

- update the existing range-scoped overrides for vulnerable `fast-uri` and `linkify-it` releases
- allow only `fast-uri@3.1.4` through the seven-day minimum release-age policy because it is the compatible patched 3.x release
- regenerate the lockfile while preserving the repository's existing audit and dependency-build policies

This resolves GHSA-4c8g-83qw-93j6, GHSA-v2hh-gcrm-f6hx, and GHSA-v245-v573-v5vm. The previously reported `brace-expansion` and `js-yaml` advisories were already clean on the current `develop` dependency graph.

## Validation

- `pnpm audit --audit-level moderate --json` — 0 vulnerabilities
- clean unlocked and frozen installs with lifecycle scripts disabled, followed by `forge soldeer update`
- `pnpm run build`
- `pnpm run lint`
- `pnpm run lint:check`
- `pnpm run test:unit` — 4,898 passed, 0 failed

The fork suite was not run because the isolated workspace has no materialized `.env`; the shared checkout uses an external-injector FIFO that was unavailable to this run.
