### PR TITLE
Pin CCIP fork test block setup

### DIFF
--- a/src/test/policies/bridge/CCIPBurnMintTokenPoolFork.t.sol
+++ b/src/test/policies/bridge/CCIPBurnMintTokenPoolFork.t.sol
@@ -54,23 +54,20 @@ contract CCIPBurnMintTokenPoolForkTest is Test {
     uint256 public mainnetForkId;
     uint256 public polygonForkId;
 
-    // Pin the block so that RPC responses are cached.
-    // Sepolia serves archive state, so this pin is stable.
+    // Both forks are pinned before block 11606201 (Sepolia) and 46367172 (Amoy), where Chainlink
+    // upgraded the lane from CCIP 1.5 to CCIP 2.0 on 2026-08-31. `chainlink-local` reads only the
+    // pre-1.6 and 1.6 send events, so it cannot route a CCIP 2.0 message, and it does not revert:
+    // the message is silently not delivered. Keep both pins on the same side of that upgrade, and
+    // raise them only when `chainlink-local` supports the lane's CCIP version at the new blocks.
     uint256 public constant MAINNET_BLOCK = 8360176;
-
-    // The Polygon Amoy fork is deliberately NOT pinned.
-    // The `polygon-amoy` alias in foundry.toml points at Alchemy, which serves Amoy from a full
-    // node rather than an archive node: state reads more than ~128 blocks (~4 minutes) behind the
-    // chain head fail with `-32001 Unable to complete request`. Any pinned block therefore breaks
-    // within minutes of being committed. Do not re-add a POLYGON_BLOCK constant unless the
-    // `polygon-amoy` RPC alias is first moved to a provider that serves Amoy archive state.
+    uint256 public constant POLYGON_BLOCK = 46360000;
 
     function setUp() public {
         // Set up forks
         // Mainnet is active
         // These use Sepolia RPCs, as CCIPLocalSimulatorFork only supports sepolia testnets
         mainnetForkId = vm.createFork("sepolia", MAINNET_BLOCK);
-        polygonForkId = vm.createFork("polygon-amoy");
+        polygonForkId = vm.createFork("polygon-amoy", POLYGON_BLOCK);
         vm.selectFork(mainnetForkId);
 
         // Addresses


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Pinned the Polygon Amoy fork tests to a fixed block for more consistent results.
  * Updated test documentation to clarify the fork timing relative to the CCIP lane upgrade.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->