### PR TITLE
docs(testing): strengthen protocol test guidance

### DIFF
--- a/.claude/skills/test-write/SAMPLE_TEST.md
+++ b/.claude/skills/test-write/SAMPLE_TEST.md
@@ -152,10 +152,9 @@ contract DepositTest is SimpleVaultTest {
     // =======================================================================
 
     // given the vault is paused
-    //   when deposit is called
-    //     [X] it reverts
+    //   [X] it reverts
 
-    function test_givenVaultPaused_whenDeposit_reverts() public givenVaultPaused {
+    function test_givenVaultPaused_reverts() public givenVaultPaused {
         deal(address(vault.asset()), user, 100e18);
         vm.startPrank(user);
         vault.asset().approve(address(vault), 100e18);
@@ -166,11 +165,10 @@ contract DepositTest is SimpleVaultTest {
         vm.stopPrank();
     }
 
-    // given the amount is zero
-    //   when deposit is called
-    //     [X] it reverts
+    // when amount is zero
+    //   [X] it reverts
 
-    function test_givenAmountIsZero_whenDeposit_reverts() public {
+    function test_whenAmountIsZero_reverts() public {
         deal(address(vault.asset()), user, 100e18);
         vm.startPrank(user);
         vault.asset().approve(address(vault), 100e18);
@@ -182,10 +180,9 @@ contract DepositTest is SimpleVaultTest {
     }
 
     // given vault is at capacity
-    //   when deposit is called
-    //     [X] it reverts
+    //   [X] it reverts
 
-    function test_givenVaultAtCapacity_whenDeposit_reverts() public givenVaultAtCapacity {
+    function test_givenVaultAtCapacity_reverts() public givenVaultAtCapacity {
         deal(address(vault.asset()), user, 1e18);
         vm.startPrank(user);
         vault.asset().approve(address(vault), 1e18);
@@ -197,10 +194,9 @@ contract DepositTest is SimpleVaultTest {
     }
 
     // given user has no allowance
-    //   when deposit is called
-    //     [X] it reverts
+    //   [X] it reverts
 
-    function test_givenUserHasNoAllowance_whenDeposit_reverts() public {
+    function test_givenUserHasNoAllowance_reverts() public {
         deal(address(vault.asset()), user, 100e18);
         vm.prank(user);
 
@@ -212,14 +208,13 @@ contract DepositTest is SimpleVaultTest {
     // SUCCESS CONDITIONS WITH MULTIPLE ASSERTIONS
     // =======================================================================
 
-    // given valid parameters
-    //   when deposit is called
-    //     [X] it mints shares to receiver
-    //     [X] it transfers tokens from caller
-    //     [X] it emits Deposit event
-    //     [X] it updates total supply
+    // when parameters are valid
+    //   [X] it mints shares to receiver
+    //   [X] it transfers tokens from caller
+    //   [X] it emits Deposit event
+    //   [X] it updates total supply
 
-    function test_givenValidParams_whenDeposit_mintsShares() public {
+    function test_whenParametersAreValid() public {
         // Arrange
         uint256 depositAmount = 100e18;
         deal(address(vault.asset()), user, depositAmount);
@@ -247,13 +242,10 @@ contract DepositTest is SimpleVaultTest {
     }
 
     // given user has existing deposit
-    //   when deposit is called again
-    //     [X] it adds to existing shares
-    //     [X] it emits Deposit event
+    //   [X] it adds to existing shares
+    //   [X] it emits Deposit event
 
-    function test_givenUserHasDeposit_whenDeposit_addsToExistingShares() public
-        givenUserHasDeposit
-    {
+    function test_givenUserHasDeposit() public givenUserHasDeposit {
         // Arrange
         uint256 additionalAmount = 50e18;
         deal(address(vault.asset()), user, additionalAmount);
@@ -284,10 +276,10 @@ contract DepositTest is SimpleVaultTest {
 
     // given user has existing deposit
     //   given vault is nearly at capacity
-    //     when deposit would exceed capacity
+    //     when amount exceeds remaining capacity
     //       [X] it reverts
 
-    function test_givenUserHasDeposit_givenVaultNearlyAtCapacity_whenDepositExceeds_reverts()
+    function test_givenUserHasDeposit_givenVaultNearlyAtCapacity_whenAmountExceedsRemainingCapacity_reverts()
         public
     {
         // Arrange - fill vault to 90% capacity
@@ -315,7 +307,7 @@ contract DepositTest is SimpleVaultTest {
 | One function per file | `deposit.t.sol` only tests `deposit()` |
 | Parent contract structure | `SimpleVaultTest` with sections for state, setup, helpers, assertions, modifiers |
 | `given*` modifiers | `givenVaultPaused`, `givenUserHasDeposit` |
-| Branching tree naming | `test_givenVaultPaused_whenDeposit_reverts()` |
+| Branching tree naming | `test_givenVaultPaused_reverts()` |
 | Error selectors | `abi.encodeWithSelector(ISimpleVault.VAULT_Paused.selector)` |
 | Multiple assertions | Event check + share balance + vault balance + total supply |
 | Error conditions first | All revert tests come before success tests |
@@ -325,12 +317,12 @@ contract DepositTest is SimpleVaultTest {
 
 ```solidity
 // given vault is below capacity
-//   when the deposit causes the vault to hit or exceed capacity
+//   when amount causes the vault to hit or exceed capacity
 //     [X] it reverts
-//   when the deposit does not cause the vault to hit capacity
+//   when amount does not cause the vault to hit capacity
 //     [X] it mints shares
 //     [X] it emits Deposit event
 
-function test_givenVaultBelowCapacity_whenDepositExceeds_reverts() public { }
-function test_givenVaultBelowCapacity_whenDepositWithinCapacity_mintsShares() public { }
+function test_givenVaultBelowCapacity_whenAmountHitsOrExceedsCapacity_reverts() public { }
+function test_givenVaultBelowCapacity_whenAmountIsWithinCapacity() public { }
 ```

--- a/.claude/skills/test-write/SAMPLE_TEST.md
+++ b/.claude/skills/test-write/SAMPLE_TEST.md
@@ -200,7 +200,7 @@ contract DepositTest is SimpleVaultTest {
         deal(address(vault.asset()), user, 100e18);
         vm.prank(user);
 
-        vm.expectRevert();
+        vm.expectRevert(abi.encodeWithSelector(ISimpleVault.VAULT_InsufficientAllowance.selector));
         vault.deposit(100e18, user);
     }
 

--- a/.claude/skills/test-write/SAMPLE_TEST.md
+++ b/.claude/skills/test-write/SAMPLE_TEST.md
@@ -317,12 +317,12 @@ contract DepositTest is SimpleVaultTest {
 
 ```solidity
 // given vault is below capacity
-//   when amount causes the vault to hit or exceed capacity
+//   when amount exceeds remaining capacity
 //     [X] it reverts
-//   when amount does not cause the vault to hit capacity
+//   when amount equals remaining capacity
 //     [X] it mints shares
 //     [X] it emits Deposit event
 
-function test_givenVaultBelowCapacity_whenAmountHitsOrExceedsCapacity_reverts() public { }
-function test_givenVaultBelowCapacity_whenAmountIsWithinCapacity() public { }
+function test_givenVaultBelowCapacity_whenAmountExceedsRemainingCapacity_reverts() public { }
+function test_givenVaultBelowCapacity_whenAmountEqualsRemainingCapacity() public { }
 ```

--- a/.claude/skills/test-write/SKILL.md
+++ b/.claude/skills/test-write/SKILL.md
@@ -47,6 +47,7 @@ abstract contract DEPOSTest {
     address public godmode;
     address public admin;
     address public user;
+    uint256 internal _positionId;
 
     // =======================================================================
     // setUp() - Contract deployment and initial configuration
@@ -103,8 +104,8 @@ abstract contract DEPOSTest {
     // State Modifiers - Establish commonly-used test states
     // =======================================================================
 
-    modifier givenPositionExists(uint256 positionId_) {
-        _createPosition(user, 100e18, 1e9);
+    modifier givenPositionExists() {
+        _positionId = _createPosition(user, 100e18, 1e9);
         _;
     }
 
@@ -152,8 +153,8 @@ Two modifier prefixes with distinct purposes:
 
 ```solidity
 // Creates a position before test runs
-modifier givenPositionExists(uint256 positionId_) {
-    _createPosition(user, 100e18, 1e9);
+modifier givenPositionExists() {
+    _positionId = _createPosition(user, 100e18, 1e9);
     _;
 }
 
@@ -180,13 +181,13 @@ modifier whenCallerIsNotAdmin() {
 
 // Usage example
 function test_givenPositionExists_whenAmountIsZero_reverts() public
-    givenPositionExists(1)
+    givenPositionExists
     whenAmountIsZero
 {
     // Position exists (given*)
     // Amount is zero (when*)
     vm.expectRevert(abi.encodeWithSelector(IContract.CONTRACT_InvalidAmount.selector));
-    DEPOS.burn(1, 0);
+    DEPOS.burn(_positionId, 0);
 }
 ```
 
@@ -194,8 +195,8 @@ function test_givenPositionExists_whenAmountIsZero_reverts() public
 
 ```solidity
 // GOOD - Clear state setup via modifier
-modifier givenPositionExists(uint256 positionId_) {
-    _createPosition(positionId_);
+modifier givenPositionExists() {
+    _positionId = _createPosition(user, 100e18, 1e9);
     _;
 }
 
@@ -215,7 +216,7 @@ modifier givenUserHasAllowance(address owner_, uint256 amount_) {
 ### Usage in Tests
 
 ```solidity
-function test_givenPositionExists_whenAmountIsZero_reverts() public givenPositionExists(1) {
+function test_givenPositionExists_whenAmountIsZero_reverts() public givenPositionExists {
     // Test logic here - position already exists
 }
 ```
@@ -528,9 +529,9 @@ function test_whenArrayLengthIsBetweenOneAndTen(uint8 length) public {
 **Why `bound()` is better for numeric ranges:**
 
 When a fuzzer generates a random `uint256`, nearly all values may be outside a small target range.
-For example, targeting `0 <= x <= 1000` discards 99.9999% of inputs. The `bound()` function wraps
-the input using modulo arithmetic to keep it in the chosen valid or invalid interval without
-discarding:
+For example, targeting `0 <= x <= 1000` discards all but 1,001 of the `2^256` possible inputs. The
+`bound()` function wraps the input using modulo arithmetic to keep it in the chosen valid or invalid
+interval without discarding:
 
 ```solidity
 // bound() implementation (simplified)

--- a/.claude/skills/test-write/SKILL.md
+++ b/.claude/skills/test-write/SKILL.md
@@ -543,11 +543,15 @@ function bound(uint256 x, uint256 min, uint256 max) pure returns (uint256) {
 // when caller is not admin
 //   [X] it reverts
 
-function test_whenCallerIsNotAdmin_reverts() public {
-    address nonAdmin = makeAddr("nonAdmin");
-    vm.expectRevert(abi.encodeWithSelector(ROLES.ROLES_RequireRole.selector));
-    vm.prank(nonAdmin);
-    DEPOS.mint(100e18, 1e9);
+function test_whenCallerIsNotAdmin_reverts(address caller_) public {
+    vm.assume(caller_ != admin);
+    vm.assume(caller_ != address(0));
+
+    vm.expectRevert(
+        abi.encodeWithSelector(ROLESv1.ROLES_RequireRole.selector, bytes32("admin"))
+    );
+    vm.prank(caller_);
+    contract.restrictedFunction(); // Uses onlyAdminRole
 }
 
 // given position exists
@@ -692,11 +696,13 @@ function _expectRevertInvalidParams(string memory param) internal {
 }
 
 // Usage
-function test_whenCallerIsNotAdmin_reverts() public {
-    address nonAdmin = makeAddr("nonAdmin");
+function test_whenCallerIsNotAdmin_reverts(address caller_) public {
+    vm.assume(caller_ != admin);
+    vm.assume(caller_ != address(0));
+
     _expectRevertNotAdmin();
-    vm.prank(nonAdmin);
-    contract.restrictedFunction();
+    vm.prank(caller_);
+    contract.restrictedFunction(); // Uses onlyAdminRole
 }
 ```
 

--- a/.claude/skills/test-write/SKILL.md
+++ b/.claude/skills/test-write/SKILL.md
@@ -627,7 +627,15 @@ function test_givenPositionExists_givenPositionIsWrapped_givenThirdPartyIsApprov
 
 ## Error Handling in Tests
 
-### Always Use Error Selectors
+### Match Specific Revert Data
+
+Match the failure path being tested, not merely the fact that some call reverted. Use the custom
+error selector, and include the encoded arguments when their values are part of the behavior being
+proved.
+
+Do not use zero-argument `vm.expectRevert()` by default. It accepts any revert and can pass when the
+call fails for the wrong reason. Use it only when an opaque external dependency provides no stable
+revert data, and document why a stronger match is impossible.
 
 **GOOD - Error selector:**
 
@@ -639,9 +647,10 @@ vm.expectRevert(
 );
 ```
 
-**BAD - String message:**
+**BAD - Any revert or string message:**
 
 ```solidity
+vm.expectRevert();
 vm.expectRevert("Insufficient remaining");
 vm.expectRevert("UNAUTHORIZED");
 ```
@@ -676,6 +685,8 @@ function test_whenCallerIsNotAdmin_reverts() public {
 
 - **Custom errors** (in contracts): Define in the contract's interface
 - **Custom errors** (in tests): Use selectors from the interface
+- **Empty revert matching**: Use only for an opaque dependency with no stable revert data, and
+  document the reason
 - **Never** use string revert messages
 
 ## Assertion Best Practices
@@ -738,7 +749,7 @@ assertEq(convertibleAmount, 2e9, "Convertible amount does not equal 2e9");
 | Test naming                               | `test_somethingBad`                            | `test_givenCondition_whenParameter` (success) or `test_givenCondition_whenParameter_reverts` (revert) |
 | Fuzz test naming                          | `testFuzz_*` or `test_*_fuzz`                  | Standard branching-tree name; parameters identify fuzzing                                             |
 | Constraining numeric ranges in fuzz       | `vm.assume(value <= 1000)` for `uint256 value` | `bound(value, 0, 1000)`                                                                               |
-| Error testing                             | `vm.expectRevert("message")`                   | `abi.encodeWithSelector(Error.selector)`                                                              |
+| Error testing                             | Empty or string-based `vm.expectRevert`         | Match the selector or fully encoded custom error                                                       |
 | Assertions                                | `assertEq(a, b)`                               | `assertEq(a, b, "description")`                                                                       |
 | File organization                         | Multiple external actions per file             | One external state-changing action per file; co-locate corresponding preview/getter assertions        |
 
@@ -762,7 +773,8 @@ assertEq(convertibleAmount, 2e9, "Convertible amount does not equal 2e9");
 - [ ] Corresponding preview/getter and write behavior agree without losing unique read-path coverage
 - [ ] Stateful invariant tests cover applicable accounting, custody, lifecycle, authorization, and
         enabled-state properties
-- [ ] Uses error selectors, not string messages
+- [ ] Revert tests match specific error data; any empty `vm.expectRevert()` documents why stronger
+      matching is impossible
 - [ ] All assertions have descriptive messages
 - [ ] Mathematical reasoning documented in comments
 - [ ] Tests cover applicable state and input edge cases

--- a/.claude/skills/test-write/SKILL.md
+++ b/.claude/skills/test-write/SKILL.md
@@ -609,13 +609,13 @@ function test_givenPositionExists_whenAmountEqualsRemaining() public {
 
 // given position exists
 //   given position is wrapped
-//     given third party is approved
-//       when caller transfers the position
+//     given transfer caller is approved
+//       when transfer caller transfers the position
 //         [X] approval preserves the owner
 //         [X] transfer updates the owner
 //         [X] transfer preserves the remaining deposit
 
-function test_givenPositionExists_givenPositionIsWrapped_givenThirdPartyIsApproved_whenCallerTransfersPosition()
+function test_givenPositionExists_givenPositionIsWrapped_givenTransferCallerIsApproved_whenTransferCallerTransfersPosition()
     public
 {
     address transferCaller = makeAddr("transferCaller");

--- a/.claude/skills/test-write/SKILL.md
+++ b/.claude/skills/test-write/SKILL.md
@@ -348,17 +348,17 @@ function test_given<Condition>_when<Parameter>() {
 
 ```solidity
 // given vault is below capacity
-//   when amount causes the vault to hit or exceed capacity
+//   when amount exceeds remaining capacity
 //     [X] it reverts
-//   when amount does not cause the vault to hit capacity
+//   when amount equals remaining capacity
 //     [X] it mints shares
 //     [X] it emits Deposit event
 
-function test_givenVaultBelowCapacity_whenAmountHitsOrExceedsCapacity_reverts() public {
+function test_givenVaultBelowCapacity_whenAmountExceedsRemainingCapacity_reverts() public {
     // test code
 }
 
-function test_givenVaultBelowCapacity_whenAmountIsWithinCapacity() public {
+function test_givenVaultBelowCapacity_whenAmountEqualsRemainingCapacity() public {
     // test code
 }
 ```
@@ -418,7 +418,8 @@ function test_whenStrictMode_whenOneRemains_reverts() public {
 }
 ```
 
-**Note:** Don't include the expected result in the function name. A single test often has multiple assertions/checks.
+**Note:** Don't include the expected result in the function name. A single test often has multiple
+assertions/checks. The `_reverts` suffix is the sole permitted outcome suffix.
 
 **Ordering:** Write error/revert tests first, then success tests. This makes failures easier to spot.
 
@@ -460,8 +461,9 @@ function test_whenInputArrayLengthIsLessThanThree_fuzz(uint8 length) public {
 
 - Use the standard branching-tree name without `testFuzz_` or `_fuzz`
 - Follow the same branching tree pattern as unit tests
-- Use `bound()` for constraining numeric values (preferred over `vm.assume()`)
-- Use `vm.assume()` only for non-numeric constraints or when `bound()` is not feasible
+- Use `bound()` when constraining a broad numeric domain to a narrow range
+- Use `vm.assume()` for non-numeric or complex constraints, and for tight numeric domains where it
+  discards only a small number of values
 - Document the bounds being tested in comments
 
 **Use `bound()` instead of `vm.assume()` for numeric values:**
@@ -470,14 +472,14 @@ Foundry has a limit on the number of discarded fuzz inputs. Using `vm.assume()` 
 
 ```solidity
 // BAD - vm.assume() discards too many values
-function test_whenAmountIsLarge(uint256 amount) public {
+function test_whenAmountIsAtMostOneThousand(uint256 amount) public {
     // This discards nearly all uint256 values except 0-1000
     vm.assume(amount <= 1000);
     // Test will fail with "Fuzz testing ran out of inputs"
 }
 
 // GOOD - use bound() to constrain the input
-function test_whenAmountIsLarge(uint256 amount) public {
+function test_whenAmountIsAtMostOneThousand(uint256 amount) public {
     uint256 boundedAmount = bound(amount, 0, 1000);
     // boundedAmount is now in range [0, 1000]
 }
@@ -527,7 +529,9 @@ function bound(uint256 x, uint256 min, uint256 max) pure returns (uint256) {
 //   [X] it reverts
 
 function test_whenCallerIsNotAdmin_reverts() public {
+    address nonAdmin = makeAddr("nonAdmin");
     vm.expectRevert(abi.encodeWithSelector(ROLES.ROLES_RequireRole.selector));
+    vm.prank(nonAdmin);
     DEPOS.mint(100e18, 1e9);
 }
 
@@ -653,7 +657,9 @@ function _expectRevertInvalidParams(string memory param) internal {
 
 // Usage
 function test_whenCallerIsNotAdmin_reverts() public {
+    address nonAdmin = makeAddr("nonAdmin");
     _expectRevertNotAdmin();
+    vm.prank(nonAdmin);
     contract.restrictedFunction();
 }
 ```

--- a/.claude/skills/test-write/SKILL.md
+++ b/.claude/skills/test-write/SKILL.md
@@ -612,7 +612,8 @@ function test_givenPositionExists_givenThirdPartyIsApproved_whenCallerIsThirdPar
     vm.prank(thirdParty);
     DEPOS.burn(positionId, 50e18);
 
-    (, , uint256 remaining, , , ) = DEPOS.positions(positionId);
+    (address owner, , uint256 remaining, , , ) = DEPOS.positions(positionId);
+    assertEq(owner, thirdParty, "position owner should be third party");
     assertEq(remaining, 50e18, "remaining should be 50");
 }
 ```

--- a/.claude/skills/test-write/SKILL.md
+++ b/.claude/skills/test-write/SKILL.md
@@ -117,7 +117,7 @@ abstract contract DEPOSTest {
 
 // src/test/modules/DEPOS/mint.t.sol - Inherits from parent
 contract MintTest is DEPOSTest {
-    function test_givenAmountZero_mint() public {
+    function test_whenAmountIsZero_reverts() public {
         // Can use DEPOS, godmode, admin, user directly
         // Can call _createPosition(), _dealTokens(), etc.
         // Can apply modifiers like givenPositionExists
@@ -179,7 +179,7 @@ modifier whenCallerIsNotAdmin() {
 }
 
 // Usage example
-function test_givenPositionExists_whenAmountIsZero() public
+function test_givenPositionExists_whenAmountIsZero_reverts() public
     givenPositionExists(1)
     whenAmountIsZero
 {
@@ -215,7 +215,7 @@ modifier givenUserHasAllowance(address owner_, uint256 amount_) {
 ### Usage in Tests
 
 ```solidity
-function test_givenPositionExists_whenBurn_reverts() public givenPositionExists(1) {
+function test_givenPositionExists_whenAmountIsZero_reverts() public givenPositionExists(1) {
     // Test logic here - position already exists
 }
 ```
@@ -348,17 +348,17 @@ function test_given<Condition>_when<Parameter>() {
 
 ```solidity
 // given vault is below capacity
-//   when the deposit causes the vault to hit or exceed capacity
+//   when amount causes the vault to hit or exceed capacity
 //     [X] it reverts
-//   when the deposit does not cause the vault to hit capacity
+//   when amount does not cause the vault to hit capacity
 //     [X] it mints shares
 //     [X] it emits Deposit event
 
-function test_givenVaultBelowCapacity_whenDepositExceeds_reverts() public {
+function test_givenVaultBelowCapacity_whenAmountHitsOrExceedsCapacity_reverts() public {
     // test code
 }
 
-function test_givenVaultBelowCapacity_whenDepositWithinCapacity() public {
+function test_givenVaultBelowCapacity_whenAmountIsWithinCapacity() public {
     // test code
 }
 ```
@@ -523,20 +523,19 @@ function bound(uint256 x, uint256 min, uint256 max) pure returns (uint256) {
 ```solidity
 // === ERROR CONDITIONS (write these first) ===
 
-// given the caller is not admin
-//   when mint is called
-//     [X] it reverts
+// when caller is not admin
+//   [X] it reverts
 
-function test_givenCallerNotAdmin() public {
+function test_whenCallerIsNotAdmin_reverts() public {
     vm.expectRevert(abi.encodeWithSelector(ROLES.ROLES_RequireRole.selector));
     DEPOS.mint(100e18, 1e9);
 }
 
-// given the amount is zero
-//   when burn is called
+// given position exists
+//   when amount is zero
 //     [X] it reverts
 
-function test_givenAmountIsZero() public {
+function test_givenPositionExists_whenAmountIsZero_reverts() public {
     uint256 positionId = _createPosition(user, 100e18, 1e9);
 
     vm.expectRevert(abi.encodeWithSelector(IDepositPositionManager.DEPOS_InvalidAmount.selector));
@@ -547,7 +546,7 @@ function test_givenAmountIsZero() public {
 //   when amount exceeds remaining
 //     [X] it reverts with InsufficientRemaining error
 
-function test_givenPositionExists_whenAmountExceedsRemaining() public {
+function test_givenPositionExists_whenAmountExceedsRemaining_reverts() public {
     uint256 positionId = _createPosition(user, 100e18, 1e9);
 
     vm.expectRevert(abi.encodeWithSelector(IDepositPositionManager.DEPOS_InsufficientRemaining.selector));
@@ -558,10 +557,9 @@ function test_givenPositionExists_whenAmountExceedsRemaining() public {
 
 // given position exists
 //   given position is expired
-//     when burn is called
-//       [X] it reverts
+//     [X] it reverts
 
-function test_givenPositionExists_givenPositionExpired() public {
+function test_givenPositionExists_givenPositionExpired_reverts() public {
     uint256 positionId = _createPosition(user, 100e18, 1e9);
     _warp(block.timestamp + 31 days);
 
@@ -591,13 +589,13 @@ function test_givenPositionExists_whenAmountEqualsRemaining() public {
 }
 
 // given position exists
-//   given user has allowance
-//     when third party burns
+//   given third party is approved
+//     when caller is third party
 //       [X] it decreases remaining
 //       [X] it updates owner
 //       [X] it emits Transfer event
 
-function test_givenPositionExists_givenUserHasAllowance_whenThirdPartyBurns() public {
+function test_givenPositionExists_givenThirdPartyIsApproved_whenCallerIsThirdParty() public {
     address thirdParty = makeAddr("thirdParty");
     uint256 positionId = _createPosition(user, 100e18, 1e9);
 
@@ -654,7 +652,7 @@ function _expectRevertInvalidParams(string memory param) internal {
 }
 
 // Usage
-function test_givenCallerNotAdmin_reverts() public {
+function test_whenCallerIsNotAdmin_reverts() public {
     _expectRevertNotAdmin();
     contract.restrictedFunction();
 }

--- a/.claude/skills/test-write/SKILL.md
+++ b/.claude/skills/test-write/SKILL.md
@@ -296,9 +296,10 @@ Test the re-enabled state separately when re-enablement can refresh dependencies
 - Cover zero/non-zero addresses, empty/single-item/maximum-size collections, duplicate entries,
     malformed encodings, and enum or selector boundaries when relevant.
 - Cover rounding thresholds and decimal-scale combinations when arithmetic behavior can change.
-- Fuzz across the valid numeric range. One interior fuzz case does not prove boundary behavior.
-- Use `bound()` when constraining numeric inputs to a range; keep explicit boundary tests even when
-    the valid range is fuzzed.
+- Choose each fuzzed numeric range from the behavior being proved, including valid and invalid
+    intervals. One interior fuzz case does not prove boundary behavior.
+- Use `bound()` to map numeric inputs into that exact target interval. Never map an invalid-input
+    test into the valid interval, and keep explicit boundary tests alongside range fuzzing.
 
 ### State Transitions
 
@@ -463,14 +464,17 @@ function test_whenInputArrayLengthIsLessThanThree_fuzz(uint8 length) public {
 
 - Use the standard branching-tree name without `testFuzz_` or `_fuzz`
 - Follow the same branching tree pattern as unit tests
-- Use `bound()` when constraining numeric inputs to a range
+- Choose the numeric target range from the behavior the test proves
+- Use `bound()` to map numeric inputs into that exact valid or invalid interval
 - Use `vm.assume()` for non-numeric or complex constraints
-- Document the bounds being tested in comments
+- Document the target interval and why it matches the tested behavior
 
-**Use `bound()` instead of `vm.assume()` for numeric values:**
+**Use `bound()` to target the numeric interval under test:**
 
 Foundry has a limit on the number of discarded fuzz inputs. Using `vm.assume()` to constrain a
-numeric input can exhaust this limit when most generated values fall outside the accepted range.
+numeric input can exhaust this limit when most generated values fall outside the target interval.
+Derive that interval from the behavior being proved, then use `bound()` to map inputs into it. The
+target may be a valid interval for a success test or an invalid interval for a revert test.
 
 ```solidity
 // BAD - vm.assume() discards too many values
@@ -480,10 +484,16 @@ function test_whenAmountIsAtMostOneThousand(uint256 amount) public {
     // Test will fail with "Fuzz testing ran out of inputs"
 }
 
-// GOOD - use bound() to constrain the input
+// GOOD - the success behavior targets the exact valid interval [0, 1000]
 function test_whenAmountIsAtMostOneThousand(uint256 amount) public {
     uint256 boundedAmount = bound(amount, 0, 1000);
-    // boundedAmount is now in range [0, 1000]
+    // boundedAmount is in the valid interval this test proves
+}
+
+// GOOD - the revert behavior targets the exact invalid interval [1001, type(uint256).max]
+function test_whenAmountExceedsOneThousand_reverts(uint256 amount) public {
+    uint256 boundedAmount = bound(amount, 1001, type(uint256).max);
+    // boundedAmount remains invalid; it is never mapped into the valid interval
 }
 
 // GOOD - vm.assume() for non-numeric or complex constraints
@@ -492,25 +502,29 @@ function test_whenAddressIsNotZero(address addr) public {
     // Only discards 1 out of 2^160 values - acceptable
 }
 
-// GOOD - use bound() even for a narrow numeric range
+// GOOD - use bound() even for a narrow numeric target interval
 function test_whenArrayLengthIsBetweenOneAndTen(uint8 length) public {
     uint8 boundedLength = uint8(bound(length, 1, 10));
-    // boundedLength is now in range [1, 10]
+    // boundedLength is in the exact interval this behavior requires
 }
 ```
 
 **When to use `bound()` vs `vm.assume()`:**
 
-| Scenario                | Use           | Example                                         |
-| ----------------------- | ------------- | ----------------------------------------------- |
-| Numeric range           | `bound()`     | `uint8(bound(len, 1, 10))` for `uint8 len`      |
-| Non-numeric constraints | `vm.assume()` | `vm.assume(addr != address(0))`                 |
-| Complex multi-variable  | `vm.assume()` | `vm.assume(x > y)`                              |
-| Address is not zero     | `vm.assume()` | `vm.assume(addr != address(0))`                 |
+| Scenario                       | Use           | Example                                                    |
+| ------------------------------ | ------------- | ---------------------------------------------------------- |
+| Exact valid numeric interval   | `bound()`     | `uint8(bound(len, 1, 10))` when `[1, 10]` should succeed   |
+| Exact invalid numeric interval | `bound()`     | `bound(amount, 1001, type(uint256).max)` for a revert test |
+| Non-numeric constraints        | `vm.assume()` | `vm.assume(addr != address(0))`                            |
+| Complex multi-variable         | `vm.assume()` | `vm.assume(x > y)`                                         |
+| Address is not zero            | `vm.assume()` | `vm.assume(addr != address(0))`                            |
 
 **Why `bound()` is better for numeric ranges:**
 
-When a fuzzer generates a random `uint256`, nearly all values will be outside a small target range. For example, targeting `0 <= x <= 1000` discards 99.9999% of inputs. The `bound()` function wraps the input using modulo arithmetic to keep it in range without discarding:
+When a fuzzer generates a random `uint256`, nearly all values may be outside a small target range.
+For example, targeting `0 <= x <= 1000` discards 99.9999% of inputs. The `bound()` function wraps
+the input using modulo arithmetic to keep it in the chosen valid or invalid interval without
+discarding:
 
 ```solidity
 // bound() implementation (simplified)
@@ -604,24 +618,29 @@ function test_givenPositionExists_whenAmountEqualsRemaining() public {
 function test_givenPositionExists_givenPositionIsWrapped_givenThirdPartyIsApproved_whenCallerTransfersPosition()
     public
 {
-    address thirdParty = makeAddr("thirdParty");
+    address transferCaller = makeAddr("transferCaller");
+    address recipient = makeAddr("recipient");
     uint256 positionId = _createPosition(user, 100e18, 1e9);
 
     vm.prank(user);
     DEPOS.wrap(positionId);
 
     vm.prank(user);
-    DEPOS.approve(thirdParty, positionId);
+    DEPOS.approve(transferCaller, positionId);
 
     IDepositPositionManager.Position memory positionBefore = DEPOS.getPosition(positionId);
     assertEq(positionBefore.owner, user, "approval should not change the position owner");
 
-    vm.prank(thirdParty);
-    DEPOS.transferFrom(user, thirdParty, positionId);
+    vm.prank(transferCaller);
+    DEPOS.transferFrom(user, recipient, positionId);
 
     IDepositPositionManager.Position memory positionAfter = DEPOS.getPosition(positionId);
-    assertEq(positionAfter.owner, thirdParty, "transfer should update the position owner");
-    assertEq(positionAfter.remainingDeposit, 100e18, "transfer should preserve the remaining deposit");
+    assertEq(positionAfter.owner, recipient, "transfer should update the position owner");
+    assertEq(
+        positionAfter.remainingDeposit,
+        positionBefore.remainingDeposit,
+        "transfer should preserve the remaining deposit"
+    );
 }
 ```
 
@@ -748,7 +767,7 @@ assertEq(convertibleAmount, 2e9, "Convertible amount does not equal 2e9");
 | State setup                               | Inline in each test                            | `given*` modifiers                                                                                    |
 | Test naming                               | `test_somethingBad`                            | `test_givenCondition_whenParameter` (success) or `test_givenCondition_whenParameter_reverts` (revert) |
 | Fuzz test naming                          | `testFuzz_*` or `test_*_fuzz`                  | Standard branching-tree name; parameters identify fuzzing                                             |
-| Constraining numeric ranges in fuzz       | `vm.assume(value <= 1000)` for `uint256 value` | `bound(value, 0, 1000)`                                                                               |
+| Constraining numeric ranges in fuzz       | `bound()` into a range unrelated to the named behavior | Choose the exact valid or invalid interval first, then use `bound()`                                   |
 | Error testing                             | Empty or string-based `vm.expectRevert`         | Match the selector or fully encoded custom error                                                       |
 | Assertions                                | `assertEq(a, b)`                               | `assertEq(a, b, "description")`                                                                       |
 | File organization                         | Multiple external actions per file             | One external state-changing action per file; co-locate corresponding preview/getter assertions        |
@@ -761,13 +780,13 @@ assertEq(convertibleAmount, 2e9, "Convertible amount does not equal 2e9");
 - [ ] Uses `given` for pre-existing state and `when` for function parameters or operation inputs
 - [ ] Repeats `given` and `when` segments when the test has multiple conditions
 - [ ] Fuzz test names do not use a `testFuzz_` prefix or `_fuzz` suffix
-- [ ] Fuzz tests use `bound()` for numeric ranges and `vm.assume()` for non-numeric or complex
-      constraints
+- [ ] Each numeric fuzz target is the exact valid or invalid interval for the behavior being proved;
+      `bound()` maps into that interval, while `vm.assume()` handles non-numeric or complex constraints
 - [ ] Caller matrix covers every authorized class, fuzzed unauthorized callers, and fuzzed callers
         for permissionless functions
 - [ ] Enabled, disabled, and re-enabled behavior is covered where applicable
-- [ ] Numeric tests cover valid ranges, exact semantic boundaries, adjacent values, and the type's
-        maximum representable value
+- [ ] Numeric tests cover valid and invalid ranges, exact semantic boundaries, adjacent values, and
+        the type's maximum representable value with explicit boundary tests
 - [ ] State-transition tests assert the resulting state, not only queue or preview behavior
 - [ ] Accounting tests use authoritative deltas and cover rollback and reentrancy where applicable
 - [ ] Corresponding preview/getter and write behavior agree without losing unique read-path coverage

--- a/.claude/skills/test-write/SKILL.md
+++ b/.claude/skills/test-write/SKILL.md
@@ -594,28 +594,34 @@ function test_givenPositionExists_whenAmountEqualsRemaining() public {
 }
 
 // given position exists
-//   given third party is approved
-//     when caller is third party
-//       [X] it decreases remaining
-//       [X] it updates owner
-//       [X] it emits Transfer event
+//   given position is wrapped
+//     given third party is approved
+//       when caller transfers the position
+//         [X] approval preserves the owner
+//         [X] transfer updates the owner
+//         [X] transfer preserves the remaining deposit
 
-function test_givenPositionExists_givenThirdPartyIsApproved_whenCallerIsThirdParty() public {
+function test_givenPositionExists_givenPositionIsWrapped_givenThirdPartyIsApproved_whenCallerTransfersPosition()
+    public
+{
     address thirdParty = makeAddr("thirdParty");
     uint256 positionId = _createPosition(user, 100e18, 1e9);
 
     vm.prank(user);
-    DEPOS.setApprovalForAll(thirdParty, true);
+    DEPOS.wrap(positionId);
 
-    vm.expectEmit(true, true, true, true);
-    emit IERC20.Transfer(user, thirdParty, 50e18);
+    vm.prank(user);
+    DEPOS.approve(thirdParty, positionId);
+
+    IDepositPositionManager.Position memory positionBefore = DEPOS.getPosition(positionId);
+    assertEq(positionBefore.owner, user, "approval should not change the position owner");
 
     vm.prank(thirdParty);
-    DEPOS.burn(positionId, 50e18);
+    DEPOS.transferFrom(user, thirdParty, positionId);
 
-    (address owner, , uint256 remaining, , , ) = DEPOS.positions(positionId);
-    assertEq(owner, thirdParty, "position owner should be third party");
-    assertEq(remaining, 50e18, "remaining should be 50");
+    IDepositPositionManager.Position memory positionAfter = DEPOS.getPosition(positionId);
+    assertEq(positionAfter.owner, thirdParty, "transfer should update the position owner");
+    assertEq(positionAfter.remainingDeposit, 100e18, "transfer should preserve the remaining deposit");
 }
 ```
 

--- a/.claude/skills/test-write/SKILL.md
+++ b/.claude/skills/test-write/SKILL.md
@@ -447,6 +447,12 @@ function test_whenThreePrices_whenDeviationIsValid(
 ) public view {
     uint64 boundedPrice1 = uint64(bound(price1, 1e9, 1e19));
     // boundedPrice1 is now in range [1e9, 1e19]
+    uint64 boundedPrice2 = uint64(bound(price2, 1e9, 1e19));
+    // boundedPrice2 is now in range [1e9, 1e19]
+    uint64 boundedPrice3 = uint64(bound(price3, 1e9, 1e19));
+    // boundedPrice3 is now in range [1e9, 1e19]
+    uint16 boundedDeviationBps = uint16(bound(deviationBps, 0, 10_000));
+    // boundedDeviationBps is now in range [0, 10_000]
     // test logic
 }
 

--- a/.claude/skills/test-write/SKILL.md
+++ b/.claude/skills/test-write/SKILL.md
@@ -297,8 +297,8 @@ Test the re-enabled state separately when re-enablement can refresh dependencies
     malformed encodings, and enum or selector boundaries when relevant.
 - Cover rounding thresholds and decimal-scale combinations when arithmetic behavior can change.
 - Fuzz across the valid numeric range. One interior fuzz case does not prove boundary behavior.
-- Use `bound()` for broad numeric domains; keep explicit boundary tests even when the valid range is
-    fuzzed.
+- Use `bound()` when constraining numeric inputs to a range; keep explicit boundary tests even when
+    the valid range is fuzzed.
 
 ### State Transitions
 
@@ -433,7 +433,8 @@ Foundry identifies fuzz tests from their parameters. Name the behavior being pro
 ```solidity
 // GOOD - the name describes the property; the parameter makes it a fuzz test
 function test_whenInputArrayLengthIsLessThanThree(uint8 length) public {
-    vm.assume(length < 3);
+    uint8 boundedLength = uint8(bound(length, 0, 2));
+    // boundedLength is now in range [0, 2]
     // test logic
 }
 
@@ -443,7 +444,8 @@ function test_whenThreePrices_whenDeviationIsValid(
     uint64 price3,
     uint16 deviationBps
 ) public view {
-    vm.assume(price1 >= 1e9 && price1 <= 1e19);
+    uint64 boundedPrice1 = uint64(bound(price1, 1e9, 1e19));
+    // boundedPrice1 is now in range [1e9, 1e19]
     // test logic
 }
 
@@ -461,14 +463,14 @@ function test_whenInputArrayLengthIsLessThanThree_fuzz(uint8 length) public {
 
 - Use the standard branching-tree name without `testFuzz_` or `_fuzz`
 - Follow the same branching tree pattern as unit tests
-- Use `bound()` when constraining a broad numeric domain to a narrow range
-- Use `vm.assume()` for non-numeric or complex constraints, and for tight numeric domains where it
-  discards only a small number of values
+- Use `bound()` when constraining numeric inputs to a range
+- Use `vm.assume()` for non-numeric or complex constraints
 - Document the bounds being tested in comments
 
 **Use `bound()` instead of `vm.assume()` for numeric values:**
 
-Foundry has a limit on the number of discarded fuzz inputs. Using `vm.assume()` to constrain a large range to a small range will exhaust this limit and cause the fuzz test to fail.
+Foundry has a limit on the number of discarded fuzz inputs. Using `vm.assume()` to constrain a
+numeric input can exhaust this limit when most generated values fall outside the accepted range.
 
 ```solidity
 // BAD - vm.assume() discards too many values
@@ -490,24 +492,23 @@ function test_whenAddressIsNotZero(address addr) public {
     // Only discards 1 out of 2^160 values - acceptable
 }
 
-// GOOD - vm.assume() for tight numeric ranges
-function test_whenArrayIsSmall(uint8 length) public {
-    vm.assume(length > 0 && length <= 10);
-    // Only discards 246 out of 256 values - acceptable
+// GOOD - use bound() even for a narrow numeric range
+function test_whenArrayLengthIsBetweenOneAndTen(uint8 length) public {
+    uint8 boundedLength = uint8(bound(length, 1, 10));
+    // boundedLength is now in range [1, 10]
 }
 ```
 
 **When to use `bound()` vs `vm.assume()`:**
 
-| Scenario                      | Use           | Example                                                           |
-| ----------------------------- | ------------- | ----------------------------------------------------------------- |
-| Constrain large numeric range | `bound()`     | `bound(value, 0, 1000)` for `uint256 value`                       |
-| Constrain small numeric range | Either        | `vm.assume(len < 10)` for `uint8 len` (only ~46 values discarded) |
-| Non-numeric constraints       | `vm.assume()` | `vm.assume(addr != address(0))`                                   |
-| Complex multi-variable        | `vm.assume()` | `vm.assume(x > y)`                                                |
-| Address is not zero           | `vm.assume()` | `vm.assume(addr != address(0))`                                   |
+| Scenario                | Use           | Example                                         |
+| ----------------------- | ------------- | ----------------------------------------------- |
+| Numeric range           | `bound()`     | `uint8(bound(len, 1, 10))` for `uint8 len`      |
+| Non-numeric constraints | `vm.assume()` | `vm.assume(addr != address(0))`                 |
+| Complex multi-variable  | `vm.assume()` | `vm.assume(x > y)`                              |
+| Address is not zero     | `vm.assume()` | `vm.assume(addr != address(0))`                 |
 
-**Why `bound()` is better for large ranges:**
+**Why `bound()` is better for numeric ranges:**
 
 When a fuzzer generates a random `uint256`, nearly all values will be outside a small target range. For example, targeting `0 <= x <= 1000` discards 99.9999% of inputs. The `bound()` function wraps the input using modulo arithmetic to keep it in range without discarding:
 
@@ -730,7 +731,7 @@ assertEq(convertibleAmount, 2e9, "Convertible amount does not equal 2e9");
 | State setup                               | Inline in each test                            | `given*` modifiers                                                                                    |
 | Test naming                               | `test_somethingBad`                            | `test_givenCondition_whenParameter` (success) or `test_givenCondition_whenParameter_reverts` (revert) |
 | Fuzz test naming                          | `testFuzz_*` or `test_*_fuzz`                  | Standard branching-tree name; parameters identify fuzzing                                             |
-| Constraining large numeric ranges in fuzz | `vm.assume(value <= 1000)` for `uint256 value` | `bound(value, 0, 1000)`                                                                               |
+| Constraining numeric ranges in fuzz       | `vm.assume(value <= 1000)` for `uint256 value` | `bound(value, 0, 1000)`                                                                               |
 | Error testing                             | `vm.expectRevert("message")`                   | `abi.encodeWithSelector(Error.selector)`                                                              |
 | Assertions                                | `assertEq(a, b)`                               | `assertEq(a, b, "description")`                                                                       |
 | File organization                         | Multiple external actions per file             | One external state-changing action per file; co-locate corresponding preview/getter assertions        |
@@ -743,7 +744,8 @@ assertEq(convertibleAmount, 2e9, "Convertible amount does not equal 2e9");
 - [ ] Uses `given` for pre-existing state and `when` for function parameters or operation inputs
 - [ ] Repeats `given` and `when` segments when the test has multiple conditions
 - [ ] Fuzz test names do not use a `testFuzz_` prefix or `_fuzz` suffix
-- [ ] Fuzz tests use `bound()` for large numeric ranges, `vm.assume()` for small ranges/non-numeric
+- [ ] Fuzz tests use `bound()` for numeric ranges and `vm.assume()` for non-numeric or complex
+      constraints
 - [ ] Caller matrix covers every authorized class, fuzzed unauthorized callers, and fuzzed callers
         for permissionless functions
 - [ ] Enabled, disabled, and re-enabled behavior is covered where applicable

--- a/.claude/skills/test-write/SKILL.md
+++ b/.claude/skills/test-write/SKILL.md
@@ -1,5 +1,6 @@
 ---
-description: Guide for writing test files following Olympus V3 testing standards
+name: test-write
+description: Write or review Olympus V3 Solidity tests, including external-function coverage matrices, authorization, enabled-state, numeric boundaries, state transitions, accounting, preview/write consistency, fuzzing, invariants, file structure, naming, and error handling.
 ---
 
 # Test Writing Guide
@@ -8,9 +9,13 @@ This guide covers the standards for writing test files in the Olympus V3 codebas
 
 ## File Organization
 
-### One Function Per File
+### Organize Around External Actions
 
-Each contract function should have its own dedicated test file. This keeps tests focused and makes navigation easier.
+Give each external state-changing action a dedicated test file. Test internal functions indirectly
+through their external callers. Co-locate a directly corresponding preview or getter with the action
+when it predicts or exposes the state established by that action and coverage is preserved. Keep a
+standalone file when a read function has independent behavior that is not naturally established by
+one action.
 
 **Examples:**
 
@@ -22,7 +27,7 @@ Each contract function should have its own dedicated test file. This keeps tests
 
 - Use lowercase, descriptive names: `mint.t.sol`, `addPeriodicTask.t.sol`
 - Use `.t.sol` extension for test files
-- Match the function name being tested
+- Match the primary external action being tested
 
 **Base test contracts:**
 
@@ -138,10 +143,10 @@ State modifiers are defined in the parent test contract and used by child tests 
 
 Two modifier prefixes with distinct purposes:
 
-| Prefix | Purpose | Example |
-|--------|---------|---------|
+| Prefix   | Purpose                                                      | Example                                         |
+| -------- | ------------------------------------------------------------ | ----------------------------------------------- |
 | `given*` | Establish existing state (objects, contracts, configuration) | `givenPositionExists`, `givenContractIsEnabled` |
-| `when*` | Denote parameter has a specific value or property | `whenAmountIsZero`, `whenCallerIsNotAdmin` |
+| `when*`  | Denote parameter has a specific value or property            | `whenAmountIsZero`, `whenCallerIsNotAdmin`      |
 
 **`given*` modifiers** - Set up state before the test:
 
@@ -241,9 +246,93 @@ function test_anotherThing() public givenContractIsEnabled {
 }
 ```
 
+## External Function Coverage Matrix
+
+Before implementation, classify every changed external function against each category below. Add
+focused tests for every applicable matrix cell. Record why a category is not applicable instead of
+silently omitting it.
+
+### Caller Authorization
+
+- Cover every permitted caller class separately.
+- Fuzz unauthorized callers. Exclude every authorized identity and any address with distinct
+    semantics, such as `address(0)`, with `vm.assume()`.
+- Fuzz the caller for permissionless functions to prove execution does not depend on one fixed
+    address.
+- Cover direct and delegated authorization, expiry, cancellation, and self-authorization when the
+    contract supports them.
+
+```solidity
+function test_whenCallerIsNotAuthorized_reverts(address caller_) public {
+    vm.assume(caller_ != owner);
+    vm.assume(caller_ != operator);
+    vm.assume(caller_ != address(0));
+
+    vm.expectRevert(abi.encodeWithSelector(IContract.NotAuthorized.selector));
+    vm.prank(caller_);
+    target.restrictedAction();
+}
+
+function test_givenActionIsReady(address caller_) public {
+    vm.prank(caller_);
+    target.permissionlessAction();
+
+    assertTrue(target.actionExecuted(), "action should be executed");
+}
+```
+
+### Contract State
+
+Classify each function as enabled-only, intentionally callable while disabled, independent of the
+enabled state, or dependent on re-enable validation. Test enabled and disabled behavior explicitly.
+Test the re-enabled state separately when re-enablement can refresh dependencies or assumptions.
+
+### Input Boundaries
+
+- Cover zero, one, the semantic minimum and maximum, and representable values immediately below
+    and above each limit. For every numeric input, explicitly test its maximum representable value,
+    such as `type(uint256).max`, whether it should succeed or revert.
+- For a cap `L`, normally prove that the exact cap succeeds and `L + 1` reverts.
+- Cover zero/non-zero addresses, empty/single-item/maximum-size collections, duplicate entries,
+    malformed encodings, and enum or selector boundaries when relevant.
+- Cover rounding thresholds and decimal-scale combinations when arithmetic behavior can change.
+- Fuzz across the valid numeric range. One interior fuzz case does not prove boundary behavior.
+- Use `bound()` for broad numeric domains; keep explicit boundary tests even when the valid range is
+    fuzzed.
+
+### State Transitions
+
+Cover applicable pairs such as absent/existing, uninitialized/initialized, inactive/active,
+current/stale, before/at/after a transition, and first/subsequent execution. Assert the resulting
+state; proving that an operation was queued or previewed is not proof that the transition succeeds.
+
+### Accounting And External Interactions
+
+- Assert authoritative balance, custody, or share deltas rather than nominal input amounts.
+- Assert affected per-user and aggregate accounting together.
+- Document and verify rounding direction.
+- Verify complete rollback when an external interaction fails.
+- Exercise callback or token reentrancy where the function crosses an untrusted boundary.
+
+### Read/Write Consistency
+
+For previews and getters that correspond to a state-changing action, verify both successful output
+and equivalent failure conditions beside the action tests. Do not remove unique read-path coverage
+when consolidating files.
+
+### Invariant Tests
+
+Add stateful invariant tests when correctness depends on relationships that must survive arbitrary
+call sequences. Strong candidates include aggregate accounting equaling the sum of positions,
+custody covering liabilities, lifecycle transitions preserving reachability, authorization never
+expanding unexpectedly, and enabled-state transitions preserving safety. Exercise realistic handler
+actions and actors. Keep explicit unit tests for individual boundaries and revert paths; invariant
+tests complement rather than replace them.
+
 ## Branching Tree Test Naming
 
-Use the branching tree pattern to organize tests by conditions and behaviors:
+Use the branching tree pattern to organize tests by conditions and behaviors. Use `given` only for
+pre-existing state and `when` only for function parameters or other inputs to the operation:
 
 ```solidity
 // given <condition>
@@ -274,7 +363,9 @@ function test_givenVaultBelowCapacity_whenDepositWithinCapacity() public {
 }
 ```
 
-**Multiple conditions in function name:** A test can have multiple `given*` and/or `when*` prefixes:
+**Multiple conditions in function name:** A test can have multiple `given*` and/or `when*` segments.
+Repeat the prefix for every condition, including multiple parameter conditions such as
+`whenCondition1_whenCondition2`:
 
 ```solidity
 // Multiple given* conditions:
@@ -283,8 +374,8 @@ function test_givenPositionExists_givenContractIsEnabled() public {
 }
 
 // Multiple when* conditions:
-function test_givenPositionExists_whenAmountIsZero_whenCallerIsNotOwner() public {
-    // Position exists, amount is zero, caller is not owner
+function test_whenAmountIsZero_whenCallerIsNotOwner() public {
+    // Amount and caller are both function inputs
 }
 
 // Both given* and when* conditions:
@@ -297,10 +388,10 @@ function test_givenPositionExists_givenContractIsEnabled_whenAmountExceedsRemain
 
 Tests that primarily vary input data parameters use `when` as the first condition. The key distinction:
 
-| Prefix | Meaning | Example |
-|--------|---------|---------|
-| `given*` | State (pre-existing conditions) | `givenPositionExists`, `givenContractIsEnabled` |
-| `when*` | Parameters (input/config being tested) | `whenThreePrices`, `whenAmountIsZero`, `whenStrictMode` |
+| Prefix   | Meaning                                         | Example                                                 |
+| -------- | ----------------------------------------------- | ------------------------------------------------------- |
+| `given*` | Pre-existing state                              | `givenPositionExists`, `givenContractIsEnabled`         |
+| `when*`  | Function parameters or other operation inputs   | `whenThreePrices`, `whenAmountIsZero`, `whenStrictMode` |
 
 ```solidity
 // when input has 3 prices
@@ -333,20 +424,19 @@ function test_whenStrictMode_whenOneRemains_reverts() public {
 
 ### Fuzz Test Naming
 
-Fuzz tests use Foundry's property-based testing to verify behavior with random inputs. Use the `_fuzz` suffix to distinguish fuzz tests from unit tests.
+Foundry identifies fuzz tests from their parameters. Name the behavior being proven; do not add a
+`testFuzz_` prefix or `_fuzz` suffix.
 
-**Pattern:** `test_given<Condition>_fuzz(...)` or `test_when<Parameter>_fuzz(...)`
-
-**DO NOT use:** `testFuzz_` prefix (this is an anti-pattern)
+**Pattern:** `test_given<Condition>(...)` or `test_when<Parameter>(...)`
 
 ```solidity
-// GOOD - _fuzz suffix
-function test_givenInputArrayLengthLessThanThree_fuzz(uint8 length) public {
+// GOOD - the name describes the property; the parameter makes it a fuzz test
+function test_whenInputArrayLengthIsLessThanThree(uint8 length) public {
     vm.assume(length < 3);
     // test logic
 }
 
-function test_givenThreePricesWithValidDeviation_fuzz(
+function test_whenThreePrices_whenDeviationIsValid(
     uint64 price1,
     uint64 price2,
     uint64 price3,
@@ -356,15 +446,19 @@ function test_givenThreePricesWithValidDeviation_fuzz(
     // test logic
 }
 
-// BAD - testFuzz_ prefix (anti-pattern)
-function testFuzz_givenInputArrayLessThanThree(uint8 length) public {
+// BAD - fuzzing mechanism encoded in the name
+function testFuzz_whenInputArrayLengthIsLessThanThree(uint8 length) public {
+    // ...
+}
+
+function test_whenInputArrayLengthIsLessThanThree_fuzz(uint8 length) public {
     // ...
 }
 ```
 
 **Fuzz test naming guidelines:**
 
-- Always use `_fuzz` suffix, never `testFuzz_` prefix
+- Use the standard branching-tree name without `testFuzz_` or `_fuzz`
 - Follow the same branching tree pattern as unit tests
 - Use `bound()` for constraining numeric values (preferred over `vm.assume()`)
 - Use `vm.assume()` only for non-numeric constraints or when `bound()` is not feasible
@@ -376,26 +470,26 @@ Foundry has a limit on the number of discarded fuzz inputs. Using `vm.assume()` 
 
 ```solidity
 // BAD - vm.assume() discards too many values
-function test_givenLargeAmount_fuzz(uint256 amount) public {
+function test_whenAmountIsLarge(uint256 amount) public {
     // This discards nearly all uint256 values except 0-1000
     vm.assume(amount <= 1000);
     // Test will fail with "Fuzz testing ran out of inputs"
 }
 
 // GOOD - use bound() to constrain the input
-function test_givenLargeAmount_fuzz(uint256 amount) public {
+function test_whenAmountIsLarge(uint256 amount) public {
     uint256 boundedAmount = bound(amount, 0, 1000);
     // boundedAmount is now in range [0, 1000]
 }
 
 // GOOD - vm.assume() for non-numeric or complex constraints
-function test_givenAddressNotZero_fuzz(address addr) public {
+function test_whenAddressIsNotZero(address addr) public {
     vm.assume(addr != address(0));
     // Only discards 1 out of 2^160 values - acceptable
 }
 
 // GOOD - vm.assume() for tight numeric ranges
-function test_givenSmallArray_fuzz(uint8 length) public {
+function test_whenArrayIsSmall(uint8 length) public {
     vm.assume(length > 0 && length <= 10);
     // Only discards 246 out of 256 values - acceptable
 }
@@ -403,13 +497,13 @@ function test_givenSmallArray_fuzz(uint8 length) public {
 
 **When to use `bound()` vs `vm.assume()`:**
 
-| Scenario | Use | Example |
-|----------|-----|---------|
-| Constrain large numeric range | `bound()` | `bound(value, 0, 1000)` for `uint256 value` |
-| Constrain small numeric range | Either | `vm.assume(len < 10)` for `uint8 len` (only ~46 values discarded) |
-| Non-numeric constraints | `vm.assume()` | `vm.assume(addr != address(0))` |
-| Complex multi-variable | `vm.assume()` | `vm.assume(x > y)` |
-| Address is not zero | `vm.assume()` | `vm.assume(addr != address(0))` |
+| Scenario                      | Use           | Example                                                           |
+| ----------------------------- | ------------- | ----------------------------------------------------------------- |
+| Constrain large numeric range | `bound()`     | `bound(value, 0, 1000)` for `uint256 value`                       |
+| Constrain small numeric range | Either        | `vm.assume(len < 10)` for `uint8 len` (only ~46 values discarded) |
+| Non-numeric constraints       | `vm.assume()` | `vm.assume(addr != address(0))`                                   |
+| Complex multi-variable        | `vm.assume()` | `vm.assume(x > y)`                                                |
+| Address is not zero           | `vm.assume()` | `vm.assume(addr != address(0))`                                   |
 
 **Why `bound()` is better for large ranges:**
 
@@ -626,25 +720,36 @@ assertEq(convertibleAmount, 2e9, "Convertible amount does not equal 2e9");
 
 ## Anti-Patterns Summary
 
-| Pattern | Avoid | Use Instead |
-|---------|-------|-------------|
-| State setup | Inline in each test | `given*` modifiers |
-| Test naming | `test_somethingBad` | `test_givenCondition_whenParameter` (success) or `test_givenCondition_whenParameter_reverts` (revert) |
-| Fuzz test naming | `testFuzz_*` | `test_givenCondition_fuzz` or `test_whenParameter_fuzz` |
-| Constraining large numeric ranges in fuzz | `vm.assume(value <= 1000)` for `uint256 value` | `bound(value, 0, 1000)` |
-| Error testing | `vm.expectRevert("message")` | `abi.encodeWithSelector(Error.selector)` |
-| Assertions | `assertEq(a, b)` | `assertEq(a, b, "description")` |
-| File organization | Multiple functions per file | One function per file |
+| Pattern                                   | Avoid                                          | Use Instead                                                                                           |
+| ----------------------------------------- | ---------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| State setup                               | Inline in each test                            | `given*` modifiers                                                                                    |
+| Test naming                               | `test_somethingBad`                            | `test_givenCondition_whenParameter` (success) or `test_givenCondition_whenParameter_reverts` (revert) |
+| Fuzz test naming                          | `testFuzz_*` or `test_*_fuzz`                  | Standard branching-tree name; parameters identify fuzzing                                             |
+| Constraining large numeric ranges in fuzz | `vm.assume(value <= 1000)` for `uint256 value` | `bound(value, 0, 1000)`                                                                               |
+| Error testing                             | `vm.expectRevert("message")`                   | `abi.encodeWithSelector(Error.selector)`                                                              |
+| Assertions                                | `assertEq(a, b)`                               | `assertEq(a, b, "description")`                                                                       |
+| File organization                         | Multiple external actions per file             | One external state-changing action per file; co-locate corresponding preview/getter assertions        |
 
 ## Checklist for New Test Files
 
-- [ ] File named after the function being tested
+- [ ] File is organized around the external action being tested
 - [ ] Inherits from appropriate parent test contract
 - [ ] Uses `given*` modifiers for state setup
-- [ ] Follows branching tree naming convention
-- [ ] Fuzz tests use `_fuzz` suffix, not `testFuzz_` prefix
+- [ ] Uses `given` for pre-existing state and `when` for function parameters or operation inputs
+- [ ] Repeats `given` and `when` segments when the test has multiple conditions
+- [ ] Fuzz test names do not use a `testFuzz_` prefix or `_fuzz` suffix
 - [ ] Fuzz tests use `bound()` for large numeric ranges, `vm.assume()` for small ranges/non-numeric
+- [ ] Caller matrix covers every authorized class, fuzzed unauthorized callers, and fuzzed callers
+        for permissionless functions
+- [ ] Enabled, disabled, and re-enabled behavior is covered where applicable
+- [ ] Numeric tests cover valid ranges, exact semantic boundaries, adjacent values, and the type's
+        maximum representable value
+- [ ] State-transition tests assert the resulting state, not only queue or preview behavior
+- [ ] Accounting tests use authoritative deltas and cover rollback and reentrancy where applicable
+- [ ] Corresponding preview/getter and write behavior agree without losing unique read-path coverage
+- [ ] Stateful invariant tests cover applicable accounting, custody, lifecycle, authorization, and
+        enabled-state properties
 - [ ] Uses error selectors, not string messages
 - [ ] All assertions have descriptive messages
 - [ ] Mathematical reasoning documented in comments
-- [ ] Tests cover edge cases (min, max, zero, boundary values)
+- [ ] Tests cover applicable state and input edge cases

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,8 +165,28 @@ Never stage unrelated files. If the worktree has unrelated modifications, leave 
 
 ### Testing Discipline
 
+- Before writing or modifying Solidity tests, use the `/test-write` skill.
 - Write or update tests before implementation
 - If tests don't exist for a function you're modifying, create them first
+- Before implementation, derive the applicable coverage matrix for every external function being
+    changed and treat it as acceptance criteria:
+    - Caller authorization: cover every permitted caller class, fuzz unauthorized callers while
+        excluding all authorized identities, and fuzz the caller for permissionless functions.
+    - Contract state: cover enabled, disabled, and re-enabled behavior. Explicitly test functions
+        that are intentionally callable while disabled.
+    - Input boundaries: cover zero, one, minimum, maximum, values immediately below and above
+        semantic limits, exact caps, and rounding thresholds. For every numeric input, test the
+        numeric type's maximum representable value. Cover zero/non-zero addresses and empty,
+        single-item, and maximum-size collections when relevant. Fuzz across the valid numeric range;
+        one interior fuzz case does not prove boundary behavior.
+    - State transitions: cover absent/existing, uninitialized/initialized, current/stale, and exact
+        transition points where applicable.
+    - Accounting and external interactions: assert authoritative balance or custody deltas,
+        aggregate consistency, rounding direction, rollback on failure, and reentrancy behavior.
+    - Read/write consistency: verify that previews and getters agree with successful execution and
+        equivalent failure conditions.
+    - Invariants: add stateful invariant tests for accounting, custody, lifecycle, authorization, and
+        enabled-state properties that must hold across arbitrary call sequences.
 - Run the specific test file after changes, not the full suite
 - Only run full test suites when explicitly requested or at major milestones
 
@@ -296,13 +316,20 @@ src/
 - Invariant tests select invariant functions while applying the same contract and path exclusions: `--match-test '^invariant_'`
 - Proposal tests are in `src/test/proposals/` and require fork environment
 
-**For detailed test writing guidance (file structure, modifiers, naming, error handling), use the `/test-write` skill.**
+**For detailed test writing guidance (coverage matrices, file structure, modifiers, naming, fuzzing,
+and error handling), use the `/test-write` skill.**
 
 Key standards summary:
 
-- One test file per contract **external** function (internal functions are tested indirectly via their callers)
+- Organize tests around external state-changing actions (internal functions are tested indirectly
+    via their callers). Co-locate directly corresponding preview or getter assertions with the action
+    when doing so preserves coverage.
 - Use `given*` modifiers for state setup
-- Follow branching tree naming: `test_given<Condition>_<Action>_<ExpectedResult>()`
+- In test function names, use `given` for pre-existing state and `when` for function parameters or
+    operation inputs. Repeat the prefix for multiple conditions, such as
+    `test_givenState_whenCondition1_whenCondition2()`.
+- Follow branching tree naming: `test_given<State>_when<Parameter1>_when<Parameter2>()`; use a
+    `_reverts` suffix for revert cases
 - Always use error selectors, never string messages: `abi.encodeWithSelector(Error.selector)`
 - All assertions must have descriptive messages
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -330,7 +330,9 @@ Key standards summary:
     `test_givenState_whenCondition1_whenCondition2()`.
 - Follow branching tree naming: `test_given<State>_when<Parameter1>_when<Parameter2>()`; use a
     `_reverts` suffix for revert cases
-- Always use error selectors, never string messages: `abi.encodeWithSelector(Error.selector)`
+- Match specific revert data with error selectors or encoded custom errors. Do not use empty
+    `vm.expectRevert()` unless an opaque dependency has no stable revert data and the test documents
+    why stronger matching is impossible. Never use string messages.
 - All assertions must have descriptive messages
 
 ### Deployment


### PR DESCRIPTION
## Summary

Strengthens Olympus V3 test guidance with an explicit external-function coverage matrix and consistent branching-tree naming. Agents now receive aligned rules for authorization, lifecycle state, input boundaries, accounting, preview/write consistency, fuzzing, and invariants without contradictory examples.

## Validation

- `pnpm build`
- `pnpm run lint:check`
- `coderabbit review --agent --type committed --base develop` (final pass; no new actionable findings)
- Protocol tests were not run because no executable Solidity changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Renamed deposit tests with clearer `given`/`when` scenario descriptions without changing behavior.
  - Strengthened missing-allowance coverage by checking the specific insufficient-allowance error.
  - Expanded coverage guidance for authorization, boundaries, state transitions, accounting, rollback, reentrancy, invariants, and preview consistency.

- **Documentation**
  - Updated Solidity testing workflows and coverage checklists.
  - Clarified fuzzing guidance, numeric bounds, and appropriate assumption usage.
  - Added guidance for external state-changing actions, getter assertions, and delegated authorization scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
